### PR TITLE
fix: show GitHub link in INFO section when only pack is available

### DIFF
--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -207,8 +207,12 @@ export function ExtensionDetail() {
                   (e) => e.cli_parent_id === group.instances[0]?.id && e.install_meta?.url,
                 )?.install_meta
               : null;
+            // Fall back to pack (user-provided or backfilled) when no URL
+            // exists in install_meta or source — e.g. CLIs installed via
+            // curl that only have a manually entered pack like "org/repo".
             const sourceUrl =
-              meta?.url_resolved ?? meta?.url ?? childMeta?.url_resolved ?? childMeta?.url ?? group.source.url;
+              meta?.url_resolved ?? meta?.url ?? childMeta?.url_resolved ?? childMeta?.url ?? group.source.url
+              ?? (group.pack ? `https://github.com/${group.pack}` : null);
             const repoPath = sourceUrl
               ? (() => {
                   const m = sourceUrl.match(/github\.com\/([^/]+\/[^/]+)/);


### PR DESCRIPTION
## Summary
- Fall back to constructing GitHub link from `pack` when `source.url` and `install_meta.url` are both null
- Covers CLIs installed outside HarnessKit (e.g. via curl) where the user manually entered a pack like `org/repo`

## Test plan
- [x] 84 frontend tests pass
- [x] Extensions with pack but no source.url now show clickable link under INFO

🤖 Generated with [Claude Code](https://claude.com/claude-code)