### PR TITLE
feat(web): update notification UI for web mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { HashRouter, Navigate, Route, Routes } from "react-router-dom";
 import { AppShell } from "./components/layout/app-shell";
 import { UpdateDialog } from "./components/layout/update-dialog";
+import { WebUpdateDialog } from "./components/layout/web-update-dialog";
 import { Confetti } from "./components/onboarding/confetti";
 import { Onboarding, useOnboarding } from "./components/onboarding/onboarding";
 import { ErrorBoundary } from "./components/shared/error-boundary";
@@ -19,6 +20,7 @@ import { useAuditStore } from "./stores/audit-store";
 import { useExtensionStore } from "./stores/extension-store";
 import { resolveMode, useUIStore } from "./stores/ui-store";
 import { useUpdateStore } from "./stores/update-store";
+import { useWebUpdateStore } from "./stores/web-update-store";
 
 /** Minimum interval (ms) between consecutive scan_and_sync calls */
 const SCAN_DEBOUNCE_MS = 5_000;
@@ -50,10 +52,13 @@ export default function App() {
     return () => mq.removeEventListener("change", onChange);
   }, [mode]);
 
-  // Check for updates on startup (non-blocking, silent failure) — desktop only
+  // Check for updates on startup (non-blocking, silent failure).
+  // Desktop uses Tauri's native updater; web mode polls GitHub releases.
   useEffect(() => {
     if (isDesktop()) {
       useUpdateStore.getState().checkForUpdate();
+    } else {
+      useWebUpdateStore.getState().checkForUpdate();
     }
   }, []);
 
@@ -144,7 +149,7 @@ export default function App() {
   return (
     <>
       {showConfetti && <Confetti />}
-      {isDesktop() && <UpdateDialog />}
+      {isDesktop() ? <UpdateDialog /> : <WebUpdateDialog />}
       <HashRouter>
         <ErrorBoundary>
           <Routes>

--- a/src/components/layout/changelog-markdown.tsx
+++ b/src/components/layout/changelog-markdown.tsx
@@ -1,0 +1,39 @@
+import Markdown from "react-markdown";
+
+const components = {
+  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary hover:underline"
+    >
+      {children}
+    </a>
+  ),
+  h2: ({ children }: { children?: React.ReactNode }) => (
+    <h4 className="mb-2 text-xs font-medium text-muted-foreground">
+      {children}
+    </h4>
+  ),
+  ul: ({ children }: { children?: React.ReactNode }) => (
+    <ul className="list-disc pl-4 space-y-1 text-sm text-foreground">
+      {children}
+    </ul>
+  ),
+  p: ({ children }: { children?: React.ReactNode }) => (
+    <p className="text-sm text-foreground">{children}</p>
+  ),
+};
+
+/** Renders a release-notes markdown body, or an "improvements" fallback when empty. */
+export function ChangelogMarkdown({ body }: { body: string }) {
+  if (!body) {
+    return (
+      <p className="text-sm text-muted-foreground italic">
+        Bug fixes and improvements.
+      </p>
+    );
+  }
+  return <Markdown components={components}>{body}</Markdown>;
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -11,6 +11,7 @@ import { NavLink } from "react-router-dom";
 import { isDesktop } from "@/lib/transport";
 import { ScopeSwitcher } from "./scope-switcher";
 import { UpdateCard } from "./update-card";
+import { WebUpdateCard } from "./web-update-card";
 
 const mainNavItems = [
   { to: "/", icon: LayoutDashboard, label: "Overview" },
@@ -88,7 +89,7 @@ export function Sidebar() {
         {/* Settings separator */}
         <div className="mt-auto mx-3 mb-1 border-t border-sidebar-border/40" />
 
-        {isDesktop() && <UpdateCard />}
+        {isDesktop() ? <UpdateCard /> : <WebUpdateCard />}
 
         <ScopeSwitcher />
 

--- a/src/components/layout/update-card.tsx
+++ b/src/components/layout/update-card.tsx
@@ -3,10 +3,11 @@ import { useUpdateStore } from "@/stores/update-store";
 
 export function UpdateCard() {
   const available = useUpdateStore((s) => s.available);
+  const dismissed = useUpdateStore((s) => s.dismissed);
   const installing = useUpdateStore((s) => s.installing);
   const promptUpdate = useUpdateStore((s) => s.promptUpdate);
 
-  if (!available) return null;
+  if (!available || dismissed) return null;
 
   return (
     <div className="mb-2 rounded-xl border border-primary/20 bg-primary/5 p-3">

--- a/src/components/layout/update-dialog.tsx
+++ b/src/components/layout/update-dialog.tsx
@@ -1,6 +1,6 @@
 import { Download, Loader2, X } from "lucide-react";
-import Markdown from "react-markdown";
 import { useUpdateStore } from "@/stores/update-store";
+import { ChangelogMarkdown } from "./changelog-markdown";
 
 export function UpdateDialog() {
   const available = useUpdateStore((s) => s.available);
@@ -36,41 +36,7 @@ export function UpdateDialog() {
 
         {/* Changelog */}
         <div className="flex-1 overflow-y-auto px-5 py-4">
-          {available.body ? (
-            <Markdown
-              components={{
-                a: ({ href, children }) => (
-                  <a
-                    href={href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-primary hover:underline"
-                  >
-                    {children}
-                  </a>
-                ),
-                h2: ({ children }) => (
-                  <h4 className="mb-2 text-xs font-medium text-muted-foreground">
-                    {children}
-                  </h4>
-                ),
-                ul: ({ children }) => (
-                  <ul className="list-disc pl-4 space-y-1 text-sm text-foreground">
-                    {children}
-                  </ul>
-                ),
-                p: ({ children }) => (
-                  <p className="text-sm text-foreground">{children}</p>
-                ),
-              }}
-            >
-              {available.body}
-            </Markdown>
-          ) : (
-            <p className="text-sm text-muted-foreground italic">
-              Bug fixes and improvements.
-            </p>
-          )}
+          <ChangelogMarkdown body={available.body} />
         </div>
 
         {/* Footer */}

--- a/src/components/layout/update-dialog.tsx
+++ b/src/components/layout/update-dialog.tsx
@@ -6,7 +6,8 @@ export function UpdateDialog() {
   const available = useUpdateStore((s) => s.available);
   const showChangelog = useUpdateStore((s) => s.showChangelog);
   const installing = useUpdateStore((s) => s.installing);
-  const dismissChangelog = useUpdateStore((s) => s.dismissChangelog);
+  const dismissDialog = useUpdateStore((s) => s.dismissDialog);
+  const dismissUpdate = useUpdateStore((s) => s.dismissUpdate);
   const confirmUpdate = useUpdateStore((s) => s.confirmUpdate);
 
   if (!showChangelog || !available) return null;
@@ -16,7 +17,7 @@ export function UpdateDialog() {
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/40 backdrop-blur-sm"
-        onClick={dismissChangelog}
+        onClick={dismissDialog}
       />
 
       {/* Dialog */}
@@ -27,7 +28,7 @@ export function UpdateDialog() {
             Update to v{available.version}
           </h3>
           <button
-            onClick={dismissChangelog}
+            onClick={dismissDialog}
             className="text-muted-foreground hover:text-foreground transition-colors"
           >
             <X size={16} />
@@ -42,7 +43,7 @@ export function UpdateDialog() {
         {/* Footer */}
         <div className="flex items-center justify-end gap-3 border-t border-border px-5 py-4">
           <button
-            onClick={dismissChangelog}
+            onClick={dismissUpdate}
             className="rounded-lg border border-border px-4 py-2 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
             Later

--- a/src/components/layout/web-update-card.tsx
+++ b/src/components/layout/web-update-card.tsx
@@ -1,0 +1,25 @@
+import { Download } from "lucide-react";
+import { useWebUpdateStore } from "@/stores/web-update-store";
+
+export function WebUpdateCard() {
+  const available = useWebUpdateStore((s) => s.available);
+  const dismissed = useWebUpdateStore((s) => s.dismissed);
+  const promptUpdate = useWebUpdateStore((s) => s.promptUpdate);
+
+  if (!available || dismissed) return null;
+
+  return (
+    <div className="mb-2 rounded-xl border border-primary/20 bg-primary/5 p-3">
+      <p className="text-xs font-medium text-foreground">
+        v{available.version} available
+      </p>
+      <button
+        onClick={promptUpdate}
+        className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-md bg-primary px-2.5 py-1.5 text-xs font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+      >
+        <Download size={12} />
+        How to Update
+      </button>
+    </div>
+  );
+}

--- a/src/components/layout/web-update-dialog.tsx
+++ b/src/components/layout/web-update-dialog.tsx
@@ -1,0 +1,59 @@
+import { ExternalLink, X } from "lucide-react";
+import { useWebUpdateStore } from "@/stores/web-update-store";
+import { ChangelogMarkdown } from "./changelog-markdown";
+
+const INSTRUCTIONS_URL = "https://github.com/RealZST/HarnessKit#updating";
+
+export function WebUpdateDialog() {
+  const available = useWebUpdateStore((s) => s.available);
+  const showDialog = useWebUpdateStore((s) => s.showDialog);
+  const dismissDialog = useWebUpdateStore((s) => s.dismissDialog);
+  const dismissUpdate = useWebUpdateStore((s) => s.dismissUpdate);
+
+  if (!showDialog || !available) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={dismissDialog}
+      />
+
+      <div className="relative w-[420px] max-h-[70vh] flex flex-col rounded-xl border border-border bg-background shadow-xl">
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <h3 className="text-base font-semibold">
+            Update to v{available.version}
+          </h3>
+          <button
+            onClick={dismissDialog}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <ChangelogMarkdown body={available.body} />
+        </div>
+
+        <div className="flex items-center justify-end gap-3 border-t border-border px-5 py-4">
+          <button
+            onClick={dismissUpdate}
+            className="rounded-lg border border-border px-4 py-2 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          >
+            Close
+          </button>
+          <a
+            href={INSTRUCTIONS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-xs font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+          >
+            <ExternalLink size={12} />
+            View Update Instructions
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -24,6 +24,7 @@ import { toast } from "@/stores/toast-store";
 import type { AppIcon, ThemeName } from "@/stores/ui-store";
 import { useUIStore } from "@/stores/ui-store";
 import { useUpdateStore } from "@/stores/update-store";
+import { useWebUpdateStore } from "@/stores/web-update-store";
 
 const THEME_OPTIONS: {
   value: ThemeName;
@@ -85,6 +86,48 @@ function UpdateSection() {
             <Download size={12} />
           )}
           {installing ? "Updating..." : `Update to v${available.version}`}
+        </button>
+      ) : (
+        <button
+          onClick={handleCheck}
+          disabled={checking}
+          className="flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 transition-colors"
+        >
+          {checking ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <RefreshCw size={12} />
+          )}
+          {checking ? "Checking..." : "Check for Updates"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function WebUpdateSection() {
+  const available = useWebUpdateStore((s) => s.available);
+  const checking = useWebUpdateStore((s) => s.checking);
+  const checkForUpdate = useWebUpdateStore((s) => s.checkForUpdate);
+  const promptUpdate = useWebUpdateStore((s) => s.promptUpdate);
+
+  const handleCheck = async () => {
+    await checkForUpdate(true);
+    if (!useWebUpdateStore.getState().available) {
+      toast.success("You're up to date");
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-xs text-muted-foreground">v{__APP_VERSION__}</span>
+      {available ? (
+        <button
+          onClick={promptUpdate}
+          className="flex items-center gap-1.5 rounded-lg bg-primary px-2.5 py-1 text-xs text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors"
+        >
+          <Download size={12} />
+          Update to v{available.version}
         </button>
       ) : (
         <button
@@ -236,7 +279,7 @@ export default function SettingsPage() {
           <h2 className="text-2xl font-bold tracking-tight select-none">
             Settings
           </h2>
-          {isDesktop() && <UpdateSection />}
+          {isDesktop() ? <UpdateSection /> : <WebUpdateSection />}
         </div>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto">

--- a/src/stores/__tests__/web-update-store.test.ts
+++ b/src/stores/__tests__/web-update-store.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const RELEASES_URL =
+  "https://api.github.com/repos/RealZST/HarnessKit/releases/latest";
+const CACHE_KEY = "hk-web-update-cache";
+const DISMISS_KEY_PREFIX = "hk-update-dismissed-v";
+
+function mockReleasesResponse(tag: string, body = "") {
+  return {
+    ok: true,
+    json: async () => ({ tag_name: tag, body }),
+  } as Response;
+}
+
+describe("web-update-store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts with no update available", async () => {
+    const { useWebUpdateStore } = await import("../web-update-store");
+    const state = useWebUpdateStore.getState();
+    expect(state.available).toBeNull();
+    expect(state.checking).toBe(false);
+    expect(state.showDialog).toBe(false);
+    expect(state.dismissed).toBe(false);
+  });
+
+  it("does not flag update when current version matches latest", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockReleasesResponse("v1.2.1")),
+    );
+
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+
+    expect(useWebUpdateStore.getState().available).toBeNull();
+  });
+
+  it("flags update when latest is newer than current", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockReleasesResponse("v1.3.0", "## Changes")),
+    );
+
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+
+    const { available } = useWebUpdateStore.getState();
+    expect(available?.version).toBe("1.3.0");
+    expect(available?.body).toContain("## Changes");
+  });
+
+  it("does not flag update when latest is older (downgrade)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockReleasesResponse("v1.0.0")),
+    );
+
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+
+    expect(useWebUpdateStore.getState().available).toBeNull();
+  });
+
+  it("strips 'New Contributors' and 'Full Changelog' sections from body", async () => {
+    const raw = [
+      "## What's Changed",
+      "- feat: thing",
+      "## New Contributors",
+      "@someone made their first contribution",
+      "**Full Changelog**: https://...",
+    ].join("\n");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockReleasesResponse("v1.3.0", raw)),
+    );
+
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+
+    const body = useWebUpdateStore.getState().available?.body ?? "";
+    expect(body).toContain("## What's Changed");
+    expect(body).toContain("- feat: thing");
+    expect(body).not.toContain("New Contributors");
+    expect(body).not.toContain("Full Changelog");
+  });
+
+  it("promptUpdate opens dialog only when an update is available", async () => {
+    const { useWebUpdateStore } = await import("../web-update-store");
+
+    useWebUpdateStore.getState().promptUpdate();
+    expect(useWebUpdateStore.getState().showDialog).toBe(false);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockReleasesResponse("v1.3.0")),
+    );
+    await useWebUpdateStore.getState().checkForUpdate();
+    useWebUpdateStore.getState().promptUpdate();
+    expect(useWebUpdateStore.getState().showDialog).toBe(true);
+  });
+
+  it("dismissDialog closes the dialog without persisting dismissal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockReleasesResponse("v1.3.0")),
+    );
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+    useWebUpdateStore.getState().promptUpdate();
+    expect(useWebUpdateStore.getState().showDialog).toBe(true);
+
+    useWebUpdateStore.getState().dismissDialog();
+    expect(useWebUpdateStore.getState().showDialog).toBe(false);
+    expect(useWebUpdateStore.getState().dismissed).toBe(false);
+    expect(localStorage.getItem(`${DISMISS_KEY_PREFIX}1.3.0`)).toBeNull();
+  });
+
+  it("dismissUpdate closes the dialog AND persists dismissal for the version", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockReleasesResponse("v1.3.0")),
+    );
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+    useWebUpdateStore.getState().promptUpdate();
+
+    useWebUpdateStore.getState().dismissUpdate();
+    expect(useWebUpdateStore.getState().showDialog).toBe(false);
+    expect(useWebUpdateStore.getState().dismissed).toBe(true);
+    expect(localStorage.getItem(`${DISMISS_KEY_PREFIX}1.3.0`)).toBe("1");
+  });
+
+  it("dismissUpdate is a no-op when no update is available", async () => {
+    const { useWebUpdateStore } = await import("../web-update-store");
+    useWebUpdateStore.getState().dismissUpdate();
+    expect(useWebUpdateStore.getState().dismissed).toBe(false);
+    expect(localStorage.length).toBe(0);
+  });
+
+  it("checkForUpdate seeds dismissed=true when localStorage has flag for the detected version", async () => {
+    localStorage.setItem(`${DISMISS_KEY_PREFIX}1.3.0`, "1");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockReleasesResponse("v1.3.0")),
+    );
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+
+    expect(useWebUpdateStore.getState().available?.version).toBe("1.3.0");
+    expect(useWebUpdateStore.getState().dismissed).toBe(true);
+  });
+
+  it("checkForUpdate keeps dismissed=false when a newer version appears", async () => {
+    localStorage.setItem(`${DISMISS_KEY_PREFIX}1.3.0`, "1");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockReleasesResponse("v1.4.0")),
+    );
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+
+    expect(useWebUpdateStore.getState().available?.version).toBe("1.4.0");
+    expect(useWebUpdateStore.getState().dismissed).toBe(false);
+  });
+
+  it("uses sessionStorage cache instead of refetching within TTL", async () => {
+    sessionStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ tag: "v1.3.0", body: "cached body", at: Date.now() }),
+    );
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(useWebUpdateStore.getState().available?.version).toBe("1.3.0");
+    expect(useWebUpdateStore.getState().available?.body).toContain(
+      "cached body",
+    );
+  });
+
+  it("ignores stale sessionStorage cache and refetches", async () => {
+    sessionStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({
+        tag: "v1.3.0",
+        body: "old",
+        at: Date.now() - 2 * 60 * 60 * 1000,
+      }),
+    );
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(mockReleasesResponse("v1.4.0", "fresh"));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+
+    expect(fetchSpy).toHaveBeenCalledWith(RELEASES_URL);
+    expect(useWebUpdateStore.getState().available?.version).toBe("1.4.0");
+    expect(useWebUpdateStore.getState().available?.body).toContain("fresh");
+  });
+
+  it("silently absorbs fetch failures", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await expect(
+      useWebUpdateStore.getState().checkForUpdate(),
+    ).resolves.toBeUndefined();
+    expect(useWebUpdateStore.getState().available).toBeNull();
+  });
+
+  it("silently absorbs non-OK HTTP responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response),
+    );
+
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+    expect(useWebUpdateStore.getState().available).toBeNull();
+  });
+
+  it("ignores malformed tag_name", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ tag_name: "garbage" }),
+      } as Response),
+    );
+
+    const { useWebUpdateStore } = await import("../web-update-store");
+    await useWebUpdateStore.getState().checkForUpdate();
+    expect(useWebUpdateStore.getState().available).toBeNull();
+  });
+});

--- a/src/stores/update-store.ts
+++ b/src/stores/update-store.ts
@@ -5,7 +5,7 @@ import { create } from "zustand";
 /** Clean up GitHub auto-generated release notes for in-app display.
  *  - Removes "New Contributors" and "Full Changelog" sections
  *  - Converts bare PR URLs to clickable markdown links (e.g. [#3](url)) */
-function cleanChangelog(body: string): string {
+export function cleanChangelog(body: string): string {
   const lines: string[] = [];
   let skip = false;
   for (const line of body.split("\n")) {
@@ -32,6 +32,10 @@ function cleanChangelog(body: string): string {
   return lines.join("\n").trim();
 }
 
+/** localStorage key prefix for "user has dismissed the update reminder for this version".
+ *  Shared between desktop and web update flows so a dismissal in either mode silences both. */
+export const DISMISS_KEY_PREFIX = "hk-update-dismissed-v";
+
 interface UpdateState {
   /** Available update version, null if none or not checked yet */
   available: { version: string; body: string } | null;
@@ -39,12 +43,16 @@ interface UpdateState {
   installing: boolean;
   /** Whether the changelog confirmation dialog is visible */
   showChangelog: boolean;
+  /** User dismissed the reminder for `available.version` (sidebar card hidden). */
+  dismissed: boolean;
 
   checkForUpdate: () => Promise<void>;
   /** Open the changelog dialog (called when user clicks Update) */
   promptUpdate: () => void;
-  /** Close the changelog dialog without updating */
-  dismissChangelog: () => void;
+  /** Close the changelog dialog without updating (X / backdrop). Does not hide card. */
+  dismissDialog: () => void;
+  /** Close the dialog AND persist a "don't remind for this version" flag (Later button). */
+  dismissUpdate: () => void;
   /** Confirm and install the update */
   confirmUpdate: () => Promise<void>;
 }
@@ -54,6 +62,7 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
   checking: false,
   installing: false,
   showChangelog: false,
+  dismissed: false,
 
   async checkForUpdate() {
     if (get().checking) return;
@@ -61,11 +70,15 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
     try {
       const update = await check();
       if (update) {
+        const dismissed =
+          localStorage.getItem(`${DISMISS_KEY_PREFIX}${update.version}`) ===
+          "1";
         set({
           available: {
             version: update.version,
             body: cleanChangelog(update.body ?? ""),
           },
+          dismissed,
         });
       }
     } catch {
@@ -81,8 +94,19 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
     }
   },
 
-  dismissChangelog() {
+  dismissDialog() {
     set({ showChangelog: false });
+  },
+
+  dismissUpdate() {
+    const { available } = get();
+    if (!available) return;
+    try {
+      localStorage.setItem(`${DISMISS_KEY_PREFIX}${available.version}`, "1");
+    } catch {
+      // localStorage unavailable — keep the in-memory dismissal anyway
+    }
+    set({ showChangelog: false, dismissed: true });
   },
 
   async confirmUpdate() {

--- a/src/stores/web-update-store.ts
+++ b/src/stores/web-update-store.ts
@@ -1,0 +1,140 @@
+import { create } from "zustand";
+import { cleanChangelog, DISMISS_KEY_PREFIX } from "./update-store";
+
+const RELEASES_URL =
+  "https://api.github.com/repos/RealZST/HarnessKit/releases/latest";
+const CACHE_KEY = "hk-web-update-cache";
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+interface CachedRelease {
+  tag: string;
+  body: string;
+  at: number;
+}
+
+function parseVersion(raw: string): [number, number, number] | null {
+  const match = raw.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function isNewer(current: string, latest: string): boolean {
+  const a = parseVersion(current);
+  const b = parseVersion(latest);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (b[i] > a[i]) return true;
+    if (b[i] < a[i]) return false;
+  }
+  return false;
+}
+
+function readCache(): CachedRelease | null {
+  try {
+    const raw = sessionStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const cached = JSON.parse(raw) as CachedRelease;
+    if (Date.now() - cached.at > CACHE_TTL_MS) return null;
+    return cached;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(tag: string, body: string): void {
+  try {
+    const entry: CachedRelease = { tag, body, at: Date.now() };
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify(entry));
+  } catch {
+    // sessionStorage unavailable — ignore
+  }
+}
+
+async function fetchLatestRelease(
+  force = false,
+): Promise<{ tag: string; body: string } | null> {
+  if (!force) {
+    const cached = readCache();
+    if (cached) return { tag: cached.tag, body: cached.body };
+  }
+  try {
+    const response = await fetch(RELEASES_URL);
+    if (!response.ok) return null;
+    const data = (await response.json()) as {
+      tag_name?: string;
+      body?: string;
+    };
+    if (!data.tag_name) return null;
+    const body = data.body ?? "";
+    writeCache(data.tag_name, body);
+    return { tag: data.tag_name, body };
+  } catch {
+    return null;
+  }
+}
+
+interface WebUpdateState {
+  /** Available update payload, null if none or not yet checked. */
+  available: { version: string; body: string } | null;
+  checking: boolean;
+  /** Whether the changelog/instructions dialog is visible. */
+  showDialog: boolean;
+  /** User dismissed the reminder for `available.version` (sidebar card hidden). */
+  dismissed: boolean;
+
+  /** When `force` is true, skip the sessionStorage cache and re-fetch from GitHub. */
+  checkForUpdate: (force?: boolean) => Promise<void>;
+  /** Open the dialog (only when an update is available). */
+  promptUpdate: () => void;
+  /** Close the dialog without persisting dismissal (X / backdrop). */
+  dismissDialog: () => void;
+  /** Close the dialog AND persist a "don't remind for this version" flag (Close button). */
+  dismissUpdate: () => void;
+}
+
+export const useWebUpdateStore = create<WebUpdateState>((set, get) => ({
+  available: null,
+  checking: false,
+  showDialog: false,
+  dismissed: false,
+
+  async checkForUpdate(force = false) {
+    if (get().checking) return;
+    set({ checking: true });
+    try {
+      const release = await fetchLatestRelease(force);
+      if (!release) return;
+      if (!isNewer(__APP_VERSION__, release.tag)) return;
+      const version = release.tag.replace(/^v/, "");
+      const dismissed =
+        localStorage.getItem(`${DISMISS_KEY_PREFIX}${version}`) === "1";
+      set({
+        available: { version, body: cleanChangelog(release.body) },
+        dismissed,
+      });
+    } finally {
+      set({ checking: false });
+    }
+  },
+
+  promptUpdate() {
+    if (get().available) {
+      set({ showDialog: true });
+    }
+  },
+
+  dismissDialog() {
+    set({ showDialog: false });
+  },
+
+  dismissUpdate() {
+    const { available } = get();
+    if (!available) return;
+    try {
+      localStorage.setItem(`${DISMISS_KEY_PREFIX}${available.version}`, "1");
+    } catch {
+      // localStorage unavailable — keep the in-memory dismissal anyway
+    }
+    set({ showDialog: false, dismissed: true });
+  },
+}));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
   },
+  define: {
+    __APP_VERSION__: JSON.stringify("1.2.1"),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary

Adds an update-awareness flow for `hk serve` (web) users that mirrors the existing desktop UpdateCard/UpdateDialog. Same sidebar card, same modal, same per-version dismiss — only the primary action changes (web routes to README install instructions instead of triggering an in-app self-install, since browsers can't `relaunch()` a Tauri binary).

Also extends desktop a bit: clicking **Later** now persists a "don't remind for this version" flag (prior behavior was modal-close only). X / backdrop / outside-click are unchanged — they remain pure modal-close.

## What's in each commit

1. `refactor(update): extract ChangelogMarkdown shared component` — pulls the GitHub-release-notes Markdown rendering out of `UpdateDialog` so the upcoming `WebUpdateDialog` can reuse it without copy-paste.
2. `feat(update): per-version dismiss for sidebar update card` — desktop side: new `dismissed` state + `dismissUpdate()` action backed by `localStorage["hk-update-dismissed-v<X.Y.Z>"]`. Card hides; "Later" persists.
3. `feat(web-update): notification UI for web mode` — `useWebUpdateStore` polls `releases/latest` with a 1h sessionStorage cache, semver compare against `__APP_VERSION__`, shares `DISMISS_KEY_PREFIX` with desktop. New `WebUpdateCard` + `WebUpdateDialog` (links to README `#updating`) + `WebUpdateSection` in Settings (manual "Check for Updates" passes `force=true` to skip the cache).

## Behavior matrix

| Surface | Desktop | Web |
|---|---|---|
| Startup | Tauri `check()` | `releases/latest` + 1h cache |
| Sidebar card | `UpdateCard` (hides on dismiss) | `WebUpdateCard` (same) |
| Card button | "Update" | "How to Update" |
| Modal X / backdrop | close-only | close-only |
| Modal secondary | "Later" → close + persist | "Close" → close + persist |
| Modal primary | "Update Now" → install | "View Update Instructions" → README#updating |
| Settings entry | "Check for Updates" | "Check for Updates" (force-bypasses cache) |

## Test plan

- [x] vitest: 12 files / 143 tests pass (16 new tests for `useWebUpdateStore`)
- [x] `npm run build` — TypeScript + Vite both clean
- [x] biome lint clean on all 11 changed/new files
- [x] Each of the 3 commits independently builds and passes tests
- [x] Manual verify in browser (vite dev server + `hk serve` backend): card appears, modal opens, "Close" persists dismissal across reloads, "View Update Instructions" opens README anchor, Settings "Check for Updates" toast fires when up-to-date

🤖 Generated with [Claude Code](https://claude.com/claude-code)