### PR TITLE
fix(select): normalize <select> chrome on desktop too

### DIFF
--- a/src/lib/web-select.ts
+++ b/src/lib/web-select.ts
@@ -1,23 +1,23 @@
-import { isDesktop } from "@/lib/transport";
-
-/** Native `<select>` styling override for web mode.
+/** Normalize `<select>` chrome across web and desktop webviews.
  *
- * macOS WebKit and Linux Chromium render native select chrome differently
- * from each other and from Tauri's webview. Apply this `style` plus a
- * matching className to keep `<select>` elements consistent across web /
- * desktop. In Tauri (desktop), returns `undefined` so the native chrome
- * is preserved.
+ * Native macOS Aqua chrome (Tauri's WKWebView on older macOS, e.g.
+ * 15.x Sequoia) renders select controls as heavy Aqua-style buttons that
+ * clash with the rest of the flat UI. Apple's newer macOS releases ship
+ * a flatter native chrome, but we can't rely on that across user OS
+ * versions. Stripping native chrome with `appearance: none` and applying
+ * a matching custom arrow gives a single consistent rendering everywhere.
  */
-export const webSelectStyle: React.CSSProperties | undefined = !isDesktop()
-  ? {
-      appearance: "none",
-      backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='12' viewBox='0 0 8 12'%3E%3Cpath d='M4 1L7 4.5H1Z' fill='%23888'/%3E%3Cpath d='M4 11L1 7.5H7Z' fill='%23888'/%3E%3C/svg%3E")`,
-      backgroundRepeat: "no-repeat",
-      backgroundPosition: "right 8px center",
-      paddingRight: "24px",
-    }
-  : undefined;
+export const webSelectStyle: React.CSSProperties = {
+  WebkitAppearance: "none",
+  appearance: "none",
+  backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='12' viewBox='0 0 8 12'%3E%3Cpath d='M4 1L7 4.5H1Z' fill='%23888'/%3E%3Cpath d='M4 11L1 7.5H7Z' fill='%23888'/%3E%3C/svg%3E")`,
+  backgroundRepeat: "no-repeat",
+  backgroundPosition: "right 8px center",
+  paddingRight: "24px",
+};
 
-/** True in web mode — used to swap `rounded-[6px] h-[26px]` for the more
- *  permissive Tauri styling (`rounded-lg py-1.5`). */
-export const isWeb = !isDesktop();
+/** Use the normalized layout (`rounded-[6px] h-[26px]`) instead of the
+ *  legacy desktop-only (`rounded-lg py-1.5`). Now true everywhere since
+ *  desktop also normalizes — kept as a constant for callers that gate
+ *  className choice on it; can be inlined later. */
+export const isWeb = true;


### PR DESCRIPTION
## Summary

In Tauri's WKWebView, native macOS `<select>` chrome renders as heavy 3D Aqua-style buttons on older macOS (e.g. 15.x Sequoia, see #26 for screenshots). They clash with the rest of the flat UI. Newer macOS releases ship a flatter native chrome and look fine, but we can't rely on every user being on a recent OS.

This PR drops the `!isDesktop()` gate from `webSelectStyle` and `isWeb` in `src/lib/web-select.ts` so the same normalized `<select>` chrome that web mode already uses (custom arrow + flat border) applies on desktop too. Adds `WebkitAppearance: "none"` alongside the standard `appearance: "none"` — a harmless extra line that ensures the override works in any older WebKit that doesn't recognize the unprefixed form.

## Why central instead of per-component

`webSelectStyle` is consumed by 5 components (`extension-filters`, `scope-target-field`, `install-dialog`, `new-skills-dialog`, `marketplace`). Patching one central constant fixes all of them at once and keeps callers' className logic untouched.

## Closes #26

Originally reported by @Orchardxyz with screenshots from macOS 15.6 — thanks for catching this and for the original PR. The fix here takes a different code path (central `web-select.ts` instead of per-file className refactor) so existing macOS native focus rings and Tailwind class semantics aren't affected. Co-authored to credit the original report.

## Test plan

- [x] vitest: 127 tests pass
- [x] tsc: clean
- [x] biome: clean
- [x] Manual on macOS 26.4 (Tauri dev): confirmed switching from native chrome to the normalized style on desktop does not regress rendering — selects look identical to web mode, no visual artifacts. (The actual bug from #26 is on macOS 15.6 which we don't have access to; the fix relies on `appearance: none` being a stable, well-supported way to strip native chrome — this is the same mechanism web mode has been using on the reporter's setup without issues.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)