### PR TITLE
refactor: flatten CLI child skills into main extension list

### DIFF
--- a/crates/hk-core/src/store.rs
+++ b/crates/hk-core/src/store.rs
@@ -927,7 +927,26 @@ impl Store {
                )",
         )?;
 
+        // 3. CLI children inherit pack from their parent
+        conn.execute_batch(
+            "UPDATE extensions SET pack = (
+                SELECT p.pack FROM extensions p
+                WHERE p.id = extensions.cli_parent_id AND p.pack IS NOT NULL
+             )
+             WHERE pack IS NULL
+               AND cli_parent_id IS NOT NULL
+               AND EXISTS (
+                SELECT 1 FROM extensions p
+                WHERE p.id = extensions.cli_parent_id AND p.pack IS NOT NULL
+               )",
+        )?;
+
         Ok(())
+    }
+
+    /// Public wrapper so callers can re-run pack backfill after setting install_meta.
+    pub fn run_backfill_packs(&self) -> Result<(), HkError> {
+        Self::backfill_packs(&self.conn)
     }
 
     pub fn insert_audit_result(&self, result: &AuditResult) -> Result<(), HkError> {

--- a/crates/hk-desktop/src/commands/extensions.rs
+++ b/crates/hk-desktop/src/commands/extensions.rs
@@ -523,13 +523,68 @@ pub async fn scan_and_sync(state: State<'_, AppState>) -> Result<usize, HkError>
     let store = state.store.clone();
     let adapters = state.adapters.clone();
     tauri::async_runtime::spawn_blocking(move || {
-        // Scan filesystem WITHOUT holding the lock — this is the slow part
         let extensions = scanner::scan_all(&adapters);
         let count = extensions.len();
 
-        // Lock briefly for a single transactional write (fast — one fsync total)
         let store = store.lock();
+
+        // Remember existing skill IDs so we only match NEW ones after sync
+        let pre_ids: std::collections::HashSet<String> = store
+            .list_extensions(Some(ExtensionKind::Skill), None)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|e| e.id)
+            .collect();
+
         store.sync_extensions(&extensions)?;
+
+        // Match only newly added skills without install_meta against marketplace
+        let unlinked: Vec<(String, String)> = store
+            .list_extensions(Some(ExtensionKind::Skill), None)?
+            .into_iter()
+            .filter(|e| e.install_meta.is_none() && !pre_ids.contains(&e.id))
+            .map(|e| (e.id, e.name))
+            .collect();
+
+        if !unlinked.is_empty() {
+            let unique_names: std::collections::HashSet<&str> =
+                unlinked.iter().map(|(_, n)| n.as_str()).collect();
+            let mut matched: std::collections::HashMap<String, (String, String, Option<String>)> =
+                std::collections::HashMap::new();
+            for name in &unique_names {
+                if let Ok(results) = hk_core::marketplace::search_skills(name, 5) {
+                    let exact: Vec<_> = results.iter().filter(|r| r.name.eq_ignore_ascii_case(name)).collect();
+                    if exact.len() == 1 {
+                        let item = exact[0];
+                        let git_url = hk_core::marketplace::git_url_for_source(&item.source);
+                        let remote_rev = manager::get_remote_head(&git_url).ok();
+                        matched.insert(name.to_string(), (git_url, item.skill_id.clone(), remote_rev));
+                    }
+                }
+            }
+            if !matched.is_empty() {
+                let now = chrono::Utc::now();
+                for (id, name) in &unlinked {
+                    if let Some((git_url, skill_id, remote_rev)) = matched.get(name.as_str()) {
+                        let meta = InstallMeta {
+                            install_type: "marketplace".into(),
+                            url: Some(format!("{}/{}", git_url.trim_end_matches(".git"), skill_id)),
+                            url_resolved: Some(git_url.clone()),
+                            branch: None,
+                            subpath: if skill_id.is_empty() { None } else { Some(skill_id.clone()) },
+                            revision: remote_rev.clone(),
+                            remote_revision: remote_rev.clone(),
+                            checked_at: Some(now),
+                            check_error: None,
+                        };
+                        let _ = store.set_install_meta(id, &meta);
+                    }
+                }
+                // Re-run backfill to extract pack from newly set URLs
+                let _ = store.run_backfill_packs();
+            }
+        }
+
         Ok(count)
     })
     .await
@@ -628,7 +683,6 @@ pub async fn check_updates(
             let unique_names: std::collections::HashSet<&str> =
                 unlinked.iter().map(|(_, name)| name.as_str()).collect();
 
-            // For each unique name, search marketplace and resolve remote revision
             let mut matched: std::collections::HashMap<String, (String, String, Option<String>)> =
                 std::collections::HashMap::new();
             for name in &unique_names {
@@ -640,8 +694,6 @@ pub async fn check_updates(
                     if exact.len() == 1 {
                         let item = exact[0];
                         let git_url = hk_core::marketplace::git_url_for_source(&item.source);
-                        // Get current remote HEAD as baseline — so we don't falsely
-                        // show "update available" when we don't know the local version
                         let remote_rev = manager::get_remote_head(&git_url).ok();
                         matched.insert(
                             name.to_string(),
@@ -656,8 +708,6 @@ pub async fn check_updates(
                 let now = chrono::Utc::now();
                 for (id, name) in &unlinked {
                     if let Some((git_url, skill_id, remote_rev)) = matched.get(name.as_str()) {
-                        // Set revision = remote_rev as baseline: "assume local is at this version"
-                        // Next check_updates will detect if remote moved past this point
                         let meta = InstallMeta {
                             install_type: "marketplace".into(),
                             url: Some(format!(
@@ -680,8 +730,6 @@ pub async fn check_updates(
                         if let Err(e) = store.set_install_meta(id, &meta) {
                             eprintln!("[hk] warning: {e}");
                         }
-                        // Don't push to updatable — we already know the status (up-to-date)
-                        // and don't need to call get_remote_head again
                     }
                 }
             }

--- a/src/components/extensions/delete-dialog.tsx
+++ b/src/components/extensions/delete-dialog.tsx
@@ -19,15 +19,12 @@ type DeleteItem = {
 };
 
 /**
- * Build path-based delete items from skill locations (for CLI and Skill).
+ * Build path-based delete items from skill locations.
  * Each item = one physical path, with agent names as the primary label.
  */
 function buildPathItems(
   locations: [string, string, string | null][],
-  childMcps?: Extension[],
-  instanceData?: Map<string, ExtContent>,
 ): DeleteItem[] {
-  // Group by physical path → list of agents + symlink target
   const pathMap = new Map<string, { agents: string[]; symlink?: string }>();
   for (const [agent, path, symlinkTarget] of locations) {
     const entry = pathMap.get(path) ?? { agents: [] };
@@ -47,29 +44,11 @@ function buildPathItems(
       symlink,
     });
   }
-
-  // Attach MCPs as separate items
-  if (childMcps) {
-    for (const m of childMcps) {
-      const mcpData = instanceData?.get(m.id);
-      items.push({
-        key: `mcp:${m.id}`,
-        agents: [...m.agents],
-        paths: mcpData?.path ? [mcpData.path] : [],
-        mcps: [m.name],
-        shared: false,
-        description: `Remove MCP server "${m.name}" from configuration`,
-      });
-    }
-  }
-
   return items;
 }
 
 /**
  * Build agent-based delete items from instances (for MCP, Hook, Plugin).
- * For these types, the "path" is the config file they live in (e.g. settings.json),
- * NOT a file being deleted — so we show a description instead.
  */
 function buildAgentItems(
   instances: GroupedExtension["instances"],
@@ -121,7 +100,6 @@ export function DeleteDialog({
 }) {
   const dlgRef = useRef<HTMLDivElement>(null);
 
-  // Escape to close
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -130,15 +108,12 @@ export function DeleteDialog({
     return () => document.removeEventListener("keydown", handleKey);
   }, [onClose]);
 
-  // Focus trap
   useFocusTrap(dlgRef, true);
 
-  // Reset selection when dialog opens
   useEffect(() => {
     setDeleteAgents(new Set());
   }, [setDeleteAgents]);
 
-  // Friendly display name (hooks use internal format like "AfterAgent:*:command")
   const displayName = group.kind === "hook"
     ? (() => {
         const parts = group.name.split(":");
@@ -150,23 +125,112 @@ export function DeleteDialog({
       })()
     : group.name;
 
-  // Build items based on extension kind
   const isCli = group.kind === "cli";
+
+  // ── CLI Uninstall Dialog ──
+  if (isCli) {
+    const binaryPath = group.instances[0]?.cli_meta?.binary_path;
+    // Deduplicate children by name+kind
+    const childMap = new Map<string, { name: string; kind: string }>();
+    for (const child of childExtensions ?? []) {
+      const key = `${child.kind}:${child.name}`;
+      if (!childMap.has(key)) childMap.set(key, { name: child.name, kind: child.kind });
+    }
+    const children = [...childMap.values()];
+
+    return (
+      <div
+        className="absolute inset-0 z-50 flex items-center justify-center rounded-xl overflow-hidden"
+        onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      >
+        <div className="absolute inset-0 bg-background/80 backdrop-blur-[2px]" />
+        <div
+          ref={dlgRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Uninstall CLI"
+          tabIndex={-1}
+          className="relative z-10 w-[calc(100%-2rem)] max-w-sm rounded-xl border border-border bg-card p-5 shadow-xl animate-fade-in outline-none max-h-[80vh] overflow-y-auto"
+        >
+          <div className="flex items-center gap-2 mb-4">
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-destructive/10 text-destructive">
+              <Trash2 size={16} />
+            </span>
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">
+                Uninstall "{displayName}"
+              </h3>
+              <p className="text-xs text-muted-foreground">
+                This action cannot be undone.
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {children.length > 0 && (
+              <>
+                <p className="text-xs text-muted-foreground">
+                  The following extensions will also be removed:
+                </p>
+                <div className="space-y-1 rounded-lg border border-border bg-muted/30 p-2.5">
+                  {children.map((child) => (
+                    <div key={`${child.kind}:${child.name}`} className="flex items-center gap-2 text-xs">
+                      <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
+                        {child.kind}
+                      </span>
+                      <span className="text-foreground">{child.name}</span>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+
+            {binaryPath && (
+              <div className="flex items-start gap-1.5 rounded-lg border border-chart-5/30 bg-chart-5/5 p-2.5 text-xs text-chart-5">
+                <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                <span>
+                  The binary <span className="font-mono">{binaryPath}</span> will also be removed.
+                </span>
+              </div>
+            )}
+
+            <button
+              disabled={deleting}
+              onClick={() => onDelete(group.agents)}
+              className="w-full flex items-center justify-center gap-1.5 rounded-lg bg-destructive px-3 py-2 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+            >
+              {deleting ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <Trash2 size={12} />
+              )}
+              Uninstall {displayName}
+            </button>
+          </div>
+
+          <button
+            onClick={onClose}
+            disabled={deleting}
+            className="mt-4 w-full rounded-lg border border-border px-3 py-2 text-xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Standard Delete Dialog (skill, MCP, hook, plugin) ──
   const isSkill = group.kind === "skill";
-  const usePathBased = (isCli || isSkill) && skillLocations && skillLocations.length > 0;
+  const usePathBased = isSkill && skillLocations && skillLocations.length > 0;
 
   const items: DeleteItem[] = usePathBased
-    ? buildPathItems(
-        skillLocations!,
-        isCli ? (childExtensions ?? []).filter((e) => e.kind === "mcp") : undefined,
-        instanceData,
-      )
+    ? buildPathItems(skillLocations!)
     : buildAgentItems(group.instances, instanceData, group.kind, group.name);
 
   const selectedKeys = deleteAgents;
   const allSelected = items.length > 0 && items.every((i) => selectedKeys.has(i.key));
   const isSingle = items.length === 1;
-  const binaryPath = isCli ? group.instances[0]?.cli_meta?.binary_path : null;
 
   return (
     <div
@@ -247,7 +311,6 @@ export function DeleteDialog({
                   />
                 )}
                 <div className="min-w-0">
-                  {/* Agent names as primary label */}
                   <span className="font-medium text-foreground">
                     {item.agents.map(agentDisplayName).join(", ")}
                   </span>
@@ -256,13 +319,11 @@ export function DeleteDialog({
                       shared
                     </span>
                   )}
-                  {/* Description (for config-based types like MCP/Hook) */}
                   {item.description && (
                     <p className="text-muted-foreground mt-0.5">
                       {item.description}
                     </p>
                   )}
-                  {/* Paths as secondary info */}
                   {item.paths.map((p) => (
                     <p
                       key={p}
@@ -272,13 +333,11 @@ export function DeleteDialog({
                       <span className="break-all">{p}</span>
                     </p>
                   ))}
-                  {/* MCPs (only if no description already mentions it) */}
                   {!item.description && item.mcps.map((name) => (
                     <p key={name} className="text-muted-foreground mt-0.5">
                       MCP: {name}
                     </p>
                   ))}
-                  {/* Symlink */}
                   {item.symlink && (
                     <p className="flex items-center gap-1 text-chart-5 mt-0.5">
                       <Link size={10} className="shrink-0" />
@@ -290,24 +349,11 @@ export function DeleteDialog({
             ))}
           </div>
 
-          {/* Binary removal warning for CLI */}
-          {isCli && allSelected && binaryPath && (
-            <div className="flex items-start gap-1.5 rounded-lg border border-chart-5/30 bg-chart-5/5 p-2.5 text-xs text-chart-5">
-              <AlertTriangle size={12} className="mt-0.5 shrink-0" />
-              <span>
-                All items selected — the binary{" "}
-                <span className="font-mono">{binaryPath}</span> will also be
-                removed.
-              </span>
-            </div>
-          )}
-
           {/* Symlink warnings */}
           {(() => {
             const selected = isSingle ? items : items.filter((i) => selectedKeys.has(i.key));
             const warnings: React.ReactNode[] = [];
 
-            // 1. Deleting a symlink removes the original
             const symlinkItems = selected.filter((i) => i.symlink);
             if (symlinkItems.length > 0) {
               warnings.push(
@@ -315,8 +361,8 @@ export function DeleteDialog({
                   <AlertTriangle size={12} className="mt-0.5 shrink-0" />
                   <span>
                     {symlinkItems.length === 1
-                      ? "This is a symlink — the original files at "
-                      : "These are symlinks — the original files at "}
+                      ? "This is a symlink \u2014 the original files at "
+                      : "These are symlinks \u2014 the original files at "}
                     {symlinkItems.map((s, i) => (
                       <span key={s.key}>
                         {i > 0 && ", "}
@@ -329,7 +375,6 @@ export function DeleteDialog({
               );
             }
 
-            // 2. Deleting an original breaks symlinks that point to it
             const selectedPaths = new Set(selected.flatMap((i) => i.paths));
             const affectedSymlinks = items.filter(
               (i) => i.symlink && selectedPaths.has(i.symlink) && !selected.includes(i),
@@ -342,7 +387,7 @@ export function DeleteDialog({
                   <span>
                     {affectedAgents.map(agentDisplayName).join(", ")}{" "}
                     {affectedAgents.length === 1 ? "has a symlink" : "have symlinks"}{" "}
-                    pointing to this path — {affectedAgents.length === 1 ? "it" : "they"} will become invalid.
+                    pointing to this path \u2014 {affectedAgents.length === 1 ? "it" : "they"} will become invalid.
                   </span>
                 </div>,
               );
@@ -385,9 +430,7 @@ export function DeleteDialog({
               ) : (
                 <Trash2 size={12} />
               )}
-              {isCli && allSelected
-                ? `Uninstall ${displayName}`
-                : `Remove ${selectedKeys.size} item${selectedKeys.size !== 1 ? "s" : ""}`}
+              Remove {selectedKeys.size} item{selectedKeys.size !== 1 ? "s" : ""}
             </button>
           )}
         </div>

--- a/src/components/extensions/delete-dialog.tsx
+++ b/src/components/extensions/delete-dialog.tsx
@@ -361,8 +361,8 @@ export function DeleteDialog({
                   <AlertTriangle size={12} className="mt-0.5 shrink-0" />
                   <span>
                     {symlinkItems.length === 1
-                      ? "This is a symlink \u2014 the original files at "
-                      : "These are symlinks \u2014 the original files at "}
+                      ? "This is a symlink  — the original files at "
+                      : "These are symlinks  — the original files at "}
                     {symlinkItems.map((s, i) => (
                       <span key={s.key}>
                         {i > 0 && ", "}
@@ -387,7 +387,7 @@ export function DeleteDialog({
                   <span>
                     {affectedAgents.map(agentDisplayName).join(", ")}{" "}
                     {affectedAgents.length === 1 ? "has a symlink" : "have symlinks"}{" "}
-                    pointing to this path \u2014 {affectedAgents.length === 1 ? "it" : "they"} will become invalid.
+                    pointing to this path  — {affectedAgents.length === 1 ? "it" : "they"} will become invalid.
                   </span>
                 </div>,
               );

--- a/src/components/extensions/detail-cli-sections.tsx
+++ b/src/components/extensions/detail-cli-sections.tsx
@@ -1,16 +1,33 @@
-import { FolderOpen, Link } from "lucide-react";
-import type { Extension, ExtensionContent as ExtContent, GroupedExtension } from "@/lib/types";
-import { agentDisplayName } from "@/lib/types";
+import type { Extension, ExtensionKind, GroupedExtension } from "@/lib/types";
+import { extensionGroupKey } from "@/lib/types";
+import { findCliChildren } from "@/stores/extension-helpers";
+import { useExtensionStore } from "@/stores/extension-store";
 
 interface CliSectionsProps {
   group: GroupedExtension;
   extensions: Extension[];
-  instanceData: Map<string, ExtContent>;
-  skillLocations: [string, string, string | null][];
 }
 
-export function CliSections({ group, extensions, instanceData, skillLocations }: CliSectionsProps) {
+export function CliSections({ group, extensions }: CliSectionsProps) {
   if (group.kind !== "cli") return null;
+
+  const setSelectedId = useExtensionStore((s) => s.setSelectedId);
+  const grouped = useExtensionStore((s) => s.grouped);
+
+  const children = findCliChildren(extensions, group.instances[0]?.id, group.pack);
+
+  // Deduplicate children by groupKey so each child skill/MCP appears once
+  const allGroups = grouped();
+  const childGroups = new Map<string, { name: string; kind: ExtensionKind; groupKey: string }>();
+  for (const child of children) {
+    const key = extensionGroupKey(child);
+    if (!childGroups.has(key)) {
+      const exists = allGroups.some((g) => g.groupKey === key);
+      if (exists) {
+        childGroups.set(key, { name: child.name, kind: child.kind, groupKey: key });
+      }
+    }
+  }
 
   return (
     <>
@@ -74,88 +91,42 @@ export function CliSections({ group, extensions, instanceData, skillLocations }:
           );
         })()}
 
-      {/* CLI Associated Extensions (Skills + MCPs) */}
-      {(() => {
-        const children = extensions.filter(
-          (e) => e.cli_parent_id === group.instances[0]?.id,
-        );
-        const mcps = children.filter((e) => e.kind === "mcp");
-        // Group skill locations by agent for display
-        const agentSkillPaths = new Map<string, { path: string; symlink: string | null }[]>();
-        for (const [agent, path, symlink] of skillLocations) {
-          const list = agentSkillPaths.get(agent) ?? [];
-          list.push({ path, symlink });
-          agentSkillPaths.set(agent, list);
+      {/* Associated Extensions — grouped by kind in cards */}
+      {childGroups.size > 0 && (() => {
+        const byKind = new Map<ExtensionKind, { name: string; kind: ExtensionKind; groupKey: string }[]>();
+        for (const child of childGroups.values()) {
+          const list = byKind.get(child.kind) ?? [];
+          list.push(child);
+          byKind.set(child.kind, list);
         }
-        return children.length > 0 ? (
-          <div className="mt-4 space-y-3">
-            {agentSkillPaths.size > 0 && (
-              <div>
-                <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-                  Associated Skills
-                </h4>
-                <div className="space-y-3">
-                  {[...agentSkillPaths.entries()].map(([agent, paths]) => (
-                    <div
-                      key={agent}
-                      className="rounded-lg border border-border bg-card p-3"
-                    >
-                      <span className="text-sm font-medium">
-                        {agentDisplayName(agent)}
-                      </span>
-                      <div className="mt-1.5 space-y-1">
-                        {paths.map((p) => (
-                          <div key={p.path}>
-                            <div className="flex items-start gap-2 text-muted-foreground">
-                              <FolderOpen size={12} className="mt-0.5 shrink-0" />
-                              <span className="break-all text-xs">{p.path}</span>
-                            </div>
-                            {p.symlink && (
-                              <div className="flex items-start gap-2 text-muted-foreground/70 ml-0">
-                                <Link size={12} className="mt-0.5 shrink-0" />
-                                <span className="break-all text-xs italic">{p.symlink}</span>
-                              </div>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-            {mcps.length > 0 && (
-              <div>
-                <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-                  Associated MCP Servers
-                </h4>
-                <div className="space-y-3">
-                  {mcps.map((child) => {
-                    const mcpData = instanceData.get(child.id);
-                    return (
-                      <div
-                        key={child.id}
-                        className="rounded-lg border border-border bg-card p-3"
+        const kindLabel: Record<string, string> = { skill: "Skills", mcp: "MCP Servers", plugin: "Plugins", hook: "Hooks" };
+        return (
+          <div className="mt-4">
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+              Associated Extensions
+            </h4>
+            <div className="space-y-2">
+              {[...byKind.entries()].map(([kind, items]) => (
+                <div key={kind} className="rounded-lg border border-border bg-card p-3">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {kindLabel[kind] ?? kind} ({items.length})
+                  </span>
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {items.map((child) => (
+                      <button
+                        key={child.groupKey}
+                        onClick={() => setSelectedId(child.groupKey)}
+                        className="rounded-md bg-muted/50 px-2 py-1 text-xs text-foreground hover:bg-accent transition-colors"
                       >
-                        <span className="text-sm font-medium">
-                          {agentDisplayName(child.agents[0] ?? "unknown")}
-                        </span>
-                        <div className="mt-1.5 space-y-1">
-                          {mcpData?.path && (
-                            <div className="flex items-start gap-2 text-muted-foreground">
-                              <FolderOpen size={12} className="mt-0.5 shrink-0" />
-                              <span className="break-all text-xs">{mcpData.path}</span>
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })}
+                        {child.name}
+                      </button>
+                    ))}
+                  </div>
                 </div>
-              </div>
-            )}
+              ))}
+            </div>
           </div>
-        ) : null;
+        );
       })()}
     </>
   );

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -17,8 +17,9 @@ import { PermissionDetail } from "@/components/extensions/permission-detail";
 import { SkillFileSection } from "@/components/extensions/skill-file-section";
 import { api } from "@/lib/invoke";
 import type { ExtensionContent as ExtContent } from "@/lib/types";
-import { agentDisplayName, sortAgents } from "@/lib/types";
+import { agentDisplayName, extensionGroupKey, sortAgents } from "@/lib/types";
 import { useAgentStore } from "@/stores/agent-store";
+import { findCliChildren } from "@/stores/extension-helpers";
 import { useExtensionStore } from "@/stores/extension-store";
 import { toast } from "@/stores/toast-store";
 
@@ -79,36 +80,10 @@ export function ExtensionDetail() {
         setInstanceData(map);
         setLoadingContent(false);
       });
-      // For CLIs, also load content for child MCP extensions (to get config paths)
-      if (group.kind === "cli") {
-        const childMcps = extensions.filter(
-          (e) => e.cli_parent_id === group.instances[0]?.id && e.kind === "mcp",
-        );
-        if (childMcps.length > 0) {
-          Promise.all(
-            childMcps.map((m) =>
-              api.getExtensionContent(m.id)
-                .then((res) => [m.id, res] as const)
-                .catch(() => [m.id, null] as const),
-            ),
-          ).then((results) => {
-            setInstanceData((prev) => {
-              const next = new Map(prev);
-              for (const [id, data] of results) {
-                if (data) next.set(id, data);
-              }
-              return next;
-            });
-          });
-        }
-      }
-      // Load skill locations for skills and CLIs (CLIs need child skill paths)
-      if (group.kind === "skill" || group.kind === "cli") {
-        const skillName = group.kind === "cli"
-          ? group.instances[0]?.cli_meta?.binary_name ?? group.name
-          : group.name;
+      // Load skill locations for skills
+      if (group.kind === "skill") {
         api
-          .getSkillLocations(skillName)
+          .getSkillLocations(group.name)
           .then(setSkillLocations)
           .catch(() => setSkillLocations([]));
       } else {
@@ -132,6 +107,21 @@ export function ExtensionDetail() {
 
   if (!group) return null;
 
+  // Find CLI parent for child extensions (by cli_parent_id or matching pack)
+  const cliParent = group.kind !== "cli"
+    ? (() => {
+        const parent = extensions.find((e) =>
+          e.kind === "cli" && (
+            e.id === group.instances[0]?.cli_parent_id ||
+            (group.pack && e.pack === group.pack)
+          ),
+        );
+        if (!parent) return null;
+        const parentGroupKey = extensionGroupKey(parent);
+        return { name: parent.name, onNavigate: () => setSelectedId(parentGroupKey) };
+      })()
+    : null;
+
   return (
     <div
       onWheel={(e) => e.stopPropagation()}
@@ -147,9 +137,21 @@ export function ExtensionDetail() {
 
       {/* Scrollable body */}
       <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-5 py-4">
-        {group.description && (
-          <p className="text-sm text-muted-foreground">{group.description}</p>
-        )}
+        <p className="text-sm text-muted-foreground">
+          {cliParent && (
+            <>
+              <span>{group.kind === "mcp" ? "This MCP server is part of " : "This skill is part of "}</span>
+              <button
+                onClick={cliParent.onNavigate}
+                className="font-medium text-primary hover:underline"
+              >
+                {cliParent.name}
+              </button>
+              {group.description ? ". " : ""}
+            </>
+          )}
+          {group.description}
+        </p>
 
         {/* 1. Status + Source row */}
         <div className="mt-4 flex items-center gap-2">
@@ -317,10 +319,22 @@ export function ExtensionDetail() {
                         if (hookUnsupported) return;
                         setDeploying(agent.name);
                         try {
-                          await installToAgent(
-                            group.instances[0].id,
-                            agent.name,
-                          );
+                          if (group.kind === "cli") {
+                            // Install all child skills/MCPs to the target agent
+                            const children = findCliChildren(extensions, group.instances[0]?.id, group.pack);
+                            // Deduplicate: one install per unique extension (skip duplicates across agents)
+                            const seen = new Set<string>();
+                            for (const child of children) {
+                              if (seen.has(child.name + child.kind)) continue;
+                              seen.add(child.name + child.kind);
+                              await installToAgent(child.id, agent.name);
+                            }
+                          } else {
+                            await installToAgent(
+                              group.instances[0].id,
+                              agent.name,
+                            );
+                          }
                           const msg = `Installed to ${agentDisplayName(agent.name)}. Takes effect in new sessions`;
                           toast.success(msg);
                         } catch {
@@ -369,8 +383,6 @@ export function ExtensionDetail() {
         <CliSections
           group={group}
           extensions={extensions}
-          instanceData={instanceData}
-          skillLocations={skillLocations}
         />
 
         {/* 8. Paths (per-agent breakdown) — skip for CLI */}
@@ -449,8 +461,8 @@ export function ExtensionDetail() {
             deleting={deleting}
             deleteAgents={deleteAgents}
             setDeleteAgents={setDeleteAgents}
-            childExtensions={group.kind === "cli" ? extensions.filter((e) => e.cli_parent_id === group.instances[0]?.id) : undefined}
-            skillLocations={group.kind === "cli" || group.kind === "skill" ? skillLocations : undefined}
+            childExtensions={group.kind === "cli" ? findCliChildren(extensions, group.instances[0]?.id, group.pack) : undefined}
+            skillLocations={group.kind === "skill" ? skillLocations : undefined}
             onDelete={async (agents) => {
               setDeleting(true);
               try {

--- a/src/components/extensions/extension-table.tsx
+++ b/src/components/extensions/extension-table.tsx
@@ -69,6 +69,7 @@ export function ExtensionTable({ data, scrollToId }: { data: GroupedExtension[];
       }),
       col.accessor("name", {
         header: "Name",
+        sortingFn: (a, b) => a.original.name.localeCompare(b.original.name, undefined, { sensitivity: "base" }),
         cell: (info) => {
           const ext = info.row.original;
           const statuses = useExtensionStore.getState().updateStatuses;

--- a/src/stores/__tests__/extension-helpers.test.ts
+++ b/src/stores/__tests__/extension-helpers.test.ts
@@ -52,14 +52,13 @@ describe("buildGroups", () => {
     expect(groups.map((g) => g.name).sort()).toEqual(["skill-a", "skill-b"]);
   });
 
-  it("excludes extensions with cli_parent_id (child skills)", () => {
-    const parent = { ...baseExt, id: "parent" };
-    const child = { ...baseExt, id: "child", cli_parent_id: "parent" };
+  it("includes extensions with cli_parent_id as separate groups", () => {
+    const parent = { ...baseExt, id: "parent", name: "my-cli", kind: "cli" as const };
+    const child = { ...baseExt, id: "child", name: "my-skill", cli_parent_id: "parent" };
     const groups = buildGroups([parent, child]);
 
-    expect(groups).toHaveLength(1);
-    expect(groups[0].instances).toHaveLength(1);
-    expect(groups[0].instances[0].id).toBe("parent");
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.name).sort()).toEqual(["my-cli", "my-skill"]);
   });
 
   it("merges tags from all instances (deduped)", () => {

--- a/src/stores/extension-helpers.ts
+++ b/src/stores/extension-helpers.ts
@@ -57,8 +57,6 @@ function deduplicatePermissions(
 export function buildGroups(extensions: Extension[]): GroupedExtension[] {
   const map = new Map<string, Extension[]>();
   for (const ext of extensions) {
-    // Skip extensions bundled under a CLI parent — they appear in the CLI's detail panel
-    if (ext.cli_parent_id) continue;
     const key = extensionGroupKey(ext);
     const list = map.get(key);
     if (list) list.push(ext);
@@ -102,6 +100,28 @@ export function buildGroups(extensions: Extension[]): GroupedExtension[] {
     });
   }
   return groups;
+}
+
+/** Find all child extensions of a CLI group (by cli_parent_id or matching pack).
+ *  When one instance of a group matches, all sibling instances are included
+ *  so that toggle/delete affects every agent the extension is installed on. */
+export function findCliChildren(
+  extensions: Extension[],
+  cliId: string | undefined,
+  cliPack: string | null,
+): Extension[] {
+  // First pass: find groupKeys of matching extensions
+  const matchedGroupKeys = new Set<string>();
+  for (const e of extensions) {
+    if (e.kind === "cli") continue;
+    if ((cliId && e.cli_parent_id === cliId) || (cliPack && e.pack === cliPack)) {
+      matchedGroupKeys.add(extensionGroupKey(e));
+    }
+  }
+  // Second pass: return ALL extensions belonging to matched groups
+  return extensions.filter(
+    (e) => e.kind !== "cli" && matchedGroupKeys.has(extensionGroupKey(e)),
+  );
 }
 
 /** Expand selected groupKeys into the underlying extension IDs. */

--- a/src/stores/extension-store.ts
+++ b/src/stores/extension-store.ts
@@ -7,7 +7,7 @@ import type {
   NewRepoSkill,
   UpdateStatus,
 } from "@/lib/types";
-import { expandGroupKeys, getCachedGroups, getCachedFiltered } from "./extension-helpers";
+import { expandGroupKeys, findCliChildren, getCachedGroups, getCachedFiltered } from "./extension-helpers";
 import { toast } from "./toast-store";
 
 export { buildGroups } from "./extension-helpers";
@@ -67,7 +67,6 @@ interface ExtensionState {
   updateAll: () => Promise<number>;
   installNewRepoSkills: (url: string, skillIds: string[], targetAgents: string[]) => Promise<void>;
   deleteFromAgents: (groupKey: string, agents: string[]) => Promise<void>;
-  childSkillsOf: (cliId: string) => Extension[];
   grouped: () => GroupedExtension[];
   filtered: () => GroupedExtension[];
 }
@@ -85,7 +84,7 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
   searchQuery: "",
   selectedId: null,
   selectedIds: new Set(),
-  sortBy: "installed_at",
+  sortBy: "name",
   updateStatuses: new Map(),
   allTags: [],
   tagFilter: null,
@@ -212,7 +211,12 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
 
   async fetchPacks() {
     const allPacks = await api.getAllPacks();
-    set({ allPacks });
+    const { packFilter } = get();
+    set({
+      allPacks,
+      // Clear stale pack filter if the pack no longer exists
+      ...(packFilter && !allPacks.includes(packFilter) ? { packFilter: null } : {}),
+    });
   },
 
   async installToAgent(id, targetAgent) {
@@ -225,7 +229,14 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
       .grouped()
       .find((g) => g.groupKey === groupKey);
     if (!group) return;
-    const ids = new Set(group.instances.map((e) => e.id));
+
+    // For CLI: also toggle all child extensions
+    let allToToggle = [...group.instances];
+    if (group.kind === "cli") {
+      allToToggle = [...allToToggle, ...findCliChildren(get().extensions, group.instances[0]?.id, group.pack)];
+    }
+
+    const ids = new Set(allToToggle.map((e) => e.id));
     // Optimistic update
     set((s) => ({
       extensions: s.extensions.map((e) =>
@@ -234,18 +245,17 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
     }));
 
     const results = await Promise.allSettled(
-      group.instances.map((e) => api.toggleExtension(e.id, enabled)),
+      allToToggle.map((e) => api.toggleExtension(e.id, enabled)),
     );
 
     const failedIds = new Set<string>();
     results.forEach((result, index) => {
       if (result.status === "rejected") {
-        failedIds.add(group.instances[index].id);
+        failedIds.add(allToToggle[index].id);
       }
     });
 
     if (failedIds.size > 0) {
-      // Revert only the failed instances
       set((s) => ({
         extensions: s.extensions.map((e) =>
           failedIds.has(e.id) ? { ...e, enabled: !enabled } : e,
@@ -434,36 +444,35 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
     let toDelete: typeof group.instances;
 
     if (group.kind === "cli") {
-      // For CLI groups: delete child skill/MCP extensions, not the CLI parent.
-      // The CLI parent is only included for full uninstall.
-      const cliInstance = group.instances[0];
-      const children = get().extensions.filter(
-        (e) => e.cli_parent_id === cliInstance?.id,
-      );
-      const matchingChildren = children.filter((e) =>
-        e.agents.some((a) => agentNames.includes(a)),
-      );
-      // Check if all agents are being deleted (full uninstall)
-      const allCliAgents = new Set(cliInstance?.agents ?? []);
-      const isFullUninstall = [...allCliAgents].every((a) =>
-        agentNames.includes(a),
-      );
-      toDelete = isFullUninstall
-        ? [...matchingChildren, ...group.instances]
-        : matchingChildren;
-    } else {
-      toDelete = group.instances.filter((e) =>
-        e.agents.some((a) => agentNames.includes(a)),
-      );
+      // CLI uninstall: no optimistic removal, no undo — execute directly
+      // so the dialog stays visible with a spinner during the operation.
+      const children = findCliChildren(get().extensions, group.instances[0]?.id, group.pack);
+      toDelete = [...children, ...group.instances];
+      const ids = toDelete.map((e) => e.id);
+      await Promise.all(ids.map((id) => api.deleteExtension(id)));
+      // Remove CLI binary
+      for (const ext of group.instances) {
+        if (ext.cli_meta?.binary_path) {
+          await api.uninstallCliBinary(ext.cli_meta.binary_path).catch((e) =>
+            console.error("Failed to remove CLI binary:", e),
+          );
+        }
+      }
+      await get().rescanAndFetch();
+      return;
     }
+
+    toDelete = group.instances.filter((e) =>
+      e.agents.some((a) => agentNames.includes(a)),
+    );
 
     if (toDelete.length === 0) return;
     const ids = new Set(toDelete.map((e) => e.id));
     // Optimistic removal
+    const isFullDelete = toDelete.length === group.instances.length;
     set((s) => ({
       extensions: s.extensions.filter((e) => !ids.has(e.id)),
-      selectedId:
-        toDelete.length === group.instances.length ? null : s.selectedId,
+      selectedId: isFullDelete ? null : s.selectedId,
     }));
     const prev = get().pendingDelete;
     if (prev) {
@@ -480,10 +489,6 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
       get().confirmDelete();
     }, 5000);
     set({ pendingDelete: { ids, extensions: toDelete, timer } });
-  },
-
-  childSkillsOf(cliId: string) {
-    return get().extensions.filter((e) => e.cli_parent_id === cliId);
   },
 
   grouped() {


### PR DESCRIPTION
## Summary

- **Flatten CLI children**: CLI child skills/MCPs now appear as independent entries in the main extension table, searchable, filterable, and individually manageable. CLI detail panel shows "Associated Extensions" grouped by kind with navigation links. Child skill detail panels show "Part of CLI" with jump-to-parent link.

- **CLI cascade operations**: CLI parent toggle cascades to all children. CLI uninstall executes directly with loading spinner (no optimistic removal), removing binary + all children. Shared `findCliChildren` helper with two-pass groupKey expansion ensures consistent child discovery across all operations.

- **Auto-link unlinked skills**: After scan, newly added skills without `install_meta` are matched against marketplace by name. Matched skills get `install_meta` set immediately so pack info appears on first load. Added `backfill_packs` Stage 3: CLI children inherit pack from parent.

- **Bug fixes**: Pack filter auto-clears when filtered pack no longer exists. Default sort changed to case-insensitive name sort.

## Test plan

- [x] Verify CLI child skills/MCPs appear as independent rows in the extension table
- [x] Click child skill → verify "Part of CLI: [name]" in description, clickable
- [x] Click CLI parent → verify "Associated Extensions" cards with navigation
- [x] Toggle CLI parent → verify all children toggle together
- [x] Toggle individual child → verify only that child toggles
- [x] Delete CLI (Uninstall) → verify spinner, all children removed, binary removed
- [x] Delete individual child skill → verify normal delete flow
- [x] Install CLI externally, verify pack info appears after scan
- [x] Uninstall all extensions from a pack → verify filter auto-clears
- [x] Verify name sort is case-insensitive (OfficeCLI sorts with "o" entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)