### PR TITLE
fix: add missing CLI install script and complete manual install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,12 +188,19 @@ Already installed? Open **Settings → Check for Updates** to upgrade in-app.
 curl -fsSL https://raw.githubusercontent.com/RealZST/HarnessKit/main/install.sh | sh
 ```
 
-Or download the binary manually:
+Or download the binary manually from the [latest release](https://github.com/RealZST/HarnessKit/releases/latest):
 
 | Chip | File |
 |------|------|
 | Apple Silicon (M1/M2/M3/M4) | `hk-macos-arm64` |
 | Intel | `hk-macos-x64` |
+
+Then install it:
+
+```bash
+chmod +x hk-macos-arm64          # make it executable (use hk-macos-x64 for Intel)
+mv hk-macos-arm64 ~/.local/bin/hk  # move to a directory in your PATH
+```
 
 After installation, restart your terminal and verify with `hk status`.
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# HarnessKit CLI installer — auto-detects architecture and installs the
+# latest `hk` binary to ~/.local/bin.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/RealZST/HarnessKit/main/install.sh | sh
+
+set -e
+
+REPO="RealZST/HarnessKit"
+INSTALL_DIR="$HOME/.local/bin"
+
+# Detect architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+  arm64|aarch64) BINARY="hk-macos-arm64" ;;
+  x86_64)        BINARY="hk-macos-x64" ;;
+  *)
+    echo "Error: unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+# Get latest release tag
+TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*: "//;s/".*//')
+if [ -z "$TAG" ]; then
+  echo "Error: failed to fetch latest release"
+  exit 1
+fi
+
+URL="https://github.com/$REPO/releases/download/$TAG/$BINARY"
+
+echo "Installing HarnessKit CLI $TAG ($ARCH)..."
+
+# Download
+mkdir -p "$INSTALL_DIR"
+curl -fsSL "$URL" -o "$INSTALL_DIR/hk"
+chmod +x "$INSTALL_DIR/hk"
+
+echo "Installed hk to $INSTALL_DIR/hk"
+
+# Check if INSTALL_DIR is in PATH
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    echo ""
+    echo "Add ~/.local/bin to your PATH:"
+    echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+    echo ""
+    echo "Then restart your terminal and verify with: hk status"
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add `install.sh` that auto-detects architecture (arm64/x64), downloads the latest `hk` binary from GitHub releases, and installs to `~/.local/bin`
- Complete the manual install instructions in README with `chmod +x` and `mv` steps

## Test plan
- [x] Tested `install.sh` locally — correctly detects arm64, downloads v1.0.3, installs to ~/.local/bin/hk
- [x] `hk status` works after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)