### PR TITLE
feat: detect repo skill changes during update checks

### DIFF
--- a/crates/hk-core/src/models.rs
+++ b/crates/hk-core/src/models.rs
@@ -286,7 +286,25 @@ pub struct DiscoveredProject {
 pub enum UpdateStatus {
     UpToDate { remote_hash: String },
     UpdateAvailable { remote_hash: String },
+    RemovedFromRepo,
     Error { message: String },
+}
+
+// --- New Repo Skills ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewRepoSkill {
+    pub repo_url: String,
+    pub pack: Option<String>,
+    pub skill_id: String,
+    pub name: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckUpdatesResult {
+    pub statuses: Vec<(String, UpdateStatus)>,
+    pub new_skills: Vec<NewRepoSkill>,
 }
 
 // --- Agent Info ---

--- a/crates/hk-desktop/src/commands/extensions.rs
+++ b/crates/hk-desktop/src/commands/extensions.rs
@@ -574,8 +574,12 @@ pub fn get_cached_update_statuses(
                 }
             }
             _ => {
-                if let Some(err) = meta.check_error {
-                    UpdateStatus::Error { message: err }
+                if let Some(ref err) = meta.check_error {
+                    if err == "removed_from_repo" {
+                        UpdateStatus::RemovedFromRepo
+                    } else {
+                        UpdateStatus::Error { message: err.clone() }
+                    }
                 } else {
                     continue; // No remote_revision and no error — nothing to report
                 }
@@ -589,10 +593,10 @@ pub fn get_cached_update_statuses(
 #[tauri::command]
 pub async fn check_updates(
     state: State<'_, AppState>,
-) -> Result<Vec<(String, UpdateStatus)>, HkError> {
+) -> Result<CheckUpdatesResult, HkError> {
     let store_clone = state.store.clone();
 
-    tauri::async_runtime::spawn_blocking(move || -> Result<Vec<(String, UpdateStatus)>, HkError> {
+    tauri::async_runtime::spawn_blocking(move || -> Result<CheckUpdatesResult, HkError> {
         // Read all extensions and release the lock before doing slow network calls
         type Updatable = Vec<(String, String, InstallMeta)>; // (id, name, meta)
         type Unlinked = Vec<(String, String)>;
@@ -694,63 +698,99 @@ pub async fn check_updates(
             })
             .collect();
 
-        // For skills marked UpdateAvailable that have a subpath, verify the
-        // skill still exists in the repo. Group by URL so we clone each repo
-        // at most once.
+        // For all skills marked UpdateAvailable, clone the repo to:
+        // 1. Verify existing skills still exist (RemovedFromRepo detection)
+        // 2. Discover new skills not yet installed
+        // Group by URL so we clone each repo at most once.
+        let mut new_skills: Vec<NewRepoSkill> = Vec::new();
         {
             use std::collections::HashMap;
-            let needs_verify: Vec<usize> = statuses
-                .iter()
-                .enumerate()
-                .filter(|(_, (_, _, meta, status))| {
-                    matches!(status, UpdateStatus::UpdateAvailable { .. })
-                        && meta.subpath.is_some()
-                })
-                .map(|(i, _)| i)
-                .collect();
 
-            if !needs_verify.is_empty() {
-                // url -> temp clone dir
-                let mut cloned_repos: HashMap<String, Option<tempfile::TempDir>> = HashMap::new();
+            // Collect all UpdateAvailable indices grouped by resolved URL
+            let mut url_to_indices: HashMap<String, Vec<usize>> = HashMap::new();
+            for (idx, (_, _, meta, status)) in statuses.iter().enumerate() {
+                if !matches!(status, UpdateStatus::UpdateAvailable { .. }) {
+                    continue;
+                }
+                let url = meta
+                    .url_resolved
+                    .as_deref()
+                    .or(meta.url.as_deref())
+                    .unwrap_or("");
+                if !url.is_empty() {
+                    url_to_indices
+                        .entry(url.to_string())
+                        .or_default()
+                        .push(idx);
+                }
+            }
 
-                for idx in needs_verify {
+            for (url, indices) in &url_to_indices {
+                // Clone once per URL
+                let temp = match tempfile::tempdir() {
+                    Ok(t) => t,
+                    Err(_) => continue,
+                };
+                let clone_path = temp.path().join("repo");
+                let output = std::process::Command::new("git")
+                    .args(["clone", "--depth", "1", "--", url, &clone_path.to_string_lossy()])
+                    .output();
+                let ok = output.map(|o| o.status.success()).unwrap_or(false);
+                if !ok {
+                    continue;
+                }
+
+                // 1. Verify existing skills with subpath
+                for &idx in indices {
                     let (_, name, meta, _) = &statuses[idx];
-                    let url = meta
-                        .url_resolved
-                        .as_deref()
-                        .or(meta.url.as_deref())
-                        .unwrap_or("");
-                    if url.is_empty() {
-                        continue;
+                    if meta.subpath.is_some()
+                        && manager::find_skill_in_repo(&clone_path, name).is_none()
+                    {
+                        eprintln!(
+                            "[hk] Skill '{}' no longer exists in repository",
+                            name
+                        );
+                        statuses[idx].3 = UpdateStatus::RemovedFromRepo;
                     }
+                }
 
-                    // Clone once per unique URL
-                    let clone_dir = cloned_repos.entry(url.to_string()).or_insert_with(|| {
-                        let temp = tempfile::tempdir().ok()?;
-                        let clone_path = temp.path().join("repo");
-                        let output = std::process::Command::new("git")
-                            .args(["clone", "--depth", "1", "--", url, &clone_path.to_string_lossy()])
-                            .output()
-                            .ok()?;
-                        if output.status.success() {
-                            Some(temp)
-                        } else {
-                            None
-                        }
-                    });
+                // 2. Discover new skills in this repo
+                let repo_skills = manager::scan_repo_skills(&clone_path);
+                if repo_skills.len() <= 1 {
+                    // Single-skill repo or empty — no new skills to discover
+                    continue;
+                }
 
-                    if let Some(temp) = clone_dir {
-                        let clone_path = temp.path().join("repo");
-                        if manager::find_skill_in_repo(&clone_path, name).is_none() {
-                            eprintln!(
-                                "[hk] Skill '{}' no longer exists in repository — marking as up-to-date",
-                                name
-                            );
-                            // Use install_revision as remote_hash so they match in
-                            // the DB and won't be flagged again after restart.
-                            let local_hash = meta.revision.clone().unwrap_or_default();
-                            statuses[idx].3 = UpdateStatus::UpToDate { remote_hash: local_hash };
+                // Collect installed skill names from DB
+                // (not just from statuses — covers skills without install_meta too)
+                let installed_names: std::collections::HashSet<String> = {
+                    let store = store_clone.lock();
+                    let all_exts = store.list_extensions(Some(ExtensionKind::Skill), None)
+                        .unwrap_or_default();
+                    let mut names = std::collections::HashSet::new();
+                    for ext in &all_exts {
+                        let matches_url = ext.install_meta.as_ref().map_or(false, |m| {
+                            m.url_resolved.as_deref().or(m.url.as_deref())
+                                == Some(url.as_str())
+                        });
+                        if matches_url {
+                            names.insert(ext.name.clone());
                         }
+                    }
+                    names
+                };
+
+                let pack = hk_core::scanner::extract_pack_from_url(url);
+
+                for skill in &repo_skills {
+                    if !installed_names.contains(skill.name.as_str()) {
+                        new_skills.push(NewRepoSkill {
+                            repo_url: url.clone(),
+                            pack: pack.clone(),
+                            skill_id: skill.skill_id.clone(),
+                            name: skill.name.clone(),
+                            description: skill.description.clone(),
+                        });
                     }
                 }
             }
@@ -763,6 +803,7 @@ pub async fn check_updates(
             let (remote_rev, check_err) = match status {
                 UpdateStatus::UpToDate { remote_hash } => (Some(remote_hash.as_str()), None),
                 UpdateStatus::UpdateAvailable { remote_hash } => (Some(remote_hash.as_str()), None),
+                UpdateStatus::RemovedFromRepo => (None, Some("removed_from_repo")),
                 UpdateStatus::Error { message } => (None, Some(message.as_str())),
             };
             if let Err(e) = store.update_check_state(id, remote_rev, now, check_err) {
@@ -770,10 +811,13 @@ pub async fn check_updates(
             }
         }
 
-        Ok(statuses
-            .into_iter()
-            .map(|(id, _, _, status)| (id, status))
-            .collect())
+        Ok(CheckUpdatesResult {
+            statuses: statuses
+                .into_iter()
+                .map(|(id, _, _, status)| (id, status))
+                .collect(),
+            new_skills,
+        })
     })
     .await
     .map_err(|e| HkError::Internal(e.to_string()))?
@@ -836,6 +880,12 @@ pub async fn update_extension(
                     "[hk] Skill '{}' no longer exists in repository — skipping update",
                     skill_name
                 );
+                // Persist removed_from_repo state so UI shows it after restart
+                let store = store_clone.lock();
+                let now = chrono::Utc::now();
+                if let Err(e) = store.update_check_state(&id, None, now, Some("removed_from_repo")) {
+                    eprintln!("[hk] warning: {e}");
+                }
                 return Ok(manager::InstallResult {
                     name: skill_name.clone(),
                     was_update: false,

--- a/crates/hk-desktop/src/commands/install.rs
+++ b/crates/hk-desktop/src/commands/install.rs
@@ -420,6 +420,111 @@ pub async fn install_scanned_skills(
     .map_err(|e| HkError::Internal(e.to_string()))?
 }
 
+// --- Install new skills discovered in existing repos ---
+
+#[tauri::command]
+pub async fn install_new_repo_skills(
+    state: State<'_, AppState>,
+    url: String,
+    skill_ids: Vec<String>,
+    target_agents: Vec<String>,
+) -> Result<Vec<manager::InstallResult>, HkError> {
+    let store_clone = state.store.clone();
+    let adapters = state.adapters.clone();
+
+    tauri::async_runtime::spawn_blocking(move || -> Result<Vec<manager::InstallResult>, HkError> {
+        // Clone the repo once
+        let temp = tempfile::tempdir()
+            .map_err(|e| HkError::Internal(format!("Failed to create temp directory: {e}")))?;
+        let clone_dir = temp.path().join("repo");
+        let output = std::process::Command::new("git")
+            .args(["clone", "--depth", "1", "--", &url, &clone_dir.to_string_lossy()])
+            .output()
+            .map_err(|e| HkError::CommandFailed(format!("Failed to run git clone: {e}")))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(HkError::CommandFailed(format!(
+                "git clone failed: {}",
+                stderr.trim()
+            )));
+        }
+
+        let mut results = Vec::new();
+        for agent_name in &target_agents {
+            let a = adapters
+                .iter()
+                .find(|a| a.name() == agent_name.as_str())
+                .ok_or_else(|| HkError::NotFound(format!("Agent '{}' not found", agent_name)))?;
+            let target_dir = a.skill_dirs().into_iter().next().ok_or_else(|| {
+                HkError::Internal(format!("No skill directory for agent '{}'", agent_name))
+            })?;
+            std::fs::create_dir_all(&target_dir)?;
+
+            for sid in &skill_ids {
+                let skill_id_opt = if sid.is_empty() { None } else { Some(sid.as_str()) };
+                let result = manager::install_from_clone(
+                    &clone_dir,
+                    &target_dir,
+                    skill_id_opt,
+                    &url,
+                )?;
+                results.push((agent_name.clone(), sid.clone(), result));
+            }
+        }
+
+        // Post-install: scan, sync, set meta, audit
+        {
+            let store = store_clone.lock();
+            let install_pack = hk_core::scanner::extract_pack_from_url(&url);
+            let mut synced_skills = std::collections::HashSet::new();
+            for (_agent_name, sid, result) in &results {
+                if !synced_skills.insert(result.name.clone()) {
+                    let meta = InstallMeta {
+                        install_type: "git".into(),
+                        url: Some(url.clone()),
+                        url_resolved: None,
+                        branch: None,
+                        subpath: if sid.is_empty() { None } else { Some(sid.clone()) },
+                        revision: result.revision.clone(),
+                        remote_revision: None,
+                        checked_at: None,
+                        check_error: None,
+                    };
+                    let ext_id = scanner::stable_id_for(&result.name, "skill", _agent_name);
+                    let _ = store.set_install_meta(&ext_id, &meta);
+                    if let Some(ref p) = install_pack {
+                        let _ = store.update_pack(&ext_id, Some(p));
+                    }
+                    continue;
+                }
+                let meta = InstallMeta {
+                    install_type: "git".into(),
+                    url: Some(url.clone()),
+                    url_resolved: None,
+                    branch: None,
+                    subpath: if sid.is_empty() { None } else { Some(sid.clone()) },
+                    revision: result.revision.clone(),
+                    remote_revision: None,
+                    checked_at: None,
+                    check_error: None,
+                };
+                service::post_install_sync(
+                    &store,
+                    &adapters,
+                    &target_agents,
+                    &result.name,
+                    Some(meta),
+                    install_pack.as_deref(),
+                )?;
+            }
+        }
+
+        Ok(results.into_iter().map(|(_, _, r)| r).collect())
+    })
+    .await
+    .map_err(|e| HkError::Internal(e.to_string()))?
+}
+
 // --- Cross-agent deploy command ---
 
 #[tauri::command]

--- a/crates/hk-desktop/src/main.rs
+++ b/crates/hk-desktop/src/main.rs
@@ -77,6 +77,7 @@ fn main() {
             commands::read_config_file_preview,
             commands::scan_git_repo,
             commands::install_scanned_skills,
+            commands::install_new_repo_skills,
             commands::get_cli_with_children,
             commands::list_cli_marketplace,
             commands::install_cli,

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   Calendar,
   Download,
   FolderOpen,
@@ -238,6 +239,14 @@ export function ExtensionDetail() {
               </>
             );
           })()}
+          {group.instances.some(
+            (inst) => updateStatuses.get(inst.id)?.status === "removed_from_repo",
+          ) && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <AlertTriangle size={14} />
+              <span>No longer available in the repository</span>
+            </div>
+          )}
           <div className="flex items-center gap-2 text-muted-foreground">
             <Calendar size={14} />
             <span>

--- a/src/components/extensions/extension-filters.tsx
+++ b/src/components/extensions/extension-filters.tsx
@@ -57,6 +57,7 @@ export function ExtensionFilters() {
   const packFilter = useExtensionStore((s) => s.packFilter);
   const setPackFilter = useExtensionStore((s) => s.setPackFilter);
   const allPacks = useExtensionStore((s) => s.allPacks);
+  const extensions = useExtensionStore((s) => s.extensions);
   const grouped = useExtensionStore((s) => s.grouped);
   const filtered = useExtensionStore((s) => s.filtered);
   const packCounts = useMemo(() => {
@@ -65,7 +66,7 @@ export function ExtensionFilters() {
       if (g.pack) counts.set(g.pack, (counts.get(g.pack) ?? 0) + 1);
     }
     return counts;
-  }, [grouped]);
+  }, [grouped, extensions]);
   const agents = useAgentStore((s) => s.agents);
   const agentOrder = useAgentStore((s) => s.agentOrder);
   const enabledAgents = useMemo(

--- a/src/components/extensions/new-skills-dialog.tsx
+++ b/src/components/extensions/new-skills-dialog.tsx
@@ -1,0 +1,236 @@
+import { Download, Loader2, Package } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
+import type { NewRepoSkill } from "@/lib/types";
+import { agentDisplayName, sortAgents } from "@/lib/types";
+import { useAgentStore } from "@/stores/agent-store";
+import { toast } from "@/stores/toast-store";
+
+interface NewSkillsDialogProps {
+  skills: NewRepoSkill[];
+  onInstall: (url: string, skillIds: string[], targetAgents: string[]) => Promise<void>;
+  onDismiss: () => void;
+  onClose: () => void;
+}
+
+export function NewSkillsDialog({ skills, onInstall, onDismiss, onClose }: NewSkillsDialogProps) {
+  const dlgRef = useRef<HTMLDivElement>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set(skills.map((s) => `${s.repo_url}::${s.skill_id}`)));
+  const [selectedAgents, setSelectedAgents] = useState<Set<string>>(new Set());
+  const [installing, setInstalling] = useState(false);
+
+  const agents = useAgentStore((s) => s.agents);
+  const agentOrder = useAgentStore((s) => s.agentOrder);
+  const detectedAgents = sortAgents(
+    agents.filter((a) => a.detected),
+    agentOrder,
+  );
+
+  // If only one agent detected, auto-select it
+  useEffect(() => {
+    if (detectedAgents.length === 1) {
+      setSelectedAgents(new Set([detectedAgents[0].name]));
+    }
+  }, [detectedAgents.length]);
+
+  // Group skills by repo
+  const grouped = new Map<string, { pack: string | null; skills: NewRepoSkill[] }>();
+  for (const skill of skills) {
+    const key = skill.repo_url;
+    if (!grouped.has(key)) {
+      grouped.set(key, { pack: skill.pack, skills: [] });
+    }
+    grouped.get(key)!.skills.push(skill);
+  }
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  useFocusTrap(dlgRef, true);
+
+  const toggleSkill = (key: string) => {
+    const next = new Set(selected);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    setSelected(next);
+  };
+
+  const toggleAgent = (name: string) => {
+    const next = new Set(selectedAgents);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    setSelectedAgents(next);
+  };
+
+  const allAgentsSelected =
+    detectedAgents.length > 0 &&
+    detectedAgents.every((a) => selectedAgents.has(a.name));
+
+  const toggleAllAgents = () => {
+    if (allAgentsSelected) {
+      setSelectedAgents(new Set());
+    } else {
+      setSelectedAgents(new Set(detectedAgents.map((a) => a.name)));
+    }
+  };
+
+  const handleInstall = async () => {
+    setInstalling(true);
+    try {
+      const targetAgents = [...selectedAgents];
+      for (const [url, group] of grouped) {
+        const selectedSkills = group.skills.filter((s) => selected.has(`${s.repo_url}::${s.skill_id}`));
+        if (selectedSkills.length === 0) continue;
+        const skillIds = selectedSkills.map((s) => s.skill_id);
+        await onInstall(url, skillIds, targetAgents);
+      }
+      onClose();
+    } catch (e: any) {
+      toast.error(`Failed to install: ${e?.message ?? e}`);
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const selectedCount = selected.size;
+  const canInstall = selectedCount > 0 && selectedAgents.size > 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="absolute inset-0 bg-background/80 backdrop-blur-[2px]" />
+
+      <div
+        ref={dlgRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="New skills available"
+        tabIndex={-1}
+        className="relative z-10 w-[calc(100%-2rem)] max-w-md rounded-xl border border-border bg-card p-5 shadow-xl animate-fade-in outline-none max-h-[80vh] overflow-y-auto"
+      >
+        {/* Header */}
+        <div className="flex items-center gap-2 mb-4">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Package size={16} />
+          </span>
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">
+              More skills available from your installed repos
+            </h3>
+          </div>
+        </div>
+
+        {/* Skill list grouped by repo */}
+        <div className="space-y-4">
+          {[...grouped].map(([url, group]) => (
+            <div key={url}>
+              <p className="text-xs font-medium text-muted-foreground mb-2">
+                {group.pack ?? url}
+              </p>
+              <div className="space-y-1.5">
+                {group.skills.map((skill) => {
+                  const key = `${skill.repo_url}::${skill.skill_id}`;
+                  return (
+                    <label
+                      key={key}
+                      className="flex items-start gap-2 rounded-lg border border-border px-3 py-2 cursor-pointer hover:bg-muted/50 transition-colors"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selected.has(key)}
+                        onChange={() => toggleSkill(key)}
+                        className="mt-0.5 shrink-0"
+                      />
+                      <div className="min-w-0">
+                        <span className="text-sm font-medium text-foreground">
+                          {skill.name}
+                        </span>
+                        {skill.description && (
+                          <p className="text-xs text-muted-foreground line-clamp-2">
+                            {skill.description}
+                          </p>
+                        )}
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Agent selection */}
+        {detectedAgents.length > 0 && (
+          <div className="mt-4">
+            <span className="text-xs text-muted-foreground">Install to</span>
+            <div className="mt-1.5 flex flex-wrap items-center gap-x-4 gap-y-1.5">
+              <label className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+                <input
+                  type="checkbox"
+                  checked={allAgentsSelected}
+                  onChange={toggleAllAgents}
+                  className="rounded border-border accent-primary"
+                />
+                All Agents
+              </label>
+              <span className="text-border">|</span>
+              {detectedAgents.map((a) => (
+                <label
+                  key={a.name}
+                  className="flex items-center gap-1.5 text-xs text-foreground"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedAgents.has(a.name)}
+                    onChange={() => toggleAgent(a.name)}
+                    className="rounded border-border accent-primary"
+                  />
+                  {agentDisplayName(a.name)}
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="mt-4">
+          <button
+            onClick={handleInstall}
+            disabled={!canInstall || installing}
+            className="w-full flex items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground disabled:opacity-50"
+          >
+            {installing ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <Download size={12} />
+            )}
+            {installing
+              ? "Installing..."
+              : `Install Selected (${selectedCount})`}
+          </button>
+          <button
+            onClick={onDismiss}
+            className="mt-2 w-full rounded-lg border border-border px-3 py-2 text-xs text-muted-foreground hover:bg-muted/50 transition-colors"
+          >
+            Not Now
+          </button>
+          <button
+            onClick={onClose}
+            className="mt-2 w-full rounded-lg px-3 py-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -13,6 +13,7 @@ import type {
   Project,
   ScanResult,
   SkillAuditInfo,
+  CheckUpdatesResult,
   UpdateStatus,
 } from "./types";
 
@@ -83,7 +84,7 @@ export const api = {
     return invoke("get_skill_locations", { name });
   },
 
-  checkUpdates(): Promise<[string, UpdateStatus][]> {
+  checkUpdates(): Promise<CheckUpdatesResult> {
     return invoke("check_updates");
   },
 
@@ -118,6 +119,18 @@ export const api = {
   ): Promise<InstallResult[]> {
     return invoke("install_scanned_skills", {
       cloneId,
+      skillIds,
+      targetAgents,
+    });
+  },
+
+  installNewRepoSkills(
+    url: string,
+    skillIds: string[],
+    targetAgents: string[],
+  ): Promise<InstallResult[]> {
+    return invoke("install_new_repo_skills", {
+      url,
       skillIds,
       targetAgents,
     });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -125,7 +125,21 @@ export interface AuditFinding {
 export type UpdateStatus =
   | { status: "up_to_date"; remote_hash: string }
   | { status: "update_available"; remote_hash: string }
+  | { status: "removed_from_repo" }
   | { status: "error"; message: string };
+
+export interface NewRepoSkill {
+  repo_url: string;
+  pack: string | null;
+  skill_id: string;
+  name: string;
+  description: string;
+}
+
+export interface CheckUpdatesResult {
+  statuses: [string, UpdateStatus][];
+  new_skills: NewRepoSkill[];
+}
 
 export interface AgentInfo {
   name: string;

--- a/src/pages/extensions.tsx
+++ b/src/pages/extensions.tsx
@@ -1,7 +1,8 @@
-import { ArrowDownCircle, Plus, RefreshCw } from "lucide-react";
+import { ArrowDownCircle, Package, Plus, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { ExtensionDetail } from "@/components/extensions/extension-detail";
+import { NewSkillsDialog } from "@/components/extensions/new-skills-dialog";
 import { ExtensionFilters } from "@/components/extensions/extension-filters";
 import { ExtensionTable } from "@/components/extensions/extension-table";
 import { useAgentStore } from "@/stores/agent-store";
@@ -63,7 +64,10 @@ export default function ExtensionsPage() {
   const updateAll = useExtensionStore((s) => s.updateAll);
   const updatingAll = useExtensionStore((s) => s.updatingAll);
   const updateStatuses = useExtensionStore((s) => s.updateStatuses);
+  const newRepoSkills = useExtensionStore((s) => s.newRepoSkills);
+  const installNewRepoSkills = useExtensionStore((s) => s.installNewRepoSkills);
   const grouped = useExtensionStore((s) => s.grouped);
+  const [showNewSkills, setShowNewSkills] = useState(false);
   const updatesAvailable = useMemo(() => {
     return grouped().filter((g) =>
       g.instances.some(
@@ -139,6 +143,15 @@ export default function ExtensionsPage() {
                 {updatingAll
                   ? "Updating..."
                   : `Update All (${updatesAvailable})`}
+              </button>
+            )}
+            {newRepoSkills.length > 0 && (
+              <button
+                onClick={() => setShowNewSkills(true)}
+                className="flex items-center gap-1 rounded-lg border border-primary/30 bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary shadow-sm transition-[background-color,box-shadow] duration-200 hover:bg-primary/20 hover:shadow-md"
+              >
+                <Package size={12} />
+                {newRepoSkills.length} More from Repos
               </button>
             )}
           </div>
@@ -218,6 +231,20 @@ export default function ExtensionsPage() {
           </div>
         )}
       </div>
+      {showNewSkills && newRepoSkills.length > 0 && (
+        <NewSkillsDialog
+          skills={newRepoSkills}
+          onInstall={async (url, skillIds, targetAgents) => {
+            await installNewRepoSkills(url, skillIds, targetAgents);
+            toast.success(`${skillIds.length} skill${skillIds.length > 1 ? "s" : ""} installed`);
+          }}
+          onDismiss={() => {
+            useExtensionStore.setState({ newRepoSkills: [] });
+            setShowNewSkills(false);
+          }}
+          onClose={() => setShowNewSkills(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/stores/extension-store.ts
+++ b/src/stores/extension-store.ts
@@ -4,6 +4,7 @@ import type {
   Extension,
   ExtensionKind,
   GroupedExtension,
+  NewRepoSkill,
   UpdateStatus,
 } from "@/lib/types";
 import { expandGroupKeys, getCachedGroups, getCachedFiltered } from "./extension-helpers";
@@ -60,9 +61,11 @@ interface ExtensionState {
   confirmDelete: () => Promise<void>;
   checkingUpdates: boolean;
   updatingAll: boolean;
+  newRepoSkills: NewRepoSkill[];
   checkUpdates: () => Promise<void>;
   updateExtension: (id: string) => Promise<boolean>;
   updateAll: () => Promise<number>;
+  installNewRepoSkills: (url: string, skillIds: string[], targetAgents: string[]) => Promise<void>;
   deleteFromAgents: (groupKey: string, agents: string[]) => Promise<void>;
   childSkillsOf: (cliId: string) => Extension[];
   grouped: () => GroupedExtension[];
@@ -91,6 +94,7 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
   pendingDelete: null,
   checkingUpdates: false,
   updatingAll: false,
+  newRepoSkills: [],
   tableSorting: [],
   setTableSorting: (sorting) => set({ tableSorting: sorting }),
 
@@ -297,12 +301,12 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
   async checkUpdates() {
     set({ checkingUpdates: true });
     try {
-      const results = await api.checkUpdates();
+      const result = await api.checkUpdates();
       const map = new Map<string, UpdateStatus>();
-      for (const [id, status] of results) {
+      for (const [id, status] of result.statuses) {
         map.set(id, status);
       }
-      set({ updateStatuses: map });
+      set({ updateStatuses: map, newRepoSkills: result.new_skills });
     } finally {
       set({ checkingUpdates: false });
     }
@@ -312,17 +316,18 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
     const result = await api.updateExtension(id);
     if (result.skipped) {
       toast.info(`${result.name} is no longer available in the remote repository`);
-      // Clear update status so it doesn't linger
+      // Set removed_from_repo status for all siblings
       const statuses = new Map(get().updateStatuses);
       const group = get()
         .grouped()
         .find((g) => g.instances.some((i) => i.id === id));
+      const removedStatus = { status: "removed_from_repo" as const };
       if (group) {
         for (const inst of group.instances) {
-          statuses.delete(inst.id);
+          statuses.set(inst.id, removedStatus);
         }
       } else {
-        statuses.delete(id);
+        statuses.set(id, removedStatus);
       }
       set({ updateStatuses: statuses });
       return true;
@@ -373,10 +378,11 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
           const result = await api.updateExtension(id);
           if (result.skipped) {
             skippedNames.push(groupName);
-            // Clear update status so it doesn't linger
+            // Set removed_from_repo status for all siblings
             const statuses = new Map(get().updateStatuses);
+            const removedStatus = { status: "removed_from_repo" as const };
             for (const sid of siblingIds) {
-              statuses.delete(sid);
+              statuses.set(sid, removedStatus);
             }
             set({ updateStatuses: statuses });
             continue;
@@ -406,6 +412,17 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
       set({ updatingAll: false });
     }
     return updated;
+  },
+
+  async installNewRepoSkills(url: string, skillIds: string[], targetAgents: string[]) {
+    await api.installNewRepoSkills(url, skillIds, targetAgents);
+    // Remove installed skills from newRepoSkills
+    set({
+      newRepoSkills: get().newRepoSkills.filter(
+        (s) => !(s.repo_url === url && skillIds.includes(s.skill_id)),
+      ),
+    });
+    await get().rescanAndFetch();
   },
 
   async deleteFromAgents(groupKey, agentNames) {


### PR DESCRIPTION
## Summary
- **Removed from repo detection**: When a skill no longer exists in its source repo, show "No longer available in the repository" indicator in the detail panel and persist `RemovedFromRepo` status across restarts
- **New skill discovery**: During `check_updates`, scan cloned repos for uninstalled skills and surface them via a "N More from Repos" button with an install dialog (per-skill checkbox, per-agent selection matching Install from Git flow)
- **New backend command**: `install_new_repo_skills` for batch installing discovered skills from a repo URL
- **Pack filter fix**: Fix `useMemo` stale dependency causing pack counts not to update immediately after installs/deletes

## Test plan
- [x] Install skills from a multi-skill repo, then Check Updates — verify "N More from Repos" button appears for uninstalled skills
- [x] Click the button, select skills and agents, install — verify skills are installed and pack filter counts update immediately
- [x] Click "Not Now" — verify button disappears until next Check Updates
- [x] Fake a removed skill (modify DB `install_revision`), Check Updates, click Update — verify "No longer available in the repository" appears in detail panel
- [x] Verify existing update/install flows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)