### PR TITLE
fix: dark sidebar bleeding to browser bg in web mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,6 +107,9 @@ export default function App() {
     } else {
       root.classList.remove("dark");
     }
+    if (!isDesktop()) {
+      root.setAttribute("data-web", "true");
+    }
     // Force macOS vibrancy to match — "light" | "dark" | null (system)
     if (isDesktop()) {
       getCurrentWindow()

--- a/src/index.css
+++ b/src/index.css
@@ -542,6 +542,13 @@
   --toast-info-text: oklch(0.78 0.1 260);
 }
 
+/* Tiesen dark on web: sidebar↔background gap is only 0.025 in lightness,
+   which desktop masks via vibrancy lift but web cannot. Brighten
+   --background to restore visible separation against sidebar. */
+html.dark[data-theme="tiesen"][data-web="true"] {
+  --background: oklch(0.175 0.012 267);
+}
+
 /* ============================================================
    @theme inline — maps CSS vars to Tailwind utility tokens
    ============================================================ */
@@ -645,6 +652,21 @@
   body,
   #root {
     background: transparent;
+  }
+  /* Web mode: lock the browser's canvas color to our theme so the
+     translucent bg-sidebar/25 layer has a stable backdrop regardless of
+     OS prefers-color-scheme or Chrome's Force Dark Mode. `only` defeats
+     Force Dark. Scoped to [data-web] so Tauri vibrancy stays intact. */
+  html[data-web="true"]      { color-scheme: only light; }
+  html.dark[data-web="true"] { color-scheme: only dark; }
+
+  /* Web dark: UA's default dark canvas is a generic gray — paint our
+     actual sidebar color so the frosted layer composites correctly.
+     (Light mode intentionally bleeds to the white UA canvas — cleaner.) */
+  html.dark[data-web="true"],
+  html.dark[data-web="true"] body,
+  html.dark[data-web="true"] #root {
+    background: var(--sidebar);
   }
   body {
     @apply text-foreground;


### PR DESCRIPTION
## Summary

Fixes #20 — in Web mode, the sidebar in Dark theme appeared near-white instead of dark. Also fixes insufficient sidebar↔main contrast in Tiesen Dark specifically.

## Root cause

- `html/body/#root` are deliberately `background: transparent` so macOS Tauri window vibrancy can show through on Desktop.
- In Web mode there's no window behind — the browser's default canvas bleeds through `bg-sidebar/25` → fine in Light (white + near-white tint looks clean) but broken in Dark (white + 25% dark ≈ washed-out near-white sidebar).
- Separately, Tiesen Dark's `--sidebar` (L 0.105) and `--background` (L 0.13) only differ by 0.025 in lightness — Desktop masks this via vibrancy lift, but Web cannot, so the two areas look identical.

## Changes

1. `src/App.tsx` — set `data-web="true"` on `<html>` when `!isDesktop()`
2. `src/index.css`:
   - `html[data-web] { color-scheme: only light }` / `html.dark[data-web] { color-scheme: only dark }` — locks UA canvas color; `only` defeats Chrome's Force Dark Mode
   - `html.dark[data-web] { background: var(--sidebar) }` — web dark gets a solid theme-colored base (UA's generic dark canvas is plain gray, not our sidebar)
   - `html.dark[data-theme="tiesen"][data-web] { --background: oklch(0.175 ...) }` — widens Tiesen Dark's sidebar↔background gap on web only

## Why scoped to `[data-web]`

Critical: macOS WKWebView (Tauri) also honors `color-scheme`, which would paint an opaque canvas and break vibrancy. Gating everything on `data-web` keeps Desktop pixel-identical.

## Test plan

- [x] Web / Tiesen Light — clean near-white sidebar (unchanged look)
- [x] Web / Tiesen Dark — sidebar dark, main content brighter and distinguishable
- [x] Web / Claude Dark — sidebar and main distinguishable (unchanged, already had enough gap)
- [x] Desktop / Tiesen Dark — vibrancy intact, pixel-identical to before
- [x] Desktop / Claude Dark — vibrancy intact, pixel-identical to before
- [x] Verify on Chrome with "Force Dark Mode for Web Contents" enabled
- [x] Verify in dark-OS browser with app in Light mode (prefers-color-scheme override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)