### PR TITLE
fix: prevent infinite re-render loop in InstallDialog

### DIFF
--- a/src/components/extensions/install-dialog.tsx
+++ b/src/components/extensions/install-dialog.tsx
@@ -51,7 +51,7 @@ export function InstallDialog({ open, mode, onClose }: InstallDialogProps) {
     if (detectedAgents.length === 1) {
       setSelectedAgents(new Set([detectedAgents[0].name]));
     }
-  }, [detectedAgents]);
+  }, [detectedAgents.length]);
 
   // Reset form when closing
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixed infinite re-render loop in `InstallDialog` that caused the Marketplace page to freeze when exactly one agent is detected
- Changed `useEffect` dependency from `[detectedAgents]` (unstable array reference) to `[detectedAgents.length]` (stable number)

## Root Cause
`detectedAgents` is recomputed via `filter()` + `sortAgents()` every render, producing a new array reference. When `length === 1`, the effect calls `setSelectedAgents(new Set([...]))`, creating a new Set reference, triggering a re-render, which creates a new `detectedAgents` reference, which re-triggers the effect — infinite loop.

## Test plan
- [x] Temporarily changed condition to match local agent count (`=== 6`), confirmed the fix prevents the freeze
- [x] Reverted condition to `=== 1`, verified normal Marketplace navigation still works
- [x] Clicked "Install from Git" dialog, confirmed it opens and functions correctly
- [x] All existing tests pass (`npm test` — 84 passed)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)