### PR TITLE
feat: add OpenCode as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ HarnessKit manages **all five extension types** from a unified interface — **S
 | **Antigravity** | ✓ | ✓ | — | — | ✓ |
 | **Copilot** | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **Windsurf** | ✓ | ✓ | — | ✓ | ✓ |
+| **OpenCode** | ✓ | ✓ | ✓ | — | ✓ |
 
 <small><i>* "—" indicates the agent currently does not support this extension type.</i></small>
 
@@ -76,7 +77,7 @@ HarnessKit manages **all five extension types** from a unified interface — **S
 
 ### 🤖 Agent Configs, Memory & Rules
 
-HarnessKit manages every agent's **Configs**, **Memory**, **Rules**, and **Ignore** files from one place. Currently supporting **7 agents**: **Claude Code**, **Codex**, **Gemini CLI**, **Cursor**, **Antigravity**, **Copilot**, and **Windsurf**.
+HarnessKit manages every agent's **Configs**, **Memory**, **Rules**, and **Ignore** files from one place. Currently supporting **8 agents**: **Claude Code**, **Codex**, **Gemini CLI**, **Cursor**, **Antigravity**, **Copilot**, **Windsurf**, and **OpenCode**.
 
 - **Config file tracking** — Automatically discovers every agent's config files — both global and per-project. Add your project directories or custom paths and HarnessKit picks them up alongside the global ones.
 - **Per-agent dashboard** — Each agent gets its own page with all files organized by category, showing scope, path, file size, and a summary of installed extensions. Expand any file to preview its content right in the app.
@@ -136,7 +137,7 @@ HarnessKit ships a standalone command-line interface (`hk`) for terminal-first w
 
 ```shell
 $ hk status
-  Agents        7 detected (claude · codex · gemini · cursor · antigravity · copilot · windsurf)
+  Agents        8 detected (claude · codex · gemini · cursor · antigravity · copilot · windsurf · opencode)
   Extensions    136 total (124 skills · 2 mcp · 8 plugins · 1 hooks · 1 clis)
 
 $ hk list --kind skill --agent claude    # filter by type and agent
@@ -325,7 +326,7 @@ See [CLI Support](#%EF%B8%8F-cli-support) above for the full list of commands.
 
 ## Roadmap
 
-- 🤖 **More Agents** — Hermes-agent, OpenClaw, OpenCode, and more
+- 🤖 **More Agents** — Hermes-agent, OpenClaw, and more
 - 📦 **Extension Migration** — Export/import your extension setup between devices
 - ⌨️ **CLI Enhancements** — More commands and richer functionality for `hk`
 

--- a/crates/hk-core/src/adapter/antigravity.rs
+++ b/crates/hk-core/src/adapter/antigravity.rs
@@ -2,7 +2,7 @@
 // Config file: ~/.gemini/antigravity/mcp_config.json
 // Format: JSON, top-level key "mcpServers", sub-keys: command, args, env, serverUrl, headers, etc.
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry};
+use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker};
 use std::path::{Path, PathBuf};
 
 pub struct AntigravityAdapter {
@@ -86,6 +86,13 @@ impl AgentAdapter for AntigravityAdapter {
         ]
     }
 
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        vec![
+            ProjectMarker::Dir(".agent/rules"),
+            ProjectMarker::Dir(".agent/skills"),
+        ]
+    }
+
     fn project_rules_patterns(&self) -> Vec<String> {
         vec![
             ".agents/rules/*.md".into(),
@@ -139,6 +146,8 @@ impl AgentAdapter for AntigravityAdapter {
                             .collect()
                     })
                     .unwrap_or_default(),
+                // Antigravity's MCP schema has no agent-native disable concept.
+                enabled: true,
             })
             .collect()
     }

--- a/crates/hk-core/src/adapter/claude.rs
+++ b/crates/hk-core/src/adapter/claude.rs
@@ -7,7 +7,7 @@
 //   https://code.claude.com/docs/en/plugins
 // Plugins: ~/.claude/plugins/, registry at installed_plugins.json, manifest at .claude-plugin/plugin.json
 
-use super::{AgentAdapter, HookEntry, McpServerEntry, PluginEntry};
+use super::{AgentAdapter, HookEntry, McpServerEntry, PluginEntry, ProjectMarker};
 use std::path::{Path, PathBuf};
 
 pub struct ClaudeAdapter {
@@ -112,6 +112,8 @@ impl AgentAdapter for ClaudeAdapter {
                             .collect()
                     })
                     .unwrap_or_default(),
+                // Claude's MCP schema has no agent-native disable concept.
+                enabled: true,
             })
             .collect()
     }
@@ -246,6 +248,13 @@ impl AgentAdapter for ClaudeAdapter {
             }
         }
         files
+    }
+
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        vec![
+            ProjectMarker::Dir(".claude"),
+            ProjectMarker::File(".mcp.json"),
+        ]
     }
 
     fn project_rules_patterns(&self) -> Vec<String> {

--- a/crates/hk-core/src/adapter/codex.rs
+++ b/crates/hk-core/src/adapter/codex.rs
@@ -5,7 +5,7 @@
 // Plugin reference: https://developers.openai.com/codex/plugins
 // Plugins: ~/.codex/plugins/cache/{marketplace}/{plugin}/{version}/, manifest at .codex-plugin/plugin.json
 
-use super::{AgentAdapter, HookEntry, McpFormat, McpServerEntry, PluginEntry};
+use super::{AgentAdapter, HookEntry, McpFormat, McpServerEntry, PluginEntry, ProjectMarker};
 use std::path::{Path, PathBuf};
 
 pub struct CodexAdapter {
@@ -93,6 +93,10 @@ impl AgentAdapter for CodexAdapter {
         files
     }
 
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        vec![ProjectMarker::Dir(".codex")]
+    }
+
     fn project_rules_patterns(&self) -> Vec<String> {
         vec!["AGENTS.md".into(), "AGENTS.override.md".into()]
     }
@@ -155,6 +159,8 @@ impl AgentAdapter for CodexAdapter {
                                 .collect()
                         })
                         .unwrap_or_default(),
+                    // Codex's TOML schema has no agent-native disable concept.
+                    enabled: true,
                 }
             })
             .collect()

--- a/crates/hk-core/src/adapter/copilot.rs
+++ b/crates/hk-core/src/adapter/copilot.rs
@@ -18,7 +18,7 @@
 // Format: {"hooks": {"PreToolUse": [{"type": "command", "command": "...", "timeout": 30}]}}
 // Events: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PreCompact, SubagentStart, SubagentStop, Stop
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry};
+use super::{AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry, ProjectMarker};
 use std::path::{Path, PathBuf};
 
 /// Read VS Code agent plugin enablement from state.vscdb.
@@ -175,6 +175,13 @@ impl AgentAdapter for CopilotAdapter {
         files
     }
 
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        vec![
+            ProjectMarker::File(".github/copilot-instructions.md"),
+            ProjectMarker::Dir(".github/instructions"),
+        ]
+    }
+
     fn project_rules_patterns(&self) -> Vec<String> {
         vec![
             ".github/copilot-instructions.md".into(),
@@ -320,6 +327,8 @@ impl AgentAdapter for CopilotAdapter {
                             .collect()
                     })
                     .unwrap_or_default(),
+                // Copilot's MCP schema has no agent-native disable concept.
+                enabled: true,
             })
             .collect()
     }

--- a/crates/hk-core/src/adapter/cursor.rs
+++ b/crates/hk-core/src/adapter/cursor.rs
@@ -5,7 +5,7 @@
 // Plugin reference: https://cursor.com/docs/plugins
 // Plugins: ~/.cursor/plugins/, manifest at .cursor-plugin/plugin.json
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, PluginEntry};
+use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, PluginEntry, ProjectMarker};
 use std::path::{Path, PathBuf};
 
 pub struct CursorAdapter {
@@ -115,6 +115,8 @@ impl AgentAdapter for CursorAdapter {
                             .collect()
                     })
                     .unwrap_or_default(),
+                // Cursor's MCP schema has no agent-native disable concept.
+                enabled: true,
             })
             .collect()
     }
@@ -170,6 +172,13 @@ impl AgentAdapter for CursorAdapter {
             }
         }
         files
+    }
+
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        vec![
+            ProjectMarker::Dir(".cursor/rules"),
+            ProjectMarker::File(".cursorrules"),
+        ]
     }
 
     fn project_rules_patterns(&self) -> Vec<String> {

--- a/crates/hk-core/src/adapter/gemini.rs
+++ b/crates/hk-core/src/adapter/gemini.rs
@@ -7,7 +7,7 @@
 // Extension (plugin) reference: https://geminicli.com/docs/extensions/
 // Extensions: ~/.gemini/extensions/{name}/, manifest at gemini-extension.json
 
-use super::{AgentAdapter, HookEntry, McpServerEntry, PluginEntry};
+use super::{AgentAdapter, HookEntry, McpServerEntry, PluginEntry, ProjectMarker};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -150,6 +150,10 @@ impl AgentAdapter for GeminiAdapter {
         files
     }
 
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        vec![ProjectMarker::Dir(".gemini")]
+    }
+
     fn project_rules_patterns(&self) -> Vec<String> {
         vec![
             "GEMINI.md".into(),
@@ -204,6 +208,8 @@ impl AgentAdapter for GeminiAdapter {
                             .collect()
                     })
                     .unwrap_or_default(),
+                // Gemini's MCP schema has no agent-native disable concept.
+                enabled: true,
             })
             .collect()
     }

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -5,6 +5,7 @@ pub mod copilot;
 pub mod cursor;
 pub mod gemini;
 pub mod hook_events;
+pub mod opencode;
 pub mod windsurf;
 
 use crate::models::ConfigScope;
@@ -253,6 +254,7 @@ pub fn all_adapters() -> Vec<Box<dyn AgentAdapter>> {
         Box::new(antigravity::AntigravityAdapter::new()),
         Box::new(copilot::CopilotAdapter::new()),
         Box::new(windsurf::WindsurfAdapter::new()),
+        Box::new(opencode::OpencodeAdapter::new()),
     ]
 }
 
@@ -261,9 +263,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_all_adapters_returns_seven() {
+    fn test_all_adapters_returns_eight() {
         let adapters = all_adapters();
-        assert_eq!(adapters.len(), 7);
+        assert_eq!(adapters.len(), 8);
         let names: Vec<&str> = adapters.iter().map(|a| a.name()).collect();
         assert!(names.contains(&"claude"));
         assert!(names.contains(&"cursor"));
@@ -272,6 +274,7 @@ mod tests {
         assert!(names.contains(&"antigravity"));
         assert!(names.contains(&"copilot"));
         assert!(names.contains(&"windsurf"));
+        assert!(names.contains(&"opencode"));
     }
 
     #[test]
@@ -291,7 +294,7 @@ mod tests {
         // setups). Adding an agent here without a confirmed PATH bug would
         // unnecessarily rewrite users' mcp_config.json with absolute paths,
         // hurting cross-machine portability.
-        for name in ["claude", "codex", "gemini", "cursor", "copilot"] {
+        for name in ["claude", "codex", "gemini", "cursor", "copilot", "opencode"] {
             assert!(
                 !by_name[name].needs_path_injection(),
                 "{name} should not need path injection"
@@ -382,6 +385,7 @@ mod tests {
             ("gemini", ".gemini/skills"),
             ("antigravity", ".agent/skills"), // Singular — Antigravity convention
             ("copilot", ".github/skills"),
+            ("opencode", ".opencode/skills"),
         ]
         .into_iter()
         .collect();

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -18,6 +18,12 @@ pub struct McpServerEntry {
     pub command: String,
     pub args: Vec<String>,
     pub env: std::collections::HashMap<String, String>,
+    /// Whether the agent itself considers this entry active. Currently only
+    /// OpenCode's schema has a per-entry `"enabled"` boolean; every other
+    /// adapter always sets this to `true` because their formats have no
+    /// agent-native disable concept. HarnessKit's own user-toggled disable
+    /// flow tracks state separately in SQLite — this field is orthogonal.
+    pub enabled: bool,
 }
 
 /// Represents a hook entry parsed from an agent's config
@@ -57,6 +63,19 @@ pub enum HookFormat {
     Windsurf,
     /// Agent does not support hooks
     None,
+}
+
+/// A path marker that, when present in a project root directory, identifies
+/// the directory as belonging to a particular agent. Each adapter declares
+/// its own markers via [`AgentAdapter::project_markers`]; project discovery
+/// (`is_project_dir`, `discover_projects`) considers a directory a project
+/// when *any* adapter's marker matches.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ProjectMarker {
+    /// A relative directory that must exist (e.g. `.claude`, `.opencode`).
+    Dir(&'static str),
+    /// A relative file that must exist (e.g. `.mcp.json`, `opencode.json`).
+    File(&'static str),
 }
 
 /// Format used by an agent for MCP server configuration.
@@ -187,6 +206,15 @@ pub trait AgentAdapter: Send + Sync {
     // These describe where this agent looks for project-scoped extensions.
     // Default empty/None means the agent has no project-level support and the
     // scanner skips it.
+
+    /// Path markers (relative to a project root) that identify a directory as
+    /// belonging to this agent. Used by `is_project_dir` / `discover_projects`
+    /// to decide whether a folder qualifies as a project for *any* agent.
+    /// Default empty means this adapter never claims any directory as its
+    /// project — only override if the agent has a stable on-disk convention.
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        vec![]
+    }
 
     /// Relative dir patterns within a project that contain skill subdirectories
     /// (e.g. `.claude/skills` for Claude — each subdirectory inside is one skill).

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -68,6 +68,13 @@ pub enum McpFormat {
     Servers,
     /// TOML with [mcp_servers.<name>] sections (Codex)
     Toml,
+    /// JSON with "mcp" top-level key (OpenCode). Each entry is a tagged
+    /// union — local servers use `{type: "local", command: [bin, ...args],
+    /// environment: {...}}`, distinct from the Claude-style `{command, args, env}`
+    /// schema. `additionalProperties: false` in the upstream schema means no
+    /// extra fields may be written.
+    /// See https://opencode.ai/config.json (McpLocalConfig).
+    Opencode,
 }
 
 pub trait AgentAdapter: Send + Sync {

--- a/crates/hk-core/src/adapter/opencode.rs
+++ b/crates/hk-core/src/adapter/opencode.rs
@@ -1,0 +1,297 @@
+use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, PluginEntry};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+pub struct OpencodeAdapter {
+    home: PathBuf,
+}
+
+impl Default for OpencodeAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OpencodeAdapter {
+    pub fn new() -> Self {
+        Self {
+            home: dirs::home_dir().unwrap_or_default(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_home(home: PathBuf) -> Self {
+        Self { home }
+    }
+
+    fn parse_json(path: &Path) -> Option<serde_json::Value> {
+        let content = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&content).ok()
+    }
+
+    fn markdown_files(dir: &Path) -> Vec<PathBuf> {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return vec![];
+        };
+        entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().is_some_and(|ext| ext == "md"))
+            .collect()
+    }
+
+    fn plugin_name(path: &Path) -> String {
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let base = file_name.strip_suffix(".disabled").unwrap_or(&file_name);
+        Path::new(base)
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().to_string())
+            .unwrap_or_else(|| base.to_string())
+    }
+
+    fn is_plugin_file(path: &Path) -> bool {
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let base = file_name.strip_suffix(".disabled").unwrap_or(&file_name);
+        matches!(
+            Path::new(base).extension().and_then(|ext| ext.to_str()),
+            Some("js" | "ts" | "mjs" | "cjs")
+        )
+    }
+
+    fn parse_local_mcp_entry(name: &str, value: &serde_json::Value) -> Option<McpServerEntry> {
+        if value.get("type").and_then(|v| v.as_str()) != Some("local") {
+            return None;
+        }
+
+        let (command, args) = match value.get("command") {
+            Some(serde_json::Value::Array(parts)) => {
+                let mut parts = parts
+                    .iter()
+                    .filter_map(|part| part.as_str().map(String::from));
+                let command = parts.next()?;
+                (command, parts.collect())
+            }
+            Some(serde_json::Value::String(command)) => (command.clone(), vec![]),
+            _ => return None,
+        };
+
+        let env = value
+            .get("environment")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect::<HashMap<_, _>>()
+            })
+            .unwrap_or_default();
+
+        Some(McpServerEntry {
+            name: name.to_string(),
+            command,
+            args,
+            env,
+        })
+    }
+}
+
+impl AgentAdapter for OpencodeAdapter {
+    fn hook_format(&self) -> HookFormat {
+        HookFormat::None
+    }
+
+    fn name(&self) -> &str {
+        "opencode"
+    }
+
+    fn base_dir(&self) -> PathBuf {
+        self.home.join(".config").join("opencode")
+    }
+
+    fn detect(&self) -> bool {
+        self.base_dir().exists()
+            || self.mcp_config_path().is_file()
+            || crate::scanner::run_which("opencode").is_some()
+    }
+
+    fn skill_dirs(&self) -> Vec<PathBuf> {
+        vec![
+            self.base_dir().join("skills"),
+            self.home.join(".agents").join("skills"),
+        ]
+    }
+
+    fn project_skill_dirs(&self) -> Vec<String> {
+        vec![".opencode/skills".into()]
+    }
+
+    fn mcp_config_path(&self) -> PathBuf {
+        self.base_dir().join("opencode.json")
+    }
+
+    fn hook_config_path(&self) -> PathBuf {
+        self.mcp_config_path()
+    }
+
+    fn plugin_dirs(&self) -> Vec<PathBuf> {
+        vec![self.base_dir().join("plugins")]
+    }
+
+    fn read_mcp_servers(&self) -> Vec<McpServerEntry> {
+        self.read_mcp_servers_from(&self.mcp_config_path())
+    }
+
+    fn read_mcp_servers_from(&self, path: &Path) -> Vec<McpServerEntry> {
+        let Some(config) = Self::parse_json(path) else {
+            return vec![];
+        };
+        let Some(servers) = config.get("mcp").and_then(|v| v.as_object()) else {
+            return vec![];
+        };
+        servers
+            .iter()
+            .filter_map(|(name, value)| Self::parse_local_mcp_entry(name, value))
+            .collect()
+    }
+
+    fn read_hooks(&self) -> Vec<HookEntry> {
+        vec![]
+    }
+
+    fn read_plugins(&self) -> Vec<PluginEntry> {
+        let mut entries = Vec::new();
+        for plugin_dir in self.plugin_dirs() {
+            let Ok(files) = std::fs::read_dir(plugin_dir) else {
+                continue;
+            };
+            for file in files.flatten() {
+                let path = file.path();
+                if !path.is_file() || !Self::is_plugin_file(&path) {
+                    continue;
+                }
+                let enabled = path.extension().is_none_or(|ext| ext != "disabled");
+                entries.push(PluginEntry {
+                    name: Self::plugin_name(&path),
+                    source: "local".into(),
+                    enabled,
+                    path: Some(path),
+                    uri: None,
+                    installed_at: None,
+                    updated_at: None,
+                });
+            }
+        }
+        entries
+    }
+
+    fn global_rules_files(&self) -> Vec<PathBuf> {
+        vec![self.base_dir().join("AGENTS.md")]
+    }
+
+    fn global_settings_files(&self) -> Vec<PathBuf> {
+        let mut files = vec![self.mcp_config_path()];
+        files.extend(Self::markdown_files(&self.base_dir().join("agents")));
+        files
+    }
+
+    fn global_workflow_files(&self) -> Vec<PathBuf> {
+        Self::markdown_files(&self.base_dir().join("commands"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::AgentAdapter;
+    use super::*;
+
+    #[test]
+    fn detect_accepts_base_dir_or_config_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".config/opencode")).unwrap();
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        assert!(adapter.detect());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().join(".config/opencode");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join("opencode.json"), "{}").unwrap();
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        assert!(adapter.detect());
+    }
+
+    #[test]
+    fn read_mcp_servers_keeps_only_local_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().join(".config/opencode");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("opencode.json"),
+            r#"{
+                "mcp": {
+                    "local-server": {
+                        "type": "local",
+                        "command": ["bun", "x", "tool"],
+                        "environment": {"TOKEN": "abc"}
+                    },
+                    "remote-server": {
+                        "type": "remote",
+                        "url": "https://example.com/mcp"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "local-server");
+        assert_eq!(servers[0].command, "bun");
+        assert_eq!(servers[0].args, vec!["x", "tool"]);
+        assert_eq!(servers[0].env.get("TOKEN"), Some(&"abc".to_string()));
+    }
+
+    #[test]
+    fn read_plugins_scans_enabled_and_disabled_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugins_dir = tmp.path().join(".config/opencode/plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+        std::fs::write(plugins_dir.join("alpha.ts"), "export default {};").unwrap();
+        std::fs::write(
+            plugins_dir.join("beta.js.disabled"),
+            "module.exports = {};",
+        )
+        .unwrap();
+
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        let plugins = adapter.read_plugins();
+        assert_eq!(plugins.len(), 2);
+        assert!(plugins.iter().any(|plugin| {
+            plugin.name == "alpha" && plugin.enabled && plugin.source == "local"
+        }));
+        assert!(plugins.iter().any(|plugin| {
+            plugin.name == "beta" && !plugin.enabled && plugin.source == "local"
+        }));
+    }
+
+    #[test]
+    fn global_settings_and_workflows_include_markdown_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join(".config/opencode");
+        std::fs::create_dir_all(base.join("agents")).unwrap();
+        std::fs::create_dir_all(base.join("commands")).unwrap();
+        std::fs::write(base.join("agents/reviewer.md"), "# reviewer").unwrap();
+        std::fs::write(base.join("commands/deploy.md"), "# deploy").unwrap();
+
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        let settings = adapter.global_settings_files();
+        let workflows = adapter.global_workflow_files();
+        assert!(settings.iter().any(|path| path.ends_with("agents/reviewer.md")));
+        assert!(workflows.iter().any(|path| path.ends_with("commands/deploy.md")));
+    }
+}

--- a/crates/hk-core/src/adapter/opencode.rs
+++ b/crates/hk-core/src/adapter/opencode.rs
@@ -1,4 +1,4 @@
-use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, PluginEntry};
+use super::{AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -103,6 +103,10 @@ impl OpencodeAdapter {
 impl AgentAdapter for OpencodeAdapter {
     fn hook_format(&self) -> HookFormat {
         HookFormat::None
+    }
+
+    fn mcp_format(&self) -> McpFormat {
+        McpFormat::Opencode
     }
 
     fn name(&self) -> &str {

--- a/crates/hk-core/src/adapter/opencode.rs
+++ b/crates/hk-core/src/adapter/opencode.rs
@@ -127,9 +127,12 @@ impl AgentAdapter for OpencodeAdapter {
     }
 
     fn detect(&self) -> bool {
+        // Aligned with the other 7 adapters (claude/codex/gemini/cursor/
+        // antigravity/copilot/windsurf) which all detect by base_dir presence
+        // alone. A `which opencode` hit without a config dir would surface an
+        // agent that has nothing for HarnessKit to manage — a UX false
+        // positive — so we keep this strict.
         self.base_dir().exists()
-            || self.mcp_config_path().is_file()
-            || crate::scanner::run_which("opencode").is_some()
     }
 
     fn skill_dirs(&self) -> Vec<PathBuf> {
@@ -272,17 +275,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn detect_accepts_base_dir_or_config_file() {
+    fn detect_requires_base_dir() {
+        // Empty home → not detected: prevents surfacing OpenCode in the agents
+        // list when the user has only the CLI installed but no config dir,
+        // matching how every other adapter checks detection.
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(tmp.path().join(".config/opencode")).unwrap();
         let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
-        assert!(adapter.detect());
+        assert!(!adapter.detect());
 
-        let tmp = tempfile::tempdir().unwrap();
-        let config_dir = tmp.path().join(".config/opencode");
-        std::fs::create_dir_all(&config_dir).unwrap();
-        std::fs::write(config_dir.join("opencode.json"), "{}").unwrap();
-        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        // base_dir present (with or without contents) → detected.
+        std::fs::create_dir_all(tmp.path().join(".config/opencode")).unwrap();
         assert!(adapter.detect());
     }
 

--- a/crates/hk-core/src/adapter/opencode.rs
+++ b/crates/hk-core/src/adapter/opencode.rs
@@ -29,14 +29,14 @@ impl OpencodeAdapter {
         serde_json::from_str(&content).ok()
     }
 
-    fn markdown_files(dir: &Path) -> Vec<PathBuf> {
+    fn files_with_ext(dir: &Path, ext: &str) -> Vec<PathBuf> {
         let Ok(entries) = std::fs::read_dir(dir) else {
             return vec![];
         };
         entries
             .flatten()
             .map(|entry| entry.path())
-            .filter(|path| path.extension().is_some_and(|ext| ext == "md"))
+            .filter(|path| path.extension().is_some_and(|e| e == ext))
             .collect()
     }
 
@@ -66,6 +66,15 @@ impl OpencodeAdapter {
 
     fn parse_local_mcp_entry(name: &str, value: &serde_json::Value) -> Option<McpServerEntry> {
         if value.get("type").and_then(|v| v.as_str()) != Some("local") {
+            return None;
+        }
+        // Honor OpenCode's `enabled: false` — when the user explicitly disabled
+        // the server in opencode.json, HarnessKit hides it from its view (same
+        // as the remote-type filter above). Field default is true, so omitted
+        // or `enabled: true` flows through normally.
+        // Spec: https://opencode.ai/docs/mcp-servers/ ("Enable or disable the
+        // MCP server on startup").
+        if value.get("enabled").and_then(|v| v.as_bool()) == Some(false) {
             return None;
         }
 
@@ -128,10 +137,6 @@ impl AgentAdapter for OpencodeAdapter {
             self.base_dir().join("skills"),
             self.home.join(".agents").join("skills"),
         ]
-    }
-
-    fn project_skill_dirs(&self) -> Vec<String> {
-        vec![".opencode/skills".into()]
     }
 
     fn mcp_config_path(&self) -> PathBuf {
@@ -198,13 +203,66 @@ impl AgentAdapter for OpencodeAdapter {
     }
 
     fn global_settings_files(&self) -> Vec<PathBuf> {
-        let mut files = vec![self.mcp_config_path()];
-        files.extend(Self::markdown_files(&self.base_dir().join("agents")));
+        // Includes the canonical config file plus the .jsonc variant (only one
+        // exists per install, but listing both lets the scanner find either),
+        // and every directory whose contents are user-configurable settings:
+        //   - agents/*.md  : agent definitions
+        //   - modes/*.md   : agent mode definitions
+        //   - themes/*.json: UI themes (palette/styling JSON)
+        // tools/*.ts and plugins/*.ts are intentionally excluded — they are
+        // code, not settings, and have their own discovery paths.
+        let base = self.base_dir();
+        let mut files = vec![
+            self.mcp_config_path(),       // opencode.json
+            base.join("opencode.jsonc"),  // jsonc variant
+        ];
+        files.extend(Self::files_with_ext(&base.join("agents"), "md"));
+        files.extend(Self::files_with_ext(&base.join("modes"), "md"));
+        files.extend(Self::files_with_ext(&base.join("themes"), "json"));
         files
     }
 
     fn global_workflow_files(&self) -> Vec<PathBuf> {
-        Self::markdown_files(&self.base_dir().join("commands"))
+        Self::files_with_ext(&self.base_dir().join("commands"), "md")
+    }
+
+    fn project_rules_patterns(&self) -> Vec<String> {
+        // Rules: project-root AGENTS.md (https://opencode.ai/docs/rules/).
+        // OpenCode also falls back to CLAUDE.md when AGENTS.md is absent, but
+        // we don't claim CLAUDE.md here — that file's primary owner is Claude
+        // Code, and surfacing it as an OpenCode rule would be misleading.
+        vec!["AGENTS.md".into()]
+    }
+
+    fn project_settings_patterns(&self) -> Vec<String> {
+        // Project config: <project_root>/opencode.json[c]
+        // (https://opencode.ai/docs/config/). Both .json and .jsonc are valid.
+        vec!["opencode.json".into(), "opencode.jsonc".into()]
+    }
+
+    fn project_workflow_patterns(&self) -> Vec<String> {
+        // Slash commands: .opencode/commands/*.md
+        // (https://opencode.ai/docs/commands/).
+        vec![".opencode/commands/*.md".into()]
+    }
+
+    fn project_skill_dirs(&self) -> Vec<String> {
+        vec![".opencode/skills".into()]
+    }
+
+    fn project_mcp_config_relpath(&self) -> Option<String> {
+        // OpenCode reads MCP servers from the same opencode.json that holds
+        // every other setting; there is no separate `.mcp.json`. The single
+        // canonical name is preferred — users on .jsonc miss project-level
+        // MCP discovery, but that matches how every other adapter (Claude
+        // `.mcp.json`, Cursor `.cursor/mcp.json`) picks one canonical path.
+        Some("opencode.json".into())
+    }
+
+    fn project_plugin_dirs(&self) -> Vec<String> {
+        // Project plugins: .opencode/plugins/ holds JS/TS files
+        // (https://opencode.ai/docs/plugins/). Same loader as global plugins.
+        vec![".opencode/plugins".into()]
     }
 }
 
@@ -261,6 +319,53 @@ mod tests {
     }
 
     #[test]
+    fn read_mcp_servers_skips_explicitly_disabled() {
+        // OpenCode lets users keep a server in opencode.json but switch it off
+        // via `enabled: false`. HarnessKit treats those as if they don't exist
+        // — surfacing them as "active" would mislead the UI and any toggle
+        // operation against them would silently fight the user's config.
+        // Default-true (omitted or `enabled: true`) must still flow through.
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().join(".config/opencode");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("opencode.json"),
+            r#"{
+                "mcp": {
+                    "active": {
+                        "type": "local",
+                        "command": ["bin"]
+                    },
+                    "explicit-on": {
+                        "type": "local",
+                        "command": ["bin"],
+                        "enabled": true
+                    },
+                    "explicit-off": {
+                        "type": "local",
+                        "command": ["bin"],
+                        "enabled": false
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        let names: Vec<_> = adapter
+            .read_mcp_servers()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        assert!(names.contains(&"active".to_string()));
+        assert!(names.contains(&"explicit-on".to_string()));
+        assert!(
+            !names.contains(&"explicit-off".to_string()),
+            "enabled:false entries must be filtered out"
+        );
+    }
+
+    #[test]
     fn read_plugins_scans_enabled_and_disabled_files() {
         let tmp = tempfile::tempdir().unwrap();
         let plugins_dir = tmp.path().join(".config/opencode/plugins");
@@ -284,18 +389,83 @@ mod tests {
     }
 
     #[test]
-    fn global_settings_and_workflows_include_markdown_files() {
+    fn global_settings_and_workflows_include_configurable_subdirs() {
         let tmp = tempfile::tempdir().unwrap();
         let base = tmp.path().join(".config/opencode");
-        std::fs::create_dir_all(base.join("agents")).unwrap();
-        std::fs::create_dir_all(base.join("commands")).unwrap();
+        for sub in ["agents", "modes", "themes", "commands", "tools"] {
+            std::fs::create_dir_all(base.join(sub)).unwrap();
+        }
         std::fs::write(base.join("agents/reviewer.md"), "# reviewer").unwrap();
+        std::fs::write(base.join("modes/build.md"), "# build mode").unwrap();
+        std::fs::write(base.join("themes/dark.json"), "{}").unwrap();
         std::fs::write(base.join("commands/deploy.md"), "# deploy").unwrap();
+        // tools/ is code — must NOT appear in settings.
+        std::fs::write(base.join("tools/lint.ts"), "export default {}").unwrap();
+        // Non-matching extensions inside scanned dirs must be ignored.
+        std::fs::write(base.join("agents/notes.txt"), "ignore me").unwrap();
 
         let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
         let settings = adapter.global_settings_files();
         let workflows = adapter.global_workflow_files();
-        assert!(settings.iter().any(|path| path.ends_with("agents/reviewer.md")));
-        assert!(workflows.iter().any(|path| path.ends_with("commands/deploy.md")));
+
+        // Three subdir kinds plus the two top-level config paths.
+        assert!(settings.iter().any(|p| p.ends_with("agents/reviewer.md")));
+        assert!(settings.iter().any(|p| p.ends_with("modes/build.md")));
+        assert!(settings.iter().any(|p| p.ends_with("themes/dark.json")));
+        assert!(settings.iter().any(|p| p.ends_with("opencode.json")));
+        assert!(settings.iter().any(|p| p.ends_with("opencode.jsonc")));
+
+        // Code-bearing dirs and non-matching extensions are excluded.
+        assert!(
+            !settings.iter().any(|p| p.ends_with("tools/lint.ts")),
+            "tools/ holds code, must not be in settings"
+        );
+        assert!(
+            !settings.iter().any(|p| p.ends_with("notes.txt")),
+            "files with non-md extensions in agents/ must be filtered"
+        );
+
+        // Workflows still flows through commands/.
+        assert!(workflows.iter().any(|p| p.ends_with("commands/deploy.md")));
+    }
+
+    #[test]
+    fn project_level_config_paths_match_upstream_conventions() {
+        // Pin the exact relative paths/patterns the project scanner uses to
+        // discover OpenCode config inside a user's repository. Cross-checked
+        // against opencode.ai/docs (config, rules, commands, plugins, mcp-servers).
+        let adapter = OpencodeAdapter::new();
+
+        // Rules: project-root AGENTS.md (no .override.md variant exists).
+        assert_eq!(adapter.project_rules_patterns(), vec!["AGENTS.md".to_string()]);
+
+        // Settings file lives at project root, both .json and .jsonc accepted.
+        assert_eq!(
+            adapter.project_settings_patterns(),
+            vec!["opencode.json".to_string(), "opencode.jsonc".to_string()]
+        );
+
+        // Slash commands.
+        assert_eq!(
+            adapter.project_workflow_patterns(),
+            vec![".opencode/commands/*.md".to_string()]
+        );
+
+        // MCP project config sits inside the same opencode.json, not a
+        // separate .mcp.json — distinct from Claude's split-file convention.
+        assert_eq!(
+            adapter.project_mcp_config_relpath(),
+            Some("opencode.json".to_string())
+        );
+
+        // Project plugins.
+        assert_eq!(
+            adapter.project_plugin_dirs(),
+            vec![".opencode/plugins".to_string()]
+        );
+
+        // Hooks: OpenCode hooks are JS/TS plugin code, not JSON config, so
+        // there is no project hook config file to discover. Stays None.
+        assert_eq!(adapter.project_hook_config_relpath(), None);
     }
 }

--- a/crates/hk-core/src/adapter/opencode.rs
+++ b/crates/hk-core/src/adapter/opencode.rs
@@ -1,4 +1,4 @@
-use super::{AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry};
+use super::{AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry, ProjectMarker};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -68,15 +68,17 @@ impl OpencodeAdapter {
         if value.get("type").and_then(|v| v.as_str()) != Some("local") {
             return None;
         }
-        // Honor OpenCode's `enabled: false` — when the user explicitly disabled
-        // the server in opencode.json, HarnessKit hides it from its view (same
-        // as the remote-type filter above). Field default is true, so omitted
-        // or `enabled: true` flows through normally.
+        // Honor OpenCode's `enabled` field by surfacing its value through the
+        // McpServerEntry — entries with `enabled: false` are NOT filtered out,
+        // matching how HarnessKit displays user-disabled MCPs from every other
+        // agent (visible with a disabled badge, not hidden). Schema default is
+        // true, so omitted means enabled.
         // Spec: https://opencode.ai/docs/mcp-servers/ ("Enable or disable the
         // MCP server on startup").
-        if value.get("enabled").and_then(|v| v.as_bool()) == Some(false) {
-            return None;
-        }
+        let enabled = value
+            .get("enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
 
         let (command, args) = match value.get("command") {
             Some(serde_json::Value::Array(parts)) => {
@@ -105,6 +107,7 @@ impl OpencodeAdapter {
             command,
             args,
             env,
+            enabled,
         })
     }
 }
@@ -229,6 +232,17 @@ impl AgentAdapter for OpencodeAdapter {
         Self::files_with_ext(&self.base_dir().join("commands"), "md")
     }
 
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        // `.opencode/` (subdirs for skills/commands/plugins/agents/modes/themes)
+        // is the most reliable marker. opencode.json[c] at project root is the
+        // top-level config (the only project where its presence implies use).
+        vec![
+            ProjectMarker::Dir(".opencode"),
+            ProjectMarker::File("opencode.json"),
+            ProjectMarker::File("opencode.jsonc"),
+        ]
+    }
+
     fn project_rules_patterns(&self) -> Vec<String> {
         // Rules: project-root AGENTS.md (https://opencode.ai/docs/rules/).
         // OpenCode also falls back to CLAUDE.md when AGENTS.md is absent, but
@@ -321,12 +335,14 @@ mod tests {
     }
 
     #[test]
-    fn read_mcp_servers_skips_explicitly_disabled() {
+    fn read_mcp_servers_surfaces_disabled_state() {
         // OpenCode lets users keep a server in opencode.json but switch it off
-        // via `enabled: false`. HarnessKit treats those as if they don't exist
-        // — surfacing them as "active" would mislead the UI and any toggle
-        // operation against them would silently fight the user's config.
-        // Default-true (omitted or `enabled: true`) must still flow through.
+        // via `enabled: false`. HarnessKit surfaces these entries as visible
+        // but flagged disabled — the same UX as user-toggled disabled MCPs
+        // from any other agent. Hiding them entirely (a previous attempt)
+        // confused users who couldn't reconcile what was in their config with
+        // what HarnessKit displayed. Default-true (omitted or explicit) flows
+        // through as enabled.
         let tmp = tempfile::tempdir().unwrap();
         let config_dir = tmp.path().join(".config/opencode");
         std::fs::create_dir_all(&config_dir).unwrap();
@@ -334,7 +350,7 @@ mod tests {
             config_dir.join("opencode.json"),
             r#"{
                 "mcp": {
-                    "active": {
+                    "default-on": {
                         "type": "local",
                         "command": ["bin"]
                     },
@@ -354,16 +370,20 @@ mod tests {
         .unwrap();
 
         let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
-        let names: Vec<_> = adapter
+        let entries: std::collections::HashMap<String, bool> = adapter
             .read_mcp_servers()
             .into_iter()
-            .map(|s| s.name)
+            .map(|s| (s.name, s.enabled))
             .collect();
-        assert!(names.contains(&"active".to_string()));
-        assert!(names.contains(&"explicit-on".to_string()));
-        assert!(
-            !names.contains(&"explicit-off".to_string()),
-            "enabled:false entries must be filtered out"
+
+        // All three entries must be visible (no hiding).
+        assert_eq!(entries.len(), 3, "all entries must surface");
+        assert_eq!(entries.get("default-on"), Some(&true), "missing 'enabled' defaults to true");
+        assert_eq!(entries.get("explicit-on"), Some(&true));
+        assert_eq!(
+            entries.get("explicit-off"),
+            Some(&false),
+            "enabled:false must be reflected, not filtered"
         );
     }
 

--- a/crates/hk-core/src/adapter/windsurf.rs
+++ b/crates/hk-core/src/adapter/windsurf.rs
@@ -9,7 +9,7 @@
 // Ignore reference:   https://docs.windsurf.com/context-awareness/windsurf-ignore
 // File:               .codeiumignore (project root)
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry};
+use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker};
 use std::path::{Path, PathBuf};
 
 pub struct WindsurfAdapter {
@@ -125,6 +125,8 @@ impl AgentAdapter for WindsurfAdapter {
                             .collect()
                     })
                     .unwrap_or_default(),
+                // Windsurf's MCP schema has no agent-native disable concept.
+                enabled: true,
             })
             .collect()
     }
@@ -186,6 +188,13 @@ impl AgentAdapter for WindsurfAdapter {
 
     fn global_settings_files(&self) -> Vec<PathBuf> {
         vec![self.mcp_config_path(), self.hook_config_path()]
+    }
+
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        vec![
+            ProjectMarker::Dir(".windsurf"),
+            ProjectMarker::File(".windsurfrules"),
+        ]
     }
 
     fn project_rules_patterns(&self) -> Vec<String> {

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -611,6 +611,10 @@ pub fn restore_mcp_server(
                             .collect()
                     })
                     .unwrap_or_default(),
+                // restore happens for the same agent that originally read this
+                // entry; the value is preserved as-is. Codex (TOML) has no
+                // agent-native disable concept, so always true.
+                enabled: true,
             };
             deploy_mcp_server_toml(config_path, &mcp_entry)
         }
@@ -1281,6 +1285,7 @@ mod tests {
             command: "npx".into(),
             args: vec!["-y".into(), "@modelcontextprotocol/server-github".into()],
             env: [("GITHUB_TOKEN".into(), "ghp_test".into())].into(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::McpServers).unwrap();
 
@@ -1307,6 +1312,7 @@ mod tests {
             command: "python".into(),
             args: vec!["server.py".into()],
             env: Default::default(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::McpServers).unwrap();
 
@@ -1326,6 +1332,7 @@ mod tests {
             command: "npx".into(),
             args: vec!["-y".into(), "@modelcontextprotocol/server-memory".into()],
             env: Default::default(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::Servers).unwrap();
 
@@ -1351,6 +1358,7 @@ mod tests {
             command: "npx".into(),
             args: vec!["-y".into(), "@upstash/context7-mcp".into()],
             env: [("MY_KEY".into(), "val".into())].into(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
@@ -1381,6 +1389,7 @@ mod tests {
             command: "npx".into(),
             args: vec!["-y".into(), "@modelcontextprotocol/server-github".into()],
             env: [("GITHUB_TOKEN".into(), "ghp_test".into())].into(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
 
@@ -1414,6 +1423,7 @@ mod tests {
             command: "npx".into(),
             args: vec!["-y".into(), "@modelcontextprotocol/server-memory".into()],
             env: Default::default(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
 
@@ -1446,6 +1456,7 @@ mod tests {
             command: "python".into(),
             args: vec!["server.py".into()],
             env: Default::default(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
 
@@ -1518,6 +1529,7 @@ mod tests {
             command: "npx".into(),
             args: vec!["-y".into(), "@upstash/context7-mcp".into()],
             env: [("API_KEY".into(), "k1".into())].into(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &original, McpFormat::Opencode).unwrap();
 
@@ -1550,6 +1562,7 @@ mod tests {
             command: "uvx".into(),
             args: vec!["markitdown-mcp@0.0.1a4".into()],
             env: Default::default(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
@@ -1572,6 +1585,7 @@ mod tests {
             command: "npx".into(),
             args: vec![],
             env: Default::default(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
@@ -1661,6 +1675,7 @@ mod tests {
             command: "uvx".into(),
             args: vec!["markitdown-mcp@0.0.1a4".into()],
             env: Default::default(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
@@ -1682,6 +1697,7 @@ mod tests {
             command: "uvx".into(),
             args: vec!["markitdown-mcp@0.0.1a4".into()],
             env: Default::default(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
@@ -1707,6 +1723,7 @@ mod tests {
             command: "uvx".into(),
             args: vec!["markitdown-mcp@0.0.1a4".into()],
             env: Default::default(),
+            enabled: true,
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -254,12 +254,14 @@ fn deploy_mcp_server_toml(config_path: &Path, entry: &McpServerEntry) -> Result<
 
 /// JSON-based MCP deploy for OpenCode (`~/.config/opencode/opencode.json`).
 /// Schema reference: https://opencode.ai/config.json (McpLocalConfig).
-/// Differs from `mcpServers`/`servers` agents in three ways:
+///
+/// Differs from `mcpServers`/`servers` agents in four ways:
 ///   - top-level key is `"mcp"`
 ///   - `command` is a single array merging the binary + its args
 ///   - env block is named `"environment"` (not `"env"`)
 ///   - entry must declare `"type": "local"` (the schema also defines a
 ///     `"remote"` variant that HarnessKit does not deploy)
+///
 /// `additionalProperties: false` upstream means we must not emit any
 /// extra fields (e.g. no separate `args`/`env`).
 fn deploy_mcp_server_opencode(

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -126,6 +126,23 @@ pub fn ensure_path_injection(entry: &mut crate::adapter::McpServerEntry) {
     }
 }
 
+/// Top-level JSON key under which each JSON-based MCP format stores server
+/// entries. The format → key mapping is the only thing that varies between
+/// JSON-format agents in the remove/restore/read paths, so centralizing it
+/// here keeps that knowledge in one place and forces explicit handling of
+/// every JSON variant via the compiler-checked match.
+///
+/// Toml is excluded — Codex's TOML format takes a separate code path in each
+/// caller and never reaches this function.
+fn json_top_key(format: McpFormat) -> &'static str {
+    match format {
+        McpFormat::McpServers => "mcpServers",
+        McpFormat::Servers => "servers",
+        McpFormat::Opencode => "mcp",
+        McpFormat::Toml => unreachable!("Toml format uses a separate TOML code path"),
+    }
+}
+
 /// Deploy an MCP server config entry into the target agent's config file.
 /// Format varies by agent — see `McpFormat`.
 pub fn deploy_mcp_server(
@@ -137,6 +154,7 @@ pub fn deploy_mcp_server(
         McpFormat::McpServers => deploy_mcp_server_json(config_path, entry, "mcpServers"),
         McpFormat::Servers => deploy_mcp_server_json(config_path, entry, "servers"),
         McpFormat::Toml => deploy_mcp_server_toml(config_path, entry),
+        McpFormat::Opencode => deploy_mcp_server_opencode(config_path, entry),
     }
 }
 
@@ -232,6 +250,54 @@ fn deploy_mcp_server_toml(config_path: &Path, entry: &McpServerEntry) -> Result<
     )?;
 
     Ok(())
+}
+
+/// JSON-based MCP deploy for OpenCode (`~/.config/opencode/opencode.json`).
+/// Schema reference: https://opencode.ai/config.json (McpLocalConfig).
+/// Differs from `mcpServers`/`servers` agents in three ways:
+///   - top-level key is `"mcp"`
+///   - `command` is a single array merging the binary + its args
+///   - env block is named `"environment"` (not `"env"`)
+///   - entry must declare `"type": "local"` (the schema also defines a
+///     `"remote"` variant that HarnessKit does not deploy)
+/// `additionalProperties: false` upstream means we must not emit any
+/// extra fields (e.g. no separate `args`/`env`).
+fn deploy_mcp_server_opencode(
+    config_path: &Path,
+    entry: &McpServerEntry,
+) -> Result<(), HkError> {
+    locked_modify_json(config_path, |config| {
+        let servers = config
+            .as_object_mut()
+            .ok_or_else(|| HkError::ConfigCorrupted("Config is not an object".into()))?
+            .entry("mcp")
+            .or_insert_with(|| serde_json::json!({}));
+
+        let mut command_array = vec![serde_json::Value::String(entry.command.clone())];
+        command_array.extend(entry.args.iter().cloned().map(serde_json::Value::String));
+
+        let mut server_obj = serde_json::Map::new();
+        server_obj.insert("type".into(), serde_json::Value::String("local".into()));
+        server_obj.insert("command".into(), serde_json::Value::Array(command_array));
+        if !entry.env.is_empty() {
+            server_obj.insert(
+                "environment".into(),
+                serde_json::Value::Object(
+                    entry
+                        .env
+                        .iter()
+                        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                        .collect(),
+                ),
+            );
+        }
+
+        servers
+            .as_object_mut()
+            .ok_or_else(|| HkError::ConfigCorrupted("mcp is not an object".into()))?
+            .insert(entry.name.clone(), serde_json::Value::Object(server_obj));
+        Ok(())
+    })
 }
 
 /// Deploy a hook config entry into the target agent's config file.
@@ -391,10 +457,7 @@ pub fn remove_mcp_server(
             Ok(())
         }
         _ => locked_modify_json(config_path, |config| {
-            let key = match format {
-                McpFormat::Servers => "servers",
-                _ => "mcpServers",
-            };
+            let key = json_top_key(format);
             if let Some(servers) = config.get_mut(key).and_then(|v| v.as_object_mut()) {
                 servers.remove(server_name);
             }
@@ -550,10 +613,7 @@ pub fn restore_mcp_server(
             deploy_mcp_server_toml(config_path, &mcp_entry)
         }
         _ => {
-            let key = match format {
-                McpFormat::Servers => "servers",
-                _ => "mcpServers",
-            };
+            let key = json_top_key(format);
             locked_modify_json(config_path, |config| {
                 let servers = config
                     .as_object_mut()
@@ -997,10 +1057,7 @@ pub fn read_mcp_server_config(
         }
         _ => {
             let config = read_or_create_json(config_path)?;
-            let key = match format {
-                McpFormat::Servers => "servers",
-                _ => "mcpServers",
-            };
+            let key = json_top_key(format);
             Ok(config.get(key).and_then(|v| v.get(server_name)).cloned())
         }
     }
@@ -1305,6 +1362,171 @@ mod tests {
             "-y"
         );
         assert_eq!(server["env"]["MY_KEY"].as_str().unwrap(), "val");
+    }
+
+    #[test]
+    fn test_deploy_mcp_server_opencode_format() {
+        // OpenCode schema (https://opencode.ai/config.json):
+        //   - top-level key "mcp"
+        //   - entry must declare type: "local"
+        //   - command is a single array merging the binary + its args
+        //   - env block is named "environment"
+        //   - additionalProperties: false → no separate "args"/"env" fields
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("opencode.json");
+        let entry = McpServerEntry {
+            name: "github".into(),
+            command: "npx".into(),
+            args: vec!["-y".into(), "@modelcontextprotocol/server-github".into()],
+            env: [("GITHUB_TOKEN".into(), "ghp_test".into())].into(),
+        };
+        deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+
+        assert!(
+            content.get("mcpServers").is_none(),
+            "must not use the Claude-style mcpServers key"
+        );
+        let server = &content["mcp"]["github"];
+        assert_eq!(server["type"], "local");
+        assert_eq!(server["command"][0], "npx");
+        assert_eq!(server["command"][1], "-y");
+        assert_eq!(server["command"][2], "@modelcontextprotocol/server-github");
+        assert_eq!(server["environment"]["GITHUB_TOKEN"], "ghp_test");
+        // additionalProperties: false is enforced upstream — verify we honor it.
+        assert!(server.get("args").is_none(), "must not emit a separate args field");
+        assert!(server.get("env").is_none(), "must use 'environment', not 'env'");
+    }
+
+    #[test]
+    fn test_deploy_mcp_server_opencode_omits_environment_when_empty() {
+        // Schema marks `environment` optional. Emitting `"environment": {}` is
+        // legal but noisy; we omit the field entirely when the source has no
+        // env vars to keep the on-disk config minimal.
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("opencode.json");
+        let entry = McpServerEntry {
+            name: "memory".into(),
+            command: "npx".into(),
+            args: vec!["-y".into(), "@modelcontextprotocol/server-memory".into()],
+            env: Default::default(),
+        };
+        deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+        let server = &content["mcp"]["memory"];
+        assert_eq!(server["type"], "local");
+        assert!(server["command"].is_array());
+        assert!(
+            server.get("environment").is_none(),
+            "should omit environment field when source has no env vars"
+        );
+    }
+
+    #[test]
+    fn test_deploy_mcp_server_opencode_preserves_existing_keys() {
+        // OpenCode's opencode.json holds many top-level keys (model, agent,
+        // skills, etc.). Deploy must merge into the existing "mcp" object
+        // without clobbering siblings or sibling-format settings.
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("opencode.json");
+        std::fs::write(
+            &config,
+            r#"{"model":"claude-sonnet-4-6","mcp":{"existing":{"type":"local","command":["node","s.js"]}}}"#,
+        )
+        .unwrap();
+
+        let entry = McpServerEntry {
+            name: "added".into(),
+            command: "python".into(),
+            args: vec!["server.py".into()],
+            env: Default::default(),
+        };
+        deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+        assert_eq!(content["model"], "claude-sonnet-4-6"); // sibling preserved
+        assert_eq!(content["mcp"]["existing"]["command"][0], "node"); // sibling entry preserved
+        assert_eq!(content["mcp"]["added"]["command"][0], "python"); // new entry added
+    }
+
+    #[test]
+    fn test_opencode_remove_restore_and_read_uses_mcp_key() {
+        // Exercise the three json_top_key code paths (remove/restore/read) for
+        // McpFormat::Opencode in one round-trip. Regression guard: an earlier
+        // implementation routed Opencode through the wildcard arm and silently
+        // operated on "mcpServers" instead of "mcp".
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("opencode.json");
+        std::fs::write(
+            &config,
+            r#"{"mcp":{"github":{"type":"local","command":["npx","server-github"],"environment":{"TOKEN":"abc"}}}}"#,
+        )
+        .unwrap();
+
+        // read
+        let saved =
+            read_mcp_server_config(&config, "github", McpFormat::Opencode).unwrap();
+        assert!(saved.is_some(), "read must find entry under 'mcp', not 'mcpServers'");
+        let saved = saved.unwrap();
+        assert_eq!(saved["environment"]["TOKEN"], "abc");
+
+        // remove
+        remove_mcp_server(&config, "github", McpFormat::Opencode).unwrap();
+        let after_remove =
+            read_mcp_server_config(&config, "github", McpFormat::Opencode).unwrap();
+        assert!(after_remove.is_none(), "remove must delete from 'mcp' key");
+
+        // restore
+        restore_mcp_server(&config, "github", &saved, McpFormat::Opencode).unwrap();
+        let restored =
+            read_mcp_server_config(&config, "github", McpFormat::Opencode).unwrap();
+        assert_eq!(
+            restored.unwrap(),
+            saved,
+            "restored entry must match what was saved (bit-perfect round-trip)"
+        );
+
+        // Confirm the entry actually lives under "mcp" on disk.
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+        assert!(content.get("mcp").is_some());
+        assert!(
+            content.get("mcpServers").is_none(),
+            "must not have leaked into mcpServers via fallback"
+        );
+    }
+
+    #[test]
+    fn test_opencode_deploy_then_adapter_read_roundtrip() {
+        // Cross-module integration: bytes deployer writes must be exactly what
+        // the OpencodeAdapter's parser reads back — i.e. a McpServerEntry
+        // survives a full write→read loop with command/args/env intact.
+        use crate::adapter::AgentAdapter;
+        use crate::adapter::opencode::OpencodeAdapter;
+
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("opencode.json");
+        let original = McpServerEntry {
+            name: "context7".into(),
+            command: "npx".into(),
+            args: vec!["-y".into(), "@upstash/context7-mcp".into()],
+            env: [("API_KEY".into(), "k1".into())].into(),
+        };
+        deploy_mcp_server(&config, &original, McpFormat::Opencode).unwrap();
+
+        let adapter = OpencodeAdapter::with_home(dir.path().to_path_buf());
+        let entries = adapter.read_mcp_servers_from(&config);
+        assert_eq!(entries.len(), 1);
+        let read_back = &entries[0];
+        assert_eq!(read_back.name, original.name);
+        assert_eq!(read_back.command, original.command);
+        assert_eq!(read_back.args, original.args);
+        assert_eq!(read_back.env, original.env);
     }
 
     #[test]

--- a/crates/hk-core/src/manager.rs
+++ b/crates/hk-core/src/manager.rs
@@ -306,6 +306,39 @@ fn plugin_key_from_ext(ext: &Extension) -> String {
     }
 }
 
+fn plugin_toggle_target(path: &Path) -> Option<PathBuf> {
+    if path.is_file() {
+        return Some(path.to_path_buf());
+    }
+
+    [
+        "plugin.json",
+        ".cursor-plugin/plugin.json",
+        ".codex-plugin/plugin.json",
+        ".plugin/plugin.json",
+        ".github/plugin/plugin.json",
+    ]
+    .iter()
+    .map(|manifest_name| path.join(manifest_name))
+    .find(|manifest| manifest.exists())
+}
+
+fn disabled_plugin_target(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.disabled", path.to_string_lossy()))
+}
+
+fn disabled_plugin_name(path: &Path) -> String {
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let base = file_name.strip_suffix(".disabled").unwrap_or(&file_name);
+    Path::new(base)
+        .file_stem()
+        .map(|stem| stem.to_string_lossy().to_string())
+        .unwrap_or_else(|| base.to_string())
+}
+
 fn toggle_plugin(ext: &Extension, enabled: bool, store: &Store, adapters: &[Box<dyn adapter::AgentAdapter>]) -> Result<(), HkError> {
     for a in adapters {
         if !ext.agents.contains(&a.name().to_string()) {
@@ -381,7 +414,7 @@ fn toggle_plugin_manifest(
         let disabled_manifest = if let Some(p) = disabled_manifest {
             Some(p)
         } else {
-            find_disabled_manifest(adapter, &ext.id)
+            find_disabled_plugin_path(adapter, &ext.id)
         };
         if let Some(disabled) = disabled_manifest {
             let s = disabled.to_string_lossy();
@@ -405,32 +438,19 @@ fn toggle_plugin_manifest(
                 continue;
             }
             if let Some(ref path) = plugin.path {
-                for manifest_name in &[
-                    "plugin.json",
-                    ".cursor-plugin/plugin.json",
-                    ".codex-plugin/plugin.json",
-                    ".plugin/plugin.json",
-                    ".github/plugin/plugin.json",
-                ] {
-                    let manifest = path.join(manifest_name);
-                    if manifest.exists() {
-                        let disabled_manifest = PathBuf::from(format!(
-                            "{}.disabled",
-                            manifest.to_string_lossy()
-                        ));
-                        let saved = serde_json::json!({ "manifest_path": disabled_manifest.to_string_lossy() });
-                        store.set_disabled_config(&ext.id, Some(&saved.to_string()))?;
-                        std::fs::rename(&manifest, &disabled_manifest)?;
-                        found = true;
-                        break;
-                    }
+                if let Some(manifest) = plugin_toggle_target(path) {
+                    let disabled_manifest = disabled_plugin_target(&manifest);
+                    let saved = serde_json::json!({ "manifest_path": disabled_manifest.to_string_lossy() });
+                    store.set_disabled_config(&ext.id, Some(&saved.to_string()))?;
+                    std::fs::rename(&manifest, &disabled_manifest)?;
+                    found = true;
                 }
             }
             break;
         }
         if !found {
             return Err(HkError::NotFound(format!(
-                "No manifest found for plugin '{}' — cannot disable",
+                "No plugin file or manifest found for plugin '{}' — cannot disable",
                 ext.name
             )));
         }
@@ -440,11 +460,28 @@ fn toggle_plugin_manifest(
 
 /// Search plugin directories for a disabled manifest matching the given extension ID.
 /// Used as a fallback for plugins disabled before we started saving the manifest path.
-fn find_disabled_manifest(adapter: &dyn adapter::AgentAdapter, ext_id: &str) -> Option<PathBuf> {
+fn find_disabled_plugin_path(adapter: &dyn adapter::AgentAdapter, ext_id: &str) -> Option<PathBuf> {
     for plugin_dir in adapter.plugin_dirs() {
         if let Ok(entries) = std::fs::read_dir(&plugin_dir) {
             for entry in entries.flatten() {
-                if !entry.path().is_dir() {
+                if entry.path().is_file() {
+                    let path = entry.path();
+                    let file_name = path.file_name()?.to_string_lossy();
+                    if !file_name.ends_with(".disabled") {
+                        continue;
+                    }
+                    let source = if adapter.name() == "opencode" {
+                        "local".to_string()
+                    } else {
+                        plugin_dir
+                            .file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_default()
+                    };
+                    let id_name = format!("{}:{}", disabled_plugin_name(&path), source);
+                    if scanner::stable_id_for(&id_name, "plugin", adapter.name()) == ext_id {
+                        return Some(path);
+                    }
                     continue;
                 }
                 // Check known manifest locations with .disabled suffix
@@ -2130,6 +2167,34 @@ mod tests {
         // Disable should fail because there's no manifest to rename
         let r = toggle_extension_with_adapters(&store, &adapters, "ghost-1", false);
         assert!(r.is_err(), "disable with no manifest should fail");
+    }
+
+    #[test]
+    fn test_opencode_plugin_toggle_renames_file() {
+        let dir = TempDir::new().unwrap();
+        let store = crate::store::Store::open(&dir.path().join("test.db")).unwrap();
+        let plugins_dir = dir.path().join(".config/opencode/plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+        let plugin_path = plugins_dir.join("lint.ts");
+        std::fs::write(&plugin_path, "export default {};").unwrap();
+
+        let adapter = crate::adapter::opencode::OpencodeAdapter::with_home(dir.path().to_path_buf());
+        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![Box::new(adapter)];
+
+        let scanned = scanner::scan_plugins(&*adapters[0]);
+        assert_eq!(scanned.len(), 1);
+        store.sync_extensions(&scanned).unwrap();
+        let ext_id = scanned[0].id.clone();
+
+        let r = toggle_extension_with_adapters(&store, &adapters, &ext_id, false);
+        assert!(r.is_ok(), "disable failed: {:?}", r.err());
+        assert!(!plugin_path.exists());
+        assert!(plugins_dir.join("lint.ts.disabled").exists());
+
+        let r = toggle_extension_with_adapters(&store, &adapters, &ext_id, true);
+        assert!(r.is_ok(), "re-enable failed: {:?}", r.err());
+        assert!(plugin_path.exists());
+        assert!(!plugins_dir.join("lint.ts.disabled").exists());
     }
 
     /// Regression: a global skill and a project skill that happen to share a

--- a/crates/hk-core/src/manager.rs
+++ b/crates/hk-core/src/manager.rs
@@ -454,14 +454,14 @@ fn toggle_plugin_manifest(
             if scanner::stable_id_for(&plugin_id_name, "plugin", adapter.name()) != ext.id {
                 continue;
             }
-            if let Some(ref path) = plugin.path {
-                if let Some(manifest) = plugin_toggle_target(path) {
-                    let disabled_manifest = disabled_plugin_target(&manifest);
-                    let saved = serde_json::json!({ "manifest_path": disabled_manifest.to_string_lossy() });
-                    store.set_disabled_config(&ext.id, Some(&saved.to_string()))?;
-                    std::fs::rename(&manifest, &disabled_manifest)?;
-                    found = true;
-                }
+            if let Some(ref path) = plugin.path
+                && let Some(manifest) = plugin_toggle_target(path)
+            {
+                let disabled_manifest = disabled_plugin_target(&manifest);
+                let saved = serde_json::json!({ "manifest_path": disabled_manifest.to_string_lossy() });
+                store.set_disabled_config(&ext.id, Some(&saved.to_string()))?;
+                std::fs::rename(&manifest, &disabled_manifest)?;
+                found = true;
             }
             break;
         }

--- a/crates/hk-core/src/manager.rs
+++ b/crates/hk-core/src/manager.rs
@@ -5,6 +5,12 @@ use crate::{adapter, deployer, sanitize, scanner};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Field names under which an MCP server entry stores its environment-variable
+/// block. Most agents use `"env"`; OpenCode's schema names the same block
+/// `"environment"`. Centralized so secret-handling code (redaction, restore
+/// warnings) stays format-agnostic.
+const MCP_ENV_KEYS: [&str; 2] = ["env", "environment"];
+
 #[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct InstallResult {
     pub name: String,
@@ -202,7 +208,10 @@ fn toggle_mcp(ext: &Extension, enabled: bool, store: &Store, adapters: &[Box<dyn
             // the user needs to manually set the real values in the config.
             // PATH is excluded: it is auto-injected, not a secret, and is
             // self-healed above for antigravity.
-            if let Some(env_obj) = entry.get("env").and_then(|v| v.as_object()) {
+            for env_key in MCP_ENV_KEYS {
+                let Some(env_obj) = entry.get(env_key).and_then(|v| v.as_object()) else {
+                    continue;
+                };
                 let redacted_keys: Vec<&str> = env_obj
                     .iter()
                     .filter(|(k, v)| k.as_str() != "PATH" && v.as_str() == Some("<redacted>"))
@@ -216,6 +225,7 @@ fn toggle_mcp(ext: &Extension, enabled: bool, store: &Store, adapters: &[Box<dyn
                         redacted_keys.join(", ")
                     );
                 }
+                break; // each entry has at most one env block — stop on first hit
             }
             deployer::restore_mcp_server(&config_path, &ext.name, &entry, format)?;
             store.set_disabled_config(&ext.id, None)?;
@@ -235,9 +245,14 @@ fn toggle_mcp(ext: &Extension, enabled: bool, store: &Store, adapters: &[Box<dyn
 }
 
 /// Redact environment variable values in an MCP server config entry.
-/// Replaces all values in the "env" object with "<redacted>" while preserving keys.
-/// This prevents secrets (API keys, tokens, etc.) from being stored in the
-/// harnesskit SQLite database when an MCP server is disabled.
+/// Replaces all values inside the env-block object with "<redacted>" while
+/// preserving keys. This prevents secrets (API keys, tokens, etc.) from being
+/// stored in the harnesskit SQLite database when an MCP server is disabled.
+///
+/// Two block names are handled: most agents use `"env"`, while OpenCode's
+/// schema names the same block `"environment"`. Only one will be present per
+/// entry, so iterating both keeps this helper format-agnostic without needing
+/// to thread `McpFormat` through every caller.
 ///
 /// `PATH` is excluded — HarnessKit auto-injects it for agents whose
 /// `needs_path_injection()` returns true (see install.rs). It is an operational
@@ -245,12 +260,14 @@ fn toggle_mcp(ext: &Extension, enabled: bool, store: &Store, adapters: &[Box<dyn
 /// can find its binary again.
 fn redact_mcp_env(entry: &serde_json::Value) -> serde_json::Value {
     let mut redacted = entry.clone();
-    if let Some(env_obj) = redacted.get_mut("env").and_then(|v| v.as_object_mut()) {
-        for (key, value) in env_obj.iter_mut() {
-            if key == "PATH" {
-                continue;
+    for env_key in MCP_ENV_KEYS {
+        if let Some(env_obj) = redacted.get_mut(env_key).and_then(|v| v.as_object_mut()) {
+            for (key, value) in env_obj.iter_mut() {
+                if key == "PATH" {
+                    continue;
+                }
+                *value = serde_json::Value::String("<redacted>".into());
             }
-            *value = serde_json::Value::String("<redacted>".into());
         }
     }
     redacted
@@ -1784,6 +1801,32 @@ mod tests {
             "PATH must be preserved verbatim, not redacted"
         );
         assert_eq!(redacted["env"]["API_KEY"], "<redacted>");
+    }
+
+    #[test]
+    fn test_redact_mcp_env_handles_opencode_environment_key() {
+        // OpenCode's MCP schema names the env block "environment" (not "env").
+        // Without this support, secrets in OpenCode entries would be stored in
+        // plaintext in the SQLite DB on disable, and the restore-time warning
+        // about manually re-setting redacted values would never fire.
+        let entry = serde_json::json!({
+            "type": "local",
+            "command": ["npx", "-y", "@modelcontextprotocol/server-github"],
+            "environment": {
+                "PATH": "/opt/homebrew/bin:/usr/local/bin",
+                "GITHUB_TOKEN": "ghp_realsecret"
+            }
+        });
+        let redacted = super::redact_mcp_env(&entry);
+        assert_eq!(
+            redacted["environment"]["PATH"],
+            "/opt/homebrew/bin:/usr/local/bin",
+            "PATH must round-trip through redaction even under OpenCode's 'environment' key"
+        );
+        assert_eq!(redacted["environment"]["GITHUB_TOKEN"], "<redacted>");
+        // Schema-defining fields (type, command) untouched.
+        assert_eq!(redacted["type"], "local");
+        assert_eq!(redacted["command"][0], "npx");
     }
 
     #[cfg(unix)]

--- a/crates/hk-core/src/scanner.rs
+++ b/crates/hk-core/src/scanner.rs
@@ -426,7 +426,10 @@ pub fn scan_plugins(adapter: &dyn AgentAdapter) -> Vec<Extension> {
                 installed_at,
                 updated_at,
 
-                source_path: None,
+                source_path: plugin
+                    .path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().to_string()),
                 cli_parent_id: None,
                 cli_meta: None,
                 install_meta: None,
@@ -1687,28 +1690,52 @@ fn infer_hook_permissions(command: &str) -> Vec<Permission> {
     permissions
 }
 
-/// Infer permissions from plugin directory contents.
-/// Reads JS/TS/Python/JSON files and applies pattern matching.
-fn infer_plugin_permissions(dir: &Path) -> Vec<Permission> {
+fn plugin_code_extension(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?.to_string_lossy();
+    let base = file_name.strip_suffix(".disabled").unwrap_or(&file_name);
+    Path::new(base)
+        .extension()
+        .map(|ext| ext.to_string_lossy().to_string())
+}
+
+/// Infer permissions from plugin source contents.
+/// Supports both directory-based plugins and single-file plugins.
+fn infer_plugin_permissions(path: &Path) -> Vec<Permission> {
     let allowed_extensions = ["js", "ts", "py", "json", "sh", "mjs", "cjs"];
     let max_total_bytes: usize = 256 * 1024;
     let mut total_bytes = 0usize;
     let mut combined_content = String::new();
 
-    let Ok(entries) = std::fs::read_dir(dir) else {
+    let mut candidate_files = Vec::new();
+    if path.is_file() {
+        if let Some(ext) = plugin_code_extension(path)
+            && allowed_extensions.contains(&ext.as_str())
+        {
+            candidate_files.push(path.to_path_buf());
+        }
+    } else if let Ok(entries) = std::fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let file = entry.path();
+            if !file.is_file() {
+                continue;
+            }
+            let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if allowed_extensions.contains(&ext) {
+                candidate_files.push(file);
+            }
+        }
+    } else {
         return vec![
             Permission::Shell { commands: vec![] },
             Permission::FileSystem { paths: vec![] },
         ];
-    };
+    }
 
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_file() { continue; }
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        if !allowed_extensions.contains(&ext) { continue; }
-        if let Ok(content) = std::fs::read_to_string(&path) {
-            if total_bytes + content.len() > max_total_bytes { break; }
+    for file in candidate_files {
+        if let Ok(content) = std::fs::read_to_string(&file) {
+            if total_bytes + content.len() > max_total_bytes {
+                break;
+            }
             total_bytes += content.len();
             combined_content.push_str(&content);
             combined_content.push('\n');
@@ -1726,7 +1753,12 @@ fn infer_plugin_permissions(dir: &Path) -> Vec<Permission> {
     let mut perms = infer_skill_permissions(&combined_content);
 
     // Also check package.json for lifecycle scripts
-    let pkg_path = dir.join("package.json");
+    let pkg_parent = if path.is_dir() {
+        path
+    } else {
+        path.parent().unwrap_or(path)
+    };
+    let pkg_path = pkg_parent.join("package.json");
     if let Ok(pkg_content) = std::fs::read_to_string(&pkg_path)
         && let Ok(json) = serde_json::from_str::<serde_json::Value>(&pkg_content)
         && let Some(scripts) = json.get("scripts").and_then(|s| s.as_object())
@@ -2625,6 +2657,18 @@ mod config_tests {
         // Should fallback to empty Shell + FileSystem
         assert!(perms.iter().any(|p| matches!(p, Permission::Shell { .. })));
         assert!(perms.iter().any(|p| matches!(p, Permission::FileSystem { .. })));
+    }
+
+    #[test]
+    fn test_plugin_permission_from_single_file_plugin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin = tmp.path().join("plugin.ts");
+        std::fs::write(&plugin, "fetch('https://example.com');").unwrap();
+        let perms = infer_plugin_permissions(&plugin);
+        assert!(
+            perms.iter().any(|p| matches!(p, Permission::Network { domains } if domains.iter().any(|domain| domain == "example.com"))),
+            "Should detect network access from a file-based plugin"
+        );
     }
 
     #[test]

--- a/crates/hk-core/src/scanner.rs
+++ b/crates/hk-core/src/scanner.rs
@@ -305,7 +305,13 @@ pub fn scan_mcp_servers(adapter: &dyn AgentAdapter) -> Vec<Extension> {
                 tags: vec![],
                 pack,
                 permissions,
-                enabled: true,
+                // Reflect the agent's own enabled state. For 7 of 8 adapters
+                // this is always true (their formats lack a disable concept);
+                // only OpenCode's schema can produce a false here, surfacing
+                // user-disabled-in-config entries as visible-but-disabled
+                // rather than hiding them. HarnessKit's separate UI-toggled
+                // disable flow operates orthogonally via SQLite tracking.
+                enabled: server.enabled,
                 trust_score: None,
                 installed_at: config_created,
                 updated_at: config_modified,
@@ -927,7 +933,9 @@ pub fn scan_project_extensions(
                     tags: vec![],
                     pack: None,
                     permissions,
-                    enabled: true,
+                    // Reflect the agent's enabled state — see global-scope
+                    // counterpart above for the cross-adapter invariant.
+                    enabled: server.enabled,
                     trust_score: None,
                     installed_at: config_created,
                     updated_at: config_modified,
@@ -1267,6 +1275,21 @@ pub fn discover_projects(root: &Path, max_depth: usize) -> Vec<DiscoveredProject
     projects
 }
 
+/// True if `dir` looks like a project root for any of the supported agents.
+/// Each adapter declares its own `project_markers` (see
+/// [`adapter::AgentAdapter::project_markers`]); we consider the directory a
+/// project as soon as one adapter's marker matches. Used by both project
+/// discovery (`discover_projects`) and the `add_project` validation in
+/// hk-desktop / hk-web.
+pub fn is_project_dir(dir: &Path) -> bool {
+    crate::adapter::all_adapters().iter().any(|a| {
+        a.project_markers().iter().any(|m| match m {
+            crate::adapter::ProjectMarker::Dir(p) => dir.join(p).is_dir(),
+            crate::adapter::ProjectMarker::File(p) => dir.join(p).is_file(),
+        })
+    })
+}
+
 fn discover_projects_recursive(
     dir: &Path,
     max_depth: usize,
@@ -1277,30 +1300,7 @@ fn discover_projects_recursive(
         return;
     }
 
-    // Check if this directory is a project (any agent's config present)
-    let is_project =
-        // Claude Code: .claude/ directory
-        dir.join(".claude").is_dir()
-        // Claude Code: .mcp.json
-        || dir.join(".mcp.json").is_file()
-        // Codex: .codex/ directory
-        || dir.join(".codex").is_dir()
-        // Gemini: .gemini/ directory
-        || dir.join(".gemini").is_dir()
-        // Cursor: .cursor/rules/ directory or .cursorrules file
-        || dir.join(".cursor").join("rules").is_dir()
-        || dir.join(".cursorrules").is_file()
-        // Copilot: .github/copilot-instructions.md or .github/instructions/
-        || dir.join(".github").join("copilot-instructions.md").is_file()
-        || dir.join(".github").join("instructions").is_dir()
-        // Antigravity: .agent/rules/ or .agent/skills/
-        || dir.join(".agent").join("rules").is_dir()
-        || dir.join(".agent").join("skills").is_dir()
-        // Windsurf: .windsurf/ directory or .windsurfrules file
-        || dir.join(".windsurf").is_dir()
-        || dir.join(".windsurfrules").is_file();
-
-    if is_project {
+    if is_project_dir(dir) {
         let name = dir
             .file_name()
             .unwrap_or_default()
@@ -2191,6 +2191,20 @@ mod tests {
         std::fs::create_dir_all(&proj7).unwrap();
         std::fs::write(proj7.join(".windsurfrules"), "Follow repo rules").unwrap();
 
+        // Project with .opencode/ (OpenCode)
+        let proj8 = root.path().join("project-h");
+        std::fs::create_dir_all(proj8.join(".opencode").join("skills")).unwrap();
+
+        // Project with opencode.json (OpenCode)
+        let proj9 = root.path().join("project-i");
+        std::fs::create_dir_all(&proj9).unwrap();
+        std::fs::write(proj9.join("opencode.json"), r#"{"mcp":{}}"#).unwrap();
+
+        // Project with opencode.jsonc (OpenCode JSONC variant)
+        let proj10 = root.path().join("project-j");
+        std::fs::create_dir_all(&proj10).unwrap();
+        std::fs::write(proj10.join("opencode.jsonc"), "// jsonc\n{}").unwrap();
+
         // Not a project
         let non_proj = root.path().join("not-a-project");
         std::fs::create_dir_all(&non_proj).unwrap();
@@ -2200,7 +2214,7 @@ mod tests {
         std::fs::create_dir_all(github_only.join(".github")).unwrap();
 
         let discovered = discover_projects(root.path(), 4);
-        assert_eq!(discovered.len(), 7);
+        assert_eq!(discovered.len(), 10);
         let names: Vec<&str> = discovered.iter().map(|d| d.name.as_str()).collect();
         assert!(names.contains(&"project-a"));
         assert!(names.contains(&"project-b"));
@@ -2209,7 +2223,28 @@ mod tests {
         assert!(names.contains(&"project-e"));
         assert!(names.contains(&"project-f"));
         assert!(names.contains(&"project-g"));
+        assert!(names.contains(&"project-h"));
+        assert!(names.contains(&"project-i"));
+        assert!(names.contains(&"project-j"));
         assert!(!names.contains(&"github-repo"));
+    }
+
+    #[test]
+    fn test_every_active_adapter_declares_project_markers() {
+        // Regression guard: any agent that participates in `discover_projects`
+        // must declare project_markers(). If a future adapter forgets to
+        // override the trait default (returning empty), this test fails so
+        // we don't silently drop a whole agent from project recognition.
+        // adapters with no on-disk project convention can be added to the
+        // exception list explicitly.
+        let adapters = crate::adapter::all_adapters();
+        for a in &adapters {
+            assert!(
+                !a.project_markers().is_empty(),
+                "{} must declare at least one project_marker",
+                a.name()
+            );
+        }
     }
 
     #[test]

--- a/crates/hk-core/src/service.rs
+++ b/crates/hk-core/src/service.rs
@@ -250,37 +250,92 @@ fn audit_extension_by_name(
 /// NOTE: .json files are excluded — package.json is handled separately by
 /// `infer_plugin_permissions` and `plugin-lifecycle-scripts` rule, and
 /// package-lock.json would consume the entire read budget with URLs.
+fn plugin_file_extension(path: &std::path::Path) -> Option<String> {
+    let file_name = path.file_name()?.to_string_lossy();
+    let base = file_name.strip_suffix(".disabled").unwrap_or(&file_name);
+    std::path::Path::new(base)
+        .extension()
+        .map(|ext| ext.to_string_lossy().to_string())
+}
+
 fn read_plugin_content(plugin_path: &str) -> String {
     use std::path::Path;
-
-    let dir = Path::new(plugin_path);
-    if !dir.is_dir() {
-        return String::new();
-    }
 
     let allowed_extensions = ["js", "ts", "py", "sh", "mjs", "cjs"];
     let max_total_bytes: usize = 512 * 1024;
     let mut total_bytes = 0usize;
     let mut parts = Vec::new();
 
-    let Ok(entries) = std::fs::read_dir(dir) else {
+    let path = Path::new(plugin_path);
+    let mut files = Vec::new();
+    if path.is_file() {
+        if let Some(ext) = plugin_file_extension(path)
+            && allowed_extensions.contains(&ext.as_str())
+        {
+            files.push(path.to_path_buf());
+        }
+    } else if let Ok(entries) = std::fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let file = entry.path();
+            if !file.is_file() {
+                continue;
+            }
+            let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if allowed_extensions.contains(&ext) {
+                files.push(file);
+            }
+        }
+    } else {
         return String::new();
-    };
+    }
 
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_file() { continue; }
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        if !allowed_extensions.contains(&ext) { continue; }
-        if let Ok(content) = std::fs::read_to_string(&path) {
+    for file in files {
+        if let Ok(content) = std::fs::read_to_string(&file) {
             let bytes_to_add = content.len();
-            if total_bytes + bytes_to_add > max_total_bytes { break; }
-            parts.push(format!("// === {} ===\n{}", path.file_name().unwrap_or_default().to_string_lossy(), content));
+            if total_bytes + bytes_to_add > max_total_bytes {
+                break;
+            }
+            parts.push(format!("// === {} ===\n{}", file.file_name().unwrap_or_default().to_string_lossy(), content));
             total_bytes += bytes_to_add;
         }
     }
 
     parts.join("\n")
+}
+
+fn remove_path(path: &std::path::Path) -> Result<(), HkError> {
+    if path.is_dir() {
+        std::fs::remove_dir_all(path)?;
+    } else if path.is_file() {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn read_plugin_detail(path: &std::path::Path, fallback: &str) -> String {
+    if path.is_file() {
+        return std::fs::read_to_string(path).unwrap_or_else(|_| fallback.to_string());
+    }
+
+    for candidate in [path.join("README.md"), path.join("readme.md")] {
+        if let Ok(text) = std::fs::read_to_string(&candidate) {
+            return text;
+        }
+    }
+
+    let mut dir = path.to_path_buf();
+    while dir.pop() {
+        if dir.join(".git").exists() {
+            for name in ["README.md", "readme.md"] {
+                if let Ok(text) = std::fs::read_to_string(dir.join(name)) {
+                    return text;
+                }
+            }
+            break;
+        }
+    }
+
+    fallback.to_string()
 }
 
 /// Find skill content and file path by scanning adapters for the matching extension.
@@ -471,20 +526,16 @@ pub fn delete_extension(
                             &plugin_key,
                         )?;
                     } else if adapter.name() == "gemini" {
-                        if let Some(ref path) = plugin.path
-                            && path.is_dir()
-                        {
-                            std::fs::remove_dir_all(path)?;
+                        if let Some(ref path) = plugin.path {
+                            remove_path(path)?;
                         }
                         deployer::remove_gemini_extension_entry(
                             &adapter.base_dir().join("extensions"),
                             &plugin.name,
                         )?;
                     } else if adapter.name() == "copilot" {
-                        if let Some(ref path) = plugin.path
-                            && path.is_dir()
-                        {
-                            std::fs::remove_dir_all(path)?;
+                        if let Some(ref path) = plugin.path {
+                            remove_path(path)?;
                         }
                         if let (Some(uri), Some(vscode_dir)) =
                             (&plugin.uri, adapter.vscode_user_dir())
@@ -498,11 +549,8 @@ pub fn delete_extension(
                                 );
                             }
                         }
-                    } else if let Some(ref path) = plugin.path
-                        && path.is_dir()
-                    {
-                        // Cursor, etc. — just remove folder
-                        std::fs::remove_dir_all(path)?;
+                    } else if let Some(ref path) = plugin.path {
+                        remove_path(path)?;
                     }
                 }
             }
@@ -692,28 +740,8 @@ pub fn get_extension_content(
                         let content = plugin
                             .path
                             .as_ref()
-                            .and_then(|p| {
-                                for candidate in [p.join("README.md"), p.join("readme.md")] {
-                                    if let Ok(text) = std::fs::read_to_string(&candidate) {
-                                        return Some(text);
-                                    }
-                                }
-                                let mut dir = p.clone();
-                                while dir.pop() {
-                                    if dir.join(".git").exists() {
-                                        for name in ["README.md", "readme.md"] {
-                                            if let Ok(text) =
-                                                std::fs::read_to_string(dir.join(name))
-                                            {
-                                                return Some(text);
-                                            }
-                                        }
-                                        break;
-                                    }
-                                }
-                                None
-                            })
-                            .unwrap_or(ext.description);
+                            .map(|path| read_plugin_detail(path, &ext.description))
+                            .unwrap_or_else(|| ext.description.clone());
                         return Ok(ExtensionContent {
                             content,
                             path: path_str,
@@ -1155,6 +1183,16 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let content = read_plugin_content(&tmp.path().to_string_lossy());
         assert!(content.is_empty());
+    }
+
+    #[test]
+    fn test_read_plugin_content_reads_single_file_plugin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin = tmp.path().join("plugin.ts");
+        std::fs::write(&plugin, "export const value = 1;").unwrap();
+        let content = read_plugin_content(&plugin.to_string_lossy());
+        assert!(content.contains("plugin.ts"));
+        assert!(content.contains("export const value = 1"));
     }
 
     /// Cross-agent skill deploy must propagate the source's install_meta to

--- a/crates/hk-desktop/src/commands/projects.rs
+++ b/crates/hk-desktop/src/commands/projects.rs
@@ -21,21 +21,10 @@ pub fn add_project(state: State<AppState>, path: String) -> Result<Project, HkEr
         .map_err(|e| HkError::CommandFailed(format!("Invalid path: {}", e)))?;
     let path = project_path.to_string_lossy().to_string();
 
-    // Validate the path contains project markers for any supported agent
-    let has_agent_config = project_path.join(".claude").is_dir()
-        || project_path.join(".mcp.json").is_file()
-        || project_path.join(".codex").is_dir()
-        || project_path.join(".gemini").is_dir()
-        || project_path.join(".cursor").join("rules").is_dir()
-        || project_path.join(".cursorrules").is_file()
-        || project_path
-            .join(".github")
-            .join("copilot-instructions.md")
-            .is_file()
-        || project_path.join(".github").join("instructions").is_dir()
-        || project_path.join(".agent").join("rules").is_dir()
-        || project_path.join(".agent").join("skills").is_dir();
-    if !has_agent_config {
+    // Validate the path contains project markers for any supported agent.
+    // Each adapter declares its own markers via project_markers() — see
+    // scanner::is_project_dir.
+    if !scanner::is_project_dir(&project_path) {
         return Err(HkError::Validation(
             "Directory does not contain any recognized agent configuration".into(),
         ));

--- a/crates/hk-web/src/handlers/projects.rs
+++ b/crates/hk-web/src/handlers/projects.rs
@@ -39,18 +39,10 @@ pub async fn add_project(
         let project_path = super::normalize(&project_path);
         let path = project_path.to_string_lossy().to_string();
 
-        // Validate the path contains project markers for any supported agent
-        let has_agent_config = project_path.join(".claude").is_dir()
-            || project_path.join(".mcp.json").is_file()
-            || project_path.join(".codex").is_dir()
-            || project_path.join(".gemini").is_dir()
-            || project_path.join(".cursor").join("rules").is_dir()
-            || project_path.join(".cursorrules").is_file()
-            || project_path.join(".github").join("copilot-instructions.md").is_file()
-            || project_path.join(".github").join("instructions").is_dir()
-            || project_path.join(".agent").join("rules").is_dir()
-            || project_path.join(".agent").join("skills").is_dir();
-        if !has_agent_config {
+        // Validate the path contains project markers for any supported agent.
+        // Each adapter declares its own markers via project_markers() — see
+        // scanner::is_project_dir.
+        if !scanner::is_project_dir(&project_path) {
             return Err(hk_core::HkError::Validation(
                 "Directory does not contain any recognized agent configuration".into(),
             ));

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -351,7 +351,7 @@ export function ExtensionDetail() {
               agents.filter((a) => a.detected),
               agentOrder,
             );
-            const AGENTS_WITHOUT_HOOKS = new Set(["antigravity"]);
+            const AGENTS_WITHOUT_HOOKS = new Set(["antigravity", "opencode"]);
             const otherAgents = detectedAgents.filter(
               (a) => !group.agents.includes(a.name),
             );

--- a/src/components/extensions/extension-filters.tsx
+++ b/src/components/extensions/extension-filters.tsx
@@ -48,6 +48,7 @@ const AGENT_FILTER_COLORS: Record<string, string> = {
     "bg-agent-antigravity/15 text-agent-antigravity border-agent-antigravity/30",
   copilot: "bg-agent-copilot/15 text-agent-copilot border-agent-copilot/30",
   windsurf: "bg-agent-windsurf/15 text-agent-windsurf border-agent-windsurf/30",
+  opencode: "bg-agent-opencode/15 text-agent-opencode border-agent-opencode/30",
 };
 
 export function ExtensionFilters() {

--- a/src/components/onboarding/onboarding.tsx
+++ b/src/components/onboarding/onboarding.tsx
@@ -56,7 +56,7 @@ type PermKey = keyof typeof PERM_ICONS;
 const MOCK_EXTENSIONS = [
   {
     kind: "skill" as const,
-    agents: ["claude", "cursor", "gemini"] as const,
+    agents: ["claude", "cursor", "gemini", "opencode"] as const,
     perms: ["filesystem", "shell"] as PermKey[],
     score: 95,
     enabled: true,
@@ -70,7 +70,7 @@ const MOCK_EXTENSIONS = [
   },
   {
     kind: "plugin" as const,
-    agents: ["cursor", "copilot"] as const,
+    agents: ["cursor", "copilot", "opencode"] as const,
     perms: ["filesystem"] as PermKey[],
     score: 100,
     enabled: true,
@@ -259,8 +259,9 @@ const AGENTS = [
   "antigravity",
   "copilot",
   "windsurf",
+  "opencode",
 ] as const;
-const FLOAT_DELAYS = [0, 0.4, 0.9, 1.3, 0.6, 1.1, 1.6];
+const FLOAT_DELAYS = [0, 0.4, 0.9, 1.3, 0.6, 1.1, 1.6, 0.8];
 const SCATTER_POSITIONS = [
   { x: -140, y: -80, r: -15 },
   { x: 100, y: -90, r: 12 },
@@ -269,6 +270,7 @@ const SCATTER_POSITIONS = [
   { x: -180, y: 10, r: -20 },
   { x: 150, y: 80, r: 15 },
   { x: 0, y: 108, r: -6 },
+  { x: 210, y: -10, r: 8 },
 ];
 
 function HandAnnotation({
@@ -779,6 +781,7 @@ const MOCK_AGENT_SIDEBAR = [
   { id: "antigravity", label: "Antigravity" },
   { id: "copilot", label: "Copilot" },
   { id: "windsurf", label: "Windsurf" },
+  { id: "opencode", label: "OpenCode" },
 ] as const;
 
 const MOCK_FILES = [

--- a/src/components/shared/agent-card.tsx
+++ b/src/components/shared/agent-card.tsx
@@ -6,20 +6,20 @@ interface AgentCardProps {
   agent: AgentInfo;
 }
 
+const CLICK_DURATIONS: Partial<Record<AgentInfo["name"], number>> = {
+  claude: 4200,
+  windsurf: 1800,
+  opencode: 4000,
+  antigravity: 800,
+};
+
 export function AgentCard({ agent }: AgentCardProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [isClicked, setIsClicked] = useState(false);
 
   const handleClick = useCallback(() => {
     setIsClicked(true);
-    const duration =
-      agent.name === "claude"
-        ? 4200
-        : agent.name === "windsurf"
-          ? 1800
-          : agent.name === "antigravity"
-            ? 800
-            : 600;
+    const duration = CLICK_DURATIONS[agent.name] ?? 600;
     setTimeout(() => setIsClicked(false), duration);
   }, [agent.name]);
 

--- a/src/components/shared/agent-card.tsx
+++ b/src/components/shared/agent-card.tsx
@@ -28,7 +28,7 @@ export function AgentCard({ agent }: AgentCardProps) {
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onClick={handleClick}
-      className={`group flex w-[110px] flex-col items-center gap-1.5 rounded-lg border border-border/60 bg-card/50 px-3 py-2.5 text-center transition-all duration-200 hover:border-border hover:bg-card hover:shadow-sm hover:-translate-y-0.5 ${agent.name === "codex" || agent.name === "antigravity" || agent.name === "claude" ? "overflow-hidden" : "overflow-visible"}`}
+      className={`group flex w-[110px] flex-col items-center gap-1.5 rounded-lg border border-border/60 bg-card/50 px-3 py-2.5 text-center transition-all duration-200 hover:border-border hover:bg-card hover:shadow-sm hover:-translate-y-0.5 ${agent.name === "codex" || agent.name === "antigravity" || agent.name === "claude" || agent.name === "opencode" ? "overflow-hidden" : "overflow-visible"}`}
     >
       <AgentMascot
         name={agent.name}

--- a/src/components/shared/agent-mascot/agent-mascot.tsx
+++ b/src/components/shared/agent-mascot/agent-mascot.tsx
@@ -6,6 +6,7 @@ import { CopilotMascot } from "./copilot-mascot";
 import { CursorMascot } from "./cursor-mascot";
 import { FallbackMascot } from "./fallback-mascot";
 import { GeminiMascot } from "./gemini-mascot";
+import { OpencodeMascot } from "./opencode-mascot";
 import { WindsurfMascot } from "./windsurf-mascot";
 
 interface AgentMascotProps {
@@ -50,6 +51,11 @@ const MASCOT_MAP: Record<
     component: WindsurfMascot,
     className: "mascot-windsurf",
     scale: 1,
+  },
+  opencode: {
+    component: OpencodeMascot,
+    className: "mascot-opencode",
+    scale: 0.92,
   },
 };
 

--- a/src/components/shared/agent-mascot/mascot.css
+++ b/src/components/shared/agent-mascot/mascot.css
@@ -1093,6 +1093,184 @@
   }
 }
 
+/* === OpenCode === */
+.mascot-opencode .opencode-snake {
+  /* perimeter = 16+20+16+20 = 72; snake body = 14, gap = 58 */
+  stroke-dasharray: 14 58;
+  stroke-dashoffset: 0;
+  opacity: 0;
+}
+.mascot-opencode .oc-tile {
+  opacity: 0;
+  transform-box: fill-box;
+  transform-origin: center center;
+}
+
+/* Hover: snake loops once around the perimeter, then fills in (tail catches head)
+   back to the full outline shape.  Total cycle: 3 s.
+   0–60 % (1.8 s)  – snake travels one full revolution (dashoffset 0 → -72)
+   60–80 % (0.6 s) – snake "closes": dasharray grows 14 58 → 72 0 while offset
+                      stays at -72 (= 0 mod 72), so the gap shrinks to zero
+   80–92 % (0.36 s) – snake fades out, outline fades back in
+   92–100 % (0.24 s) – outline holds; on loop boundary both snap to start state */
+.mascot-opencode.is-animated .opencode-outline {
+  animation: opencode-outline-hover 3s ease-in-out infinite;
+}
+.mascot-opencode.is-animated .opencode-snake {
+  animation: opencode-snake-hover 3s ease-in-out infinite;
+}
+
+/* Click: icon shatters into mosaic tiles, then reassembles with a snap */
+.mascot-opencode.is-clicked .opencode-icon {
+  animation: opencode-icon-hide 5s ease forwards;
+}
+.mascot-opencode.is-clicked .opencode-mosaic .oc-tile:nth-child(1) {
+  animation: oc-scatter-top 5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+.mascot-opencode.is-clicked .opencode-mosaic .oc-tile:nth-child(2) {
+  animation: oc-scatter-right 5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+.mascot-opencode.is-clicked .opencode-mosaic .oc-tile:nth-child(3) {
+  animation: oc-scatter-bottom 5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+.mascot-opencode.is-clicked .opencode-mosaic .oc-tile:nth-child(4) {
+  animation: oc-scatter-left 5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+.mascot-opencode.is-clicked .opencode-mosaic .oc-tile:nth-child(5) {
+  animation: oc-scatter-tl 5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+.mascot-opencode.is-clicked .opencode-mosaic .oc-tile:nth-child(6) {
+  animation: oc-scatter-tr 5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+.mascot-opencode.is-clicked .opencode-mosaic .oc-tile:nth-child(7) {
+  animation: oc-scatter-bl 5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+.mascot-opencode.is-clicked .opencode-mosaic .oc-tile:nth-child(8) {
+  animation: oc-scatter-br 5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+
+/* Hover keyframes
+   outline-hover: visible at loop boundary → instant hide → hold → fade back in */
+@keyframes opencode-outline-hover {
+  0%    { opacity: 1; }
+  0.1%  { opacity: 0; }
+  82%   { opacity: 0; }
+  92%   { opacity: 1; }
+  100%  { opacity: 1; }
+}
+/* snake-hover: invisible at loop boundary → instant show → travel → fill in → fade out → reset */
+@keyframes opencode-snake-hover {
+  0%    { opacity: 0;  stroke-dasharray: 14 58; stroke-dashoffset: 0; }
+  0.1%  { opacity: 1;  stroke-dasharray: 14 58; stroke-dashoffset: 0; }
+  60%   { opacity: 1;  stroke-dasharray: 14 58; stroke-dashoffset: -72; }
+  80%   { opacity: 1;  stroke-dasharray: 72 0;  stroke-dashoffset: -72; }
+  88%   { opacity: 0;  stroke-dasharray: 72 0;  stroke-dashoffset: -72; }
+  100%  { opacity: 0;  stroke-dasharray: 14 58; stroke-dashoffset: 0; }
+}
+
+/* Click keyframes
+  Icon: fade out quickly, stay hidden through the scatter/hold/reassemble beats,
+  then fade back in after the tiles have paused in the settled state. */
+@keyframes opencode-icon-hide {
+  0%   { opacity: 1; }
+  5%   { opacity: 0; }
+  96%  { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+/* Scatter timing (5 s total):
+   0– 6 %: tiles appear at rest position
+   6–24 %: scatter outward
+   24–38 %: hold at the furthest scattered position
+   38–50 %: fly back, overshoot slightly past origin
+   50–56 %: settle to exact rest position (snap feel)
+   56–96 %: hold assembled for 2 s (visible end-state beat)
+   96–100 %: fade out as original icon returns */
+
+/* Border tiles — cardinal directions */
+@keyframes oc-scatter-top {
+  0%   { opacity: 0; transform: translate(0,    0)    rotate(0deg);  }
+  6%   { opacity: 1; transform: translate(0,    0)    rotate(0deg);  }
+  24%  { opacity: 1; transform: translate(0,   -20px) rotate(-7deg); }
+  38%  { opacity: 1; transform: translate(0,   -20px) rotate(-7deg); }
+  50%  { opacity: 1; transform: translate(0,    2px)  rotate(1deg);  }
+  56%  { opacity: 1; transform: translate(0,    0)    rotate(0deg);  }
+  96%  { opacity: 1; transform: translate(0,    0)    rotate(0deg);  }
+  100% { opacity: 0; transform: translate(0,    0)    rotate(0deg);  }
+}
+@keyframes oc-scatter-right {
+  0%   { opacity: 0; transform: translate(0,    0)   rotate(0deg);  }
+  6%   { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
+  24%  { opacity: 1; transform: translate(20px, 0)   rotate(7deg);  }
+  38%  { opacity: 1; transform: translate(20px, 0)   rotate(7deg);  }
+  50%  { opacity: 1; transform: translate(-2px, 0)   rotate(-1deg); }
+  56%  { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
+  96%  { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
+  100% { opacity: 0; transform: translate(0,    0)   rotate(0deg);  }
+}
+@keyframes oc-scatter-bottom {
+  0%   { opacity: 0; transform: translate(0,    0)   rotate(0deg);  }
+  6%   { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
+  24%  { opacity: 1; transform: translate(0,   20px) rotate(7deg);  }
+  38%  { opacity: 1; transform: translate(0,   20px) rotate(7deg);  }
+  50%  { opacity: 1; transform: translate(0,   -2px) rotate(-1deg); }
+  56%  { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
+  96%  { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
+  100% { opacity: 0; transform: translate(0,    0)   rotate(0deg);  }
+}
+@keyframes oc-scatter-left {
+  0%   { opacity: 0; transform: translate(0,     0)  rotate(0deg);  }
+  6%   { opacity: 1; transform: translate(0,     0)  rotate(0deg);  }
+  24%  { opacity: 1; transform: translate(-20px, 0)  rotate(-7deg); }
+  38%  { opacity: 1; transform: translate(-20px, 0)  rotate(-7deg); }
+  50%  { opacity: 1; transform: translate(2px,   0)  rotate(1deg);  }
+  56%  { opacity: 1; transform: translate(0,     0)  rotate(0deg);  }
+  96%  { opacity: 1; transform: translate(0,     0)  rotate(0deg);  }
+  100% { opacity: 0; transform: translate(0,     0)  rotate(0deg);  }
+}
+
+/* Inner tiles — diagonal */
+@keyframes oc-scatter-tl {
+  0%   { opacity: 0; transform: translate(0,     0)     rotate(0deg);   }
+  6%   { opacity: 1; transform: translate(0,     0)     rotate(0deg);   }
+  24%  { opacity: 1; transform: translate(-16px,-16px)  rotate(-15deg); }
+  38%  { opacity: 1; transform: translate(-16px,-16px)  rotate(-15deg); }
+  50%  { opacity: 1; transform: translate(2px,   2px)   rotate(2deg);   }
+  56%  { opacity: 1; transform: translate(0,     0)     rotate(0deg);   }
+  96%  { opacity: 1; transform: translate(0,     0)     rotate(0deg);   }
+  100% { opacity: 0; transform: translate(0,     0)     rotate(0deg);   }
+}
+@keyframes oc-scatter-tr {
+  0%   { opacity: 0; transform: translate(0,    0)     rotate(0deg);  }
+  6%   { opacity: 1; transform: translate(0,    0)     rotate(0deg);  }
+  24%  { opacity: 1; transform: translate(16px,-16px)  rotate(15deg); }
+  38%  { opacity: 1; transform: translate(16px,-16px)  rotate(15deg); }
+  50%  { opacity: 1; transform: translate(-2px,  2px)  rotate(-2deg); }
+  56%  { opacity: 1; transform: translate(0,    0)     rotate(0deg);  }
+  96%  { opacity: 1; transform: translate(0,    0)     rotate(0deg);  }
+  100% { opacity: 0; transform: translate(0,    0)     rotate(0deg);  }
+}
+@keyframes oc-scatter-bl {
+  0%   { opacity: 0; transform: translate(0,     0)    rotate(0deg);  }
+  6%   { opacity: 1; transform: translate(0,     0)    rotate(0deg);  }
+  24%  { opacity: 1; transform: translate(-16px, 16px) rotate(15deg); }
+  38%  { opacity: 1; transform: translate(-16px, 16px) rotate(15deg); }
+  50%  { opacity: 1; transform: translate(2px,  -2px)  rotate(-2deg); }
+  56%  { opacity: 1; transform: translate(0,     0)    rotate(0deg);  }
+  96%  { opacity: 1; transform: translate(0,     0)    rotate(0deg);  }
+  100% { opacity: 0; transform: translate(0,     0)    rotate(0deg);  }
+}
+@keyframes oc-scatter-br {
+  0%   { opacity: 0; transform: translate(0,    0)    rotate(0deg);   }
+  6%   { opacity: 1; transform: translate(0,    0)    rotate(0deg);   }
+  24%  { opacity: 1; transform: translate(16px, 16px) rotate(-15deg); }
+  38%  { opacity: 1; transform: translate(16px, 16px) rotate(-15deg); }
+  50%  { opacity: 1; transform: translate(-2px,-2px)  rotate(2deg);   }
+  56%  { opacity: 1; transform: translate(0,    0)    rotate(0deg);   }
+  96%  { opacity: 1; transform: translate(0,    0)    rotate(0deg);   }
+  100% { opacity: 0; transform: translate(0,    0)    rotate(0deg);   }
+}
+
 /* === Fallback === */
 .mascot-fallback.is-animated .fallback-icon {
   animation: fallback-pulse 2s ease-in-out infinite;
@@ -1128,6 +1306,7 @@
   .mascot-antigravity.is-animated *,
   .mascot-copilot.is-animated *,
   .mascot-windsurf.is-animated *,
+  .mascot-opencode.is-animated *,
   .mascot-fallback.is-animated *,
   .mascot-claude.is-clicked,
   .mascot-claude.is-clicked *,
@@ -1141,6 +1320,8 @@
   .mascot-copilot.is-clicked *,
   .mascot-windsurf.is-clicked,
   .mascot-windsurf.is-clicked *,
+  .mascot-opencode.is-clicked,
+  .mascot-opencode.is-clicked *,
   .mascot-fallback.is-clicked * {
     animation: none;
     transition: none;

--- a/src/components/shared/agent-mascot/mascot.css
+++ b/src/components/shared/agent-mascot/mascot.css
@@ -1191,8 +1191,8 @@
 @keyframes oc-scatter-top {
   0%   { opacity: 0; transform: translate(0,    0)    rotate(0deg);  }
   6%   { opacity: 1; transform: translate(0,    0)    rotate(0deg);  }
-  24%  { opacity: 1; transform: translate(0,   -20px) rotate(-7deg); }
-  38%  { opacity: 1; transform: translate(0,   -20px) rotate(-7deg); }
+  24%  { opacity: 1; transform: translate(0,   -13px) rotate(-7deg); }
+  38%  { opacity: 1; transform: translate(0,   -13px) rotate(-7deg); }
   50%  { opacity: 1; transform: translate(0,    2px)  rotate(1deg);  }
   56%  { opacity: 1; transform: translate(0,    0)    rotate(0deg);  }
   96%  { opacity: 1; transform: translate(0,    0)    rotate(0deg);  }
@@ -1201,8 +1201,8 @@
 @keyframes oc-scatter-right {
   0%   { opacity: 0; transform: translate(0,    0)   rotate(0deg);  }
   6%   { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
-  24%  { opacity: 1; transform: translate(20px, 0)   rotate(7deg);  }
-  38%  { opacity: 1; transform: translate(20px, 0)   rotate(7deg);  }
+  24%  { opacity: 1; transform: translate(13px, 0)   rotate(7deg);  }
+  38%  { opacity: 1; transform: translate(13px, 0)   rotate(7deg);  }
   50%  { opacity: 1; transform: translate(-2px, 0)   rotate(-1deg); }
   56%  { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
   96%  { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
@@ -1211,8 +1211,8 @@
 @keyframes oc-scatter-bottom {
   0%   { opacity: 0; transform: translate(0,    0)   rotate(0deg);  }
   6%   { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
-  24%  { opacity: 1; transform: translate(0,   20px) rotate(7deg);  }
-  38%  { opacity: 1; transform: translate(0,   20px) rotate(7deg);  }
+  24%  { opacity: 1; transform: translate(0,   13px) rotate(7deg);  }
+  38%  { opacity: 1; transform: translate(0,   13px) rotate(7deg);  }
   50%  { opacity: 1; transform: translate(0,   -2px) rotate(-1deg); }
   56%  { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
   96%  { opacity: 1; transform: translate(0,    0)   rotate(0deg);  }
@@ -1221,8 +1221,8 @@
 @keyframes oc-scatter-left {
   0%   { opacity: 0; transform: translate(0,     0)  rotate(0deg);  }
   6%   { opacity: 1; transform: translate(0,     0)  rotate(0deg);  }
-  24%  { opacity: 1; transform: translate(-20px, 0)  rotate(-7deg); }
-  38%  { opacity: 1; transform: translate(-20px, 0)  rotate(-7deg); }
+  24%  { opacity: 1; transform: translate(-13px, 0)  rotate(-7deg); }
+  38%  { opacity: 1; transform: translate(-13px, 0)  rotate(-7deg); }
   50%  { opacity: 1; transform: translate(2px,   0)  rotate(1deg);  }
   56%  { opacity: 1; transform: translate(0,     0)  rotate(0deg);  }
   96%  { opacity: 1; transform: translate(0,     0)  rotate(0deg);  }
@@ -1233,8 +1233,8 @@
 @keyframes oc-scatter-tl {
   0%   { opacity: 0; transform: translate(0,     0)     rotate(0deg);   }
   6%   { opacity: 1; transform: translate(0,     0)     rotate(0deg);   }
-  24%  { opacity: 1; transform: translate(-16px,-16px)  rotate(-15deg); }
-  38%  { opacity: 1; transform: translate(-16px,-16px)  rotate(-15deg); }
+  24%  { opacity: 1; transform: translate(-10px,-10px)  rotate(-15deg); }
+  38%  { opacity: 1; transform: translate(-10px,-10px)  rotate(-15deg); }
   50%  { opacity: 1; transform: translate(2px,   2px)   rotate(2deg);   }
   56%  { opacity: 1; transform: translate(0,     0)     rotate(0deg);   }
   96%  { opacity: 1; transform: translate(0,     0)     rotate(0deg);   }
@@ -1243,8 +1243,8 @@
 @keyframes oc-scatter-tr {
   0%   { opacity: 0; transform: translate(0,    0)     rotate(0deg);  }
   6%   { opacity: 1; transform: translate(0,    0)     rotate(0deg);  }
-  24%  { opacity: 1; transform: translate(16px,-16px)  rotate(15deg); }
-  38%  { opacity: 1; transform: translate(16px,-16px)  rotate(15deg); }
+  24%  { opacity: 1; transform: translate(10px,-10px)  rotate(15deg); }
+  38%  { opacity: 1; transform: translate(10px,-10px)  rotate(15deg); }
   50%  { opacity: 1; transform: translate(-2px,  2px)  rotate(-2deg); }
   56%  { opacity: 1; transform: translate(0,    0)     rotate(0deg);  }
   96%  { opacity: 1; transform: translate(0,    0)     rotate(0deg);  }
@@ -1253,8 +1253,8 @@
 @keyframes oc-scatter-bl {
   0%   { opacity: 0; transform: translate(0,     0)    rotate(0deg);  }
   6%   { opacity: 1; transform: translate(0,     0)    rotate(0deg);  }
-  24%  { opacity: 1; transform: translate(-16px, 16px) rotate(15deg); }
-  38%  { opacity: 1; transform: translate(-16px, 16px) rotate(15deg); }
+  24%  { opacity: 1; transform: translate(-10px, 10px) rotate(15deg); }
+  38%  { opacity: 1; transform: translate(-10px, 10px) rotate(15deg); }
   50%  { opacity: 1; transform: translate(2px,  -2px)  rotate(-2deg); }
   56%  { opacity: 1; transform: translate(0,     0)    rotate(0deg);  }
   96%  { opacity: 1; transform: translate(0,     0)    rotate(0deg);  }
@@ -1263,8 +1263,8 @@
 @keyframes oc-scatter-br {
   0%   { opacity: 0; transform: translate(0,    0)    rotate(0deg);   }
   6%   { opacity: 1; transform: translate(0,    0)    rotate(0deg);   }
-  24%  { opacity: 1; transform: translate(16px, 16px) rotate(-15deg); }
-  38%  { opacity: 1; transform: translate(16px, 16px) rotate(-15deg); }
+  24%  { opacity: 1; transform: translate(10px, 10px) rotate(-15deg); }
+  38%  { opacity: 1; transform: translate(10px, 10px) rotate(-15deg); }
   50%  { opacity: 1; transform: translate(-2px,-2px)  rotate(2deg);   }
   56%  { opacity: 1; transform: translate(0,    0)    rotate(0deg);   }
   96%  { opacity: 1; transform: translate(0,    0)    rotate(0deg);   }

--- a/src/components/shared/agent-mascot/opencode-mascot.tsx
+++ b/src/components/shared/agent-mascot/opencode-mascot.tsx
@@ -1,0 +1,60 @@
+interface MascotSvgProps {
+  size: number;
+}
+
+export function OpencodeMascot({ size }: MascotSvgProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      style={{ overflow: "visible" }}
+    >
+      {/* Static icon */}
+      <g className="opencode-icon">
+        <path
+          className="opencode-outline"
+          d="M4 2h16v20H4z"
+          fill="none"
+          stroke="var(--mascot-icon-color)"
+          strokeWidth="2.2"
+          strokeLinejoin="round"
+        />
+        <rect
+          className="opencode-core"
+          x="8"
+          y="6"
+          width="8"
+          height="12"
+          fill="var(--mascot-icon-color)"
+        />
+      </g>
+
+      {/* Hover: snake traces the outline perimeter */}
+      <path
+        className="opencode-snake"
+        d="M4 2h16v20H4z"
+        fill="none"
+        stroke="var(--mascot-icon-color)"
+        strokeWidth="2.2"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+
+      {/* Click: mosaic pixel tiles */}
+      <g className="opencode-mosaic">
+        {/* Border strips approximating the outline stroke */}
+        <rect className="oc-tile" x="3" y="0.9" width="18" height="2.2" fill="var(--mascot-icon-color)" />
+        <rect className="oc-tile" x="18.9" y="0.9" width="2.2" height="21.2" fill="var(--mascot-icon-color)" />
+        <rect className="oc-tile" x="3" y="20.9" width="18" height="2.2" fill="var(--mascot-icon-color)" />
+        <rect className="oc-tile" x="2.9" y="0.9" width="2.2" height="21.2" fill="var(--mascot-icon-color)" />
+        {/* Inner rect split into 2×2 quadrants */}
+        <rect className="oc-tile" x="8"  y="6"  width="4" height="6" fill="var(--mascot-icon-color)" />
+        <rect className="oc-tile" x="12" y="6"  width="4" height="6" fill="var(--mascot-icon-color)" />
+        <rect className="oc-tile" x="8"  y="12" width="4" height="6" fill="var(--mascot-icon-color)" />
+        <rect className="oc-tile" x="12" y="12" width="4" height="6" fill="var(--mascot-icon-color)" />
+      </g>
+    </svg>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -87,6 +87,7 @@
   --agent-antigravity: oklch(0.58 0.12 250);
   --agent-copilot: oklch(0.52 0.14 290);
   --agent-windsurf: oklch(0.68 0.16 225);
+  --agent-opencode: oklch(0.52 0.07 250);
   --toast-success-bg: oklch(0.94 0.06 155);
   --toast-success-border: oklch(0.72 0.16 155);
   --toast-success-text: oklch(0.4 0.1 155);
@@ -180,6 +181,7 @@
   --agent-antigravity: oklch(0.72 0.1 250);
   --agent-copilot: oklch(0.72 0.12 290);
   --agent-windsurf: oklch(0.8 0.13 225);
+  --agent-opencode: oklch(0.76 0.06 250);
   --toast-success-bg: oklch(0.23 0.04 155);
   --toast-success-border: oklch(0.55 0.14 155);
   --toast-success-text: oklch(0.78 0.12 155);

--- a/src/index.css
+++ b/src/index.css
@@ -275,6 +275,7 @@
   --agent-antigravity: oklch(0.58 0.12 250);
   --agent-copilot: oklch(0.52 0.14 290);
   --agent-windsurf: oklch(0.68 0.16 225);
+  --agent-opencode: oklch(0.52 0.07 250);
   --toast-success-bg: oklch(0.94 0.06 155);
   --toast-success-border: oklch(0.65 0.15 155);
   --toast-success-text: oklch(0.4 0.1 155);
@@ -362,6 +363,7 @@
   --agent-antigravity: oklch(0.72 0.1 250);
   --agent-copilot: oklch(0.72 0.12 290);
   --agent-windsurf: oklch(0.8 0.13 225);
+  --agent-opencode: oklch(0.76 0.06 250);
   --toast-success-bg: oklch(0.26 0.04 155);
   --toast-success-border: oklch(0.55 0.14 155);
   --toast-success-text: oklch(0.78 0.12 155);
@@ -461,6 +463,7 @@
   --agent-antigravity: oklch(0.58 0.12 250);
   --agent-copilot: oklch(0.52 0.14 290);
   --agent-windsurf: oklch(0.68 0.16 225);
+  --agent-opencode: oklch(0.52 0.07 250);
   --toast-success-bg: oklch(0.94 0.06 155);
   --toast-success-border: oklch(0.72 0.16 155);
   --toast-success-text: oklch(0.4 0.1 155);
@@ -554,6 +557,7 @@
   --agent-antigravity: oklch(0.72 0.1 250);
   --agent-copilot: oklch(0.72 0.12 290);
   --agent-windsurf: oklch(0.8 0.13 225);
+  --agent-opencode: oklch(0.76 0.06 250);
   --toast-success-bg: oklch(0.23 0.04 155);
   --toast-success-border: oklch(0.55 0.14 155);
   --toast-success-text: oklch(0.78 0.12 155);
@@ -622,6 +626,7 @@ html.dark[data-theme="tiesen"][data-web="true"] {
   --color-agent-antigravity: var(--agent-antigravity);
   --color-agent-copilot: var(--agent-copilot);
   --color-agent-windsurf: var(--agent-windsurf);
+  --color-agent-opencode: var(--agent-opencode);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -219,8 +219,20 @@ describe("extensionGroupKey", () => {
 
 describe("sortAgentNames", () => {
   it("sorts agents in canonical order", () => {
-    const result = sortAgentNames(["windsurf", "cursor", "claude", "gemini"]);
-    expect(result).toEqual(["claude", "gemini", "cursor", "windsurf"]);
+    const result = sortAgentNames([
+      "opencode",
+      "windsurf",
+      "cursor",
+      "claude",
+      "gemini",
+    ]);
+    expect(result).toEqual([
+      "claude",
+      "gemini",
+      "cursor",
+      "windsurf",
+      "opencode",
+    ]);
   });
 
   it("puts unknown agents at the end", () => {
@@ -236,6 +248,7 @@ describe("agentDisplayName", () => {
     expect(agentDisplayName("codex")).toBe("Codex");
     expect(agentDisplayName("cursor")).toBe("Cursor");
     expect(agentDisplayName("windsurf")).toBe("Windsurf");
+    expect(agentDisplayName("opencode")).toBe("OpenCode");
   });
 
   it("capitalizes first letter for unknown agents", () => {

--- a/src/lib/agent-capabilities.ts
+++ b/src/lib/agent-capabilities.ts
@@ -21,6 +21,7 @@ const PROJECT_INSTALL_SUPPORT: Record<string, Set<ExtensionKind>> = {
   gemini: new Set(["skill"]), // MCP/hook adapter completion deferred (v2)
   antigravity: new Set(["skill"]), // MCP/hook adapter completion deferred (v2)
   copilot: new Set(["skill"]), // MCP adapter completion deferred (v2)
+  opencode: new Set(["skill", "mcp"]), // hook unsupported (HookFormat::None)
 };
 
 /** Whether the agent's adapter declares project-level support for this kind.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -267,6 +267,7 @@ export const AGENT_ORDER = [
   "antigravity",
   "copilot",
   "windsurf",
+  "opencode",
 ] as const;
 
 /** Sort an array of agents (or agent-like objects with a `name` field) by a given order. */
@@ -289,6 +290,7 @@ const AGENT_DISPLAY_NAMES: Record<string, string> = {
   antigravity: "Antigravity",
   copilot: "Copilot",
   windsurf: "Windsurf",
+  opencode: "OpenCode",
 };
 
 /** Get the display name for an agent (e.g. "claude" → "Claude Code"). */


### PR DESCRIPTION
## Summary

This PR adds OpenCode as a first-class agent in HarnessKit.

## What Changed

- registered OpenCode in the canonical agent list and UI metadata
- added OpenCode detection from the config directory, config file, or PATH
- added global OpenCode config discovery
- added OpenCode skill scanning
- added support for local MCP entries defined in opencode.json
- added support for local file-based plugins in the OpenCode plugins directory
- added OpenCode rules and workflow discovery
- updated branding and agent presentation for OpenCode

## Scope

This PR intentionally includes:

- agent detection
- global config discovery
- skills
- local MCP servers
- local file-based plugins
- rules
- workflows

This PR intentionally does not include:

- remote MCP servers
- npm-based plugins declared in opencode.json

## Screenshots

<img width="1034" height="214" alt="PixPin_2026-05-03_14-15-30" src="https://github.com/user-attachments/assets/3d5f01f5-3220-45e7-9a74-e3f0a0a12991" />

