### PR TITLE
feat: auto-check for updates with sidebar card

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import OverviewPage from "./pages/overview";
 import SettingsPage from "./pages/settings";
 import { useAuditStore } from "./stores/audit-store";
 import { useExtensionStore } from "./stores/extension-store";
+import { useUpdateStore } from "./stores/update-store";
 import { resolveMode, useUIStore } from "./stores/ui-store";
 
 /** Minimum interval (ms) between consecutive scan_and_sync calls */
@@ -45,6 +46,11 @@ export default function App() {
     mq.addEventListener("change", onChange);
     return () => mq.removeEventListener("change", onChange);
   }, [mode]);
+
+  // Check for updates on startup (non-blocking, silent failure)
+  useEffect(() => {
+    useUpdateStore.getState().checkForUpdate();
+  }, []);
 
   // Background scan + rescan on window focus
   useEffect(() => {

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   ShoppingBag,
 } from "lucide-react";
 import { NavLink } from "react-router-dom";
+import { UpdateCard } from "./update-card";
 
 const mainNavItems = [
   { to: "/", icon: LayoutDashboard, label: "Overview" },
@@ -84,6 +85,8 @@ export function Sidebar() {
 
         {/* Settings separator */}
         <div className="mt-auto mx-3 mb-1 border-t border-sidebar-border/40" />
+
+        <UpdateCard />
 
         {utilityNavItems.map((item) => (
           <SidebarLink key={item.to} {...item} />

--- a/src/components/layout/update-card.tsx
+++ b/src/components/layout/update-card.tsx
@@ -1,0 +1,30 @@
+import { Download, Loader2 } from "lucide-react";
+import { useUpdateStore } from "@/stores/update-store";
+
+export function UpdateCard() {
+  const available = useUpdateStore((s) => s.available);
+  const installing = useUpdateStore((s) => s.installing);
+  const installUpdate = useUpdateStore((s) => s.installUpdate);
+
+  if (!available) return null;
+
+  return (
+    <div className="mb-2 rounded-xl border border-primary/20 bg-primary/5 p-3">
+      <p className="text-xs font-medium text-foreground">
+        v{available.version} available
+      </p>
+      <button
+        onClick={installUpdate}
+        disabled={installing}
+        className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-md bg-primary px-2.5 py-1.5 text-xs font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:opacity-50"
+      >
+        {installing ? (
+          <Loader2 size={12} className="animate-spin" />
+        ) : (
+          <Download size={12} />
+        )}
+        {installing ? "Updating..." : "Update"}
+      </button>
+    </div>
+  );
+}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,5 +1,4 @@
-import { check } from "@tauri-apps/plugin-updater";
-import { relaunch } from "@tauri-apps/plugin-process";
+import { useUpdateStore } from "@/stores/update-store";
 import { clsx } from "clsx";
 import {
   Check,
@@ -56,54 +55,21 @@ const ICON_OPTIONS: { value: AppIcon; label: string; src: string }[] = [
 ];
 
 function UpdateSection() {
-  const [checking, setChecking] = useState(false);
-  const [installing, setInstalling] = useState(false);
-  const [updateAvailable, setUpdateAvailable] = useState<{
-    version: string;
-    body: string;
-  } | null>(null);
-  const [checked, setChecked] = useState(false);
-
-  const handleCheck = async () => {
-    setChecking(true);
-    try {
-      const update = await check();
-      if (update) {
-        setUpdateAvailable({ version: update.version, body: update.body ?? "" });
-      } else {
-        setChecked(true);
-        toast.success("Already up to date");
-      }
-    } catch {
-      toast.error("Failed to check for updates");
-    } finally {
-      setChecking(false);
-    }
-  };
-
-  const handleInstall = async () => {
-    if (!updateAvailable) return;
-    setInstalling(true);
-    try {
-      const update = await check();
-      if (update) {
-        await update.downloadAndInstall();
-        await relaunch();
-      }
-    } catch {
-      toast.error("Failed to install update");
-      setInstalling(false);
-    }
-  };
+  const available = useUpdateStore((s) => s.available);
+  const checking = useUpdateStore((s) => s.checking);
+  const installing = useUpdateStore((s) => s.installing);
+  const checked = useUpdateStore((s) => s.checked);
+  const checkForUpdate = useUpdateStore((s) => s.checkForUpdate);
+  const installUpdate = useUpdateStore((s) => s.installUpdate);
 
   return (
     <div className="flex items-center gap-3">
       <span className="text-xs text-muted-foreground">
         v{__APP_VERSION__}
       </span>
-      {updateAvailable ? (
+      {available ? (
         <button
-          onClick={handleInstall}
+          onClick={installUpdate}
           disabled={installing}
           className="flex items-center gap-1.5 rounded-lg bg-primary px-2.5 py-1 text-xs text-primary-foreground shadow-sm hover:bg-primary/90 disabled:opacity-50 transition-colors"
         >
@@ -112,11 +78,11 @@ function UpdateSection() {
           ) : (
             <Download size={12} />
           )}
-          {installing ? "Installing..." : `Update to v${updateAvailable.version}`}
+          {installing ? "Updating..." : `Update to v${available.version}`}
         </button>
       ) : (
         <button
-          onClick={handleCheck}
+          onClick={checkForUpdate}
           disabled={checking}
           className="flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 transition-colors"
         >

--- a/src/stores/update-store.ts
+++ b/src/stores/update-store.ts
@@ -1,0 +1,51 @@
+import { create } from "zustand";
+import { check } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+
+interface UpdateState {
+  /** Available update version, null if none or not checked yet */
+  available: { version: string; body: string } | null;
+  checking: boolean;
+  installing: boolean;
+  /** Whether a check has completed (regardless of result) */
+  checked: boolean;
+
+  checkForUpdate: () => Promise<void>;
+  installUpdate: () => Promise<void>;
+}
+
+export const useUpdateStore = create<UpdateState>((set, get) => ({
+  available: null,
+  checking: false,
+  installing: false,
+  checked: false,
+
+  async checkForUpdate() {
+    if (get().checking) return;
+    set({ checking: true });
+    try {
+      const update = await check();
+      if (update) {
+        set({ available: { version: update.version, body: update.body ?? "" } });
+      }
+    } catch {
+      // Silent failure — update check is non-critical
+    } finally {
+      set({ checking: false, checked: true });
+    }
+  },
+
+  async installUpdate() {
+    if (get().installing) return;
+    set({ installing: true });
+    try {
+      const update = await check();
+      if (update) {
+        await update.downloadAndInstall();
+        await relaunch();
+      }
+    } catch {
+      set({ installing: false });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary
- Auto-check for updates on app startup using Tauri updater plugin
- Show update card in sidebar above Settings when a new version is available
- Extract update state into dedicated zustand store, shared by sidebar card and Settings page

## Test plan
- [x] Card appears in sidebar when update is available (verified with mock)
- [x] Card hidden when no update available
- [x] Update button triggers download + install + relaunch
- [x] Settings page "Check for Updates" still works, shares state with sidebar card

🤖 Generated with [Claude Code](https://claude.com/claude-code)