### PR TITLE
fix & feat(marketplace): improve extension install status detection and UI

### DIFF
--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -254,15 +254,14 @@ export default function MarketplacePage() {
       const matchSource = extSource === item.source || ext.pack === item.source;
 
       if (item.kind === "skill") {
-        // If the extension was installed as a full plugin, it covers all skills in that repo
-        if (ext.kind === "plugin") {
-          return matchSource;
-        }
-
+        // Match strictly by name. The scanner sometimes classifies individual
+        // items in a collection repo (e.g. github/awesome-copilot) as kind=plugin,
+        // so "same source URL + kind=plugin" doesn't reliably mean the whole repo
+        // is installed — it could be just one sibling. See PR #21 discussion.
         const targetName = item.skill_id && item.skill_id.length > 0 ? item.skill_id : item.name;
         return ext.name === targetName && matchSource;
       }
-      
+
       return ext.name === item.name && matchSource;
     });
   };

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -251,7 +251,13 @@ export default function MarketplacePage() {
       }
       if (!extSource && ext.pack) extSource = ext.pack;
 
-      const matchSource = extSource === item.source || ext.pack === item.source;
+      // GitHub repo slugs are case-insensitive; marketplace normalizes to
+      // lowercase while scanner preserves original casing. Compare lowered
+      // on both sides to avoid false negatives.
+      const itemSourceLower = item.source.toLowerCase();
+      const matchSource =
+        extSource.toLowerCase() === itemSourceLower ||
+        (ext.pack ?? "").toLowerCase() === itemSourceLower;
 
       if (item.kind === "skill") {
         // Match strictly by name. The scanner sometimes classifies individual
@@ -259,10 +265,10 @@ export default function MarketplacePage() {
         // so "same source URL + kind=plugin" doesn't reliably mean the whole repo
         // is installed — it could be just one sibling. See PR #21 discussion.
         const targetName = item.skill_id && item.skill_id.length > 0 ? item.skill_id : item.name;
-        return ext.name === targetName && matchSource;
+        return ext.name.toLowerCase() === targetName.toLowerCase() && matchSource;
       }
 
-      return ext.name === item.name && matchSource;
+      return ext.name.toLowerCase() === item.name.toLowerCase() && matchSource;
     });
   };
 

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -221,12 +221,50 @@ export default function MarketplacePage() {
     install,
   } = useMarketplaceStore();
   const { agents, fetch: fetchAgents, agentOrder } = useAgentStore();
+  const extensions = useExtensionStore((s) => s.extensions);
   const [installed, setInstalled] = useState<Set<string>>(new Set());
   const [justInstalled, setJustInstalled] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [showInstall, setShowInstall] = useState(false);
   const [installMode, setInstallMode] = useState<"git" | "local">("git");
   const detailPanelRef = useRef<HTMLDivElement>(null);
+
+  const isItemInstalled = (item: MarketplaceItem, agentName: string) => {
+    const key = `${item.id}:${agentName}`;
+    if (installed.has(key)) return true;
+
+    return extensions.some((ext) => {
+      if (!ext.agents.includes(agentName)) return false;
+      
+      if (item.kind === "skill") {
+        if (!["skill", "plugin"].includes(ext.kind)) return false;
+      } else {
+        if (ext.kind !== item.kind) return false;
+      }
+
+      const extUrl = ext.install_meta?.url_resolved ?? ext.install_meta?.url ?? ext.source.url;
+      let extSource = "";
+      if (extUrl) {
+        const match = extUrl.match(/github\.com\/([^/]+\/[^/]+)/);
+        extSource = match ? match[1].replace(/\.git$/, "") : extUrl;
+      }
+      if (!extSource && ext.pack) extSource = ext.pack;
+
+      const matchSource = extSource === item.source || ext.pack === item.source;
+
+      if (item.kind === "skill") {
+        // If the extension was installed as a full plugin, it covers all skills in that repo
+        if (ext.kind === "plugin") {
+          return matchSource;
+        }
+
+        const targetName = item.skill_id && item.skill_id.length > 0 ? item.skill_id : item.name;
+        return ext.name === targetName && matchSource;
+      }
+      
+      return ext.name === item.name && matchSource;
+    });
+  };
 
   const prefersReducedMotion = () =>
     window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -653,7 +691,7 @@ export default function MarketplacePage() {
                     <div className="flex flex-wrap gap-1.5" aria-live="polite">
                       {detectedAgents.map((agent) => {
                         const key = `${selectedItem.id}:${agent.name}`;
-                        const isInstalled = installed.has(key);
+                        const isInstalled = isItemInstalled(selectedItem, agent.name);
                         const isFlashing = justInstalled.has(key);
                         const isInstallingThis = installing === key;
                         const isInstallingAny =

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { InstallDialog } from "@/components/extensions/install-dialog";
+import { AgentMascot } from "@/components/shared/agent-mascot/agent-mascot";
 import { Hint } from "@/components/shared/hint";
 import { useScrollPassthrough } from "@/hooks/use-scroll-passthrough";
 import { humanizeError } from "@/lib/errors";
@@ -715,22 +716,21 @@ export default function MarketplacePage() {
                                 "disabled:opacity-50",
                             )}
                           >
+                            <div className={isInstalled ? "" : "opacity-90"}>
+                              <AgentMascot name={agent.name} size={14} />
+                            </div>
+                            <span className={isInstalled ? "install-success-text" : ""}>
+                              {agentDisplayName(agent.name)}
+                            </span>
                             {isInstalled ? (
                               <ShieldCheck
-                                size={12}
-                                className="animate-scale-in text-primary"
+                                size={14}
+                                className="animate-scale-in text-primary shrink-0"
                               />
                             ) : isInstallingThis ? (
-                              <Loader2 size={12} className="animate-spin" />
+                              <Loader2 size={12} className="animate-spin shrink-0 text-muted-foreground" />
                             ) : (
-                              <Download size={12} />
-                            )}
-                            {isInstalled ? (
-                              <span className="install-success-text">
-                                Installed
-                              </span>
-                            ) : (
-                              agentDisplayName(agent.name)
+                              <Download size={12} className="shrink-0 text-muted-foreground" />
                             )}
                           </button>
                         );


### PR DESCRIPTION
This PR improves the accuracy and visual feedback of the "Install to Agent" button in the Marketplace:

### 1. Fix: Install Status Detection
- The Marketplace previously relied entirely on a local, temporary `useState` to track whether an extension was installed.
- Now, it actively checks the global `useExtensionStore` matching `kind`, `agent`, and `source` to accurately reflect installations that already exist on the user's machine, or persist correctly across renders.

### 2. Feat: Agent Mascot UI
- Replaced the generic "Installed" text with the specific `<AgentMascot />` and the agent's display name.
- This makes it immediately clear visually which agent the skill was installed to, solving the UX issue of having multiple identical "Installed" buttons side-by-side.
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/1e75292f-be63-4526-afe4-33f8f5748adf" />
