### PR TITLE
feat(opencode): support jsonc configs with comment preservation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2e5dea04f54739ca5694ee06e4448ffda065a55b3427d2b131bd5ea697ea2c"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,6 +1854,7 @@ dependencies = [
  "dirs",
  "fs2",
  "glob",
+ "jsonc-parser",
  "lru",
  "notify",
  "openssl-sys",
@@ -2412,6 +2413,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonc-parser"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2e5dea04f54739ca5694ee06e4448ffda065a55b3427d2b131bd5ea697ea2c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/crates/hk-core/Cargo.toml
+++ b/crates/hk-core/Cargo.toml
@@ -14,6 +14,7 @@ regex = "1"
 toml = "0.8"
 dirs = "6"
 glob = "0.3"
+jsonc-parser = { version = "0.32", features = ["serde"] }
 
 lru = "0.12"
 parking_lot = "0.12"

--- a/crates/hk-core/Cargo.toml
+++ b/crates/hk-core/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1"
 toml = "0.8"
 dirs = "6"
 glob = "0.3"
-jsonc-parser = { version = "0.32", features = ["serde"] }
+jsonc-parser = { version = "0.32", features = ["serde", "serde_json", "cst"] }
 
 lru = "0.12"
 parking_lot = "0.12"

--- a/crates/hk-core/src/adapter/opencode.rs
+++ b/crates/hk-core/src/adapter/opencode.rs
@@ -1,4 +1,5 @@
 use super::{AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry, ProjectMarker};
+use crate::models::ConfigScope;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -26,7 +27,16 @@ impl OpencodeAdapter {
 
     fn parse_json(path: &Path) -> Option<serde_json::Value> {
         let content = std::fs::read_to_string(path).ok()?;
-        serde_json::from_str(&content).ok()
+        // OpenCode's own loader runs every config file through jsonc-parser
+        // (packages/opencode/src/config/config.ts: ConfigParse.jsonc), so a
+        // single `//` comment in the user's opencode.json — let alone an
+        // opencode.jsonc — would silently empty HK's MCP list under
+        // serde_json. Match upstream behavior by parsing the same superset.
+        jsonc_parser::parse_to_serde_value::<serde_json::Value>(
+            &content,
+            &Default::default(),
+        )
+        .ok()
     }
 
     fn files_with_ext(dir: &Path, ext: &str) -> Vec<PathBuf> {
@@ -62,6 +72,19 @@ impl OpencodeAdapter {
             Path::new(base).extension().and_then(|ext| ext.to_str()),
             Some("js" | "ts" | "mjs" | "cjs")
         )
+    }
+
+    /// Pick the OpenCode config file inside `base_dir`: `.jsonc` if it
+    /// exists, else `.json`. Used for both global (`~/.config/opencode`) and
+    /// project-scope (`<project>/`) lookups; the same precedence rule applies
+    /// because OpenCode treats them identically in both scopes.
+    fn pick_config_path(base_dir: &Path) -> PathBuf {
+        let jsonc = base_dir.join("opencode.jsonc");
+        if jsonc.is_file() {
+            jsonc
+        } else {
+            base_dir.join("opencode.json")
+        }
     }
 
     fn parse_local_mcp_entry(name: &str, value: &serde_json::Value) -> Option<McpServerEntry> {
@@ -146,7 +169,14 @@ impl AgentAdapter for OpencodeAdapter {
     }
 
     fn mcp_config_path(&self) -> PathBuf {
-        self.base_dir().join("opencode.json")
+        // Both opencode.json and opencode.jsonc are valid config filenames
+        // (https://opencode.ai/docs/config/). Prefer the .jsonc variant when
+        // it exists: OpenCode loads it second and its keys override .json on
+        // conflict, so HK's read picks the file whose values are actually in
+        // effect, and HK's writes target the file the user is using. Falls
+        // back to .json otherwise (matches the new-install default and keeps
+        // existing behavior for users who never adopted jsonc).
+        Self::pick_config_path(&self.base_dir())
     }
 
     fn hook_config_path(&self) -> PathBuf {
@@ -269,11 +299,25 @@ impl AgentAdapter for OpencodeAdapter {
 
     fn project_mcp_config_relpath(&self) -> Option<String> {
         // OpenCode reads MCP servers from the same opencode.json that holds
-        // every other setting; there is no separate `.mcp.json`. The single
-        // canonical name is preferred — users on .jsonc miss project-level
-        // MCP discovery, but that matches how every other adapter (Claude
-        // `.mcp.json`, Cursor `.cursor/mcp.json`) picks one canonical path.
+        // every other setting; there is no separate `.mcp.json`. We return
+        // the canonical .json name for callers that don't have project_path
+        // (e.g. capability flags). Smart .jsonc/.json picking happens in the
+        // overridden `mcp_config_path_for` below, where the project path is
+        // available to probe disk state.
         Some("opencode.json".into())
+    }
+
+    fn mcp_config_path_for(&self, scope: &ConfigScope) -> Option<PathBuf> {
+        // Override the default impl so project-scope discovery prefers an
+        // existing opencode.jsonc over .json when both are absent the same
+        // way as global scope. Without this, scanner.rs's is_file() gate on
+        // `<project>/opencode.json` would skip jsonc-only projects entirely.
+        match scope {
+            ConfigScope::Global => Some(self.mcp_config_path()),
+            ConfigScope::Project { path, .. } => {
+                Some(Self::pick_config_path(Path::new(path)))
+            }
+        }
     }
 
     fn project_plugin_dirs(&self) -> Vec<String> {
@@ -489,5 +533,113 @@ mod tests {
         // Hooks: OpenCode hooks are JS/TS plugin code, not JSON config, so
         // there is no project hook config file to discover. Stays None.
         assert_eq!(adapter.project_hook_config_relpath(), None);
+    }
+
+    #[test]
+    fn read_mcp_servers_accepts_jsonc_comments_in_dot_json() {
+        // OpenCode's loader runs every config file through jsonc-parser
+        // regardless of extension (packages/opencode/src/config/config.ts:
+        // ConfigParse.jsonc). The most common HK breakage isn't a .jsonc
+        // file at all — it's a user adding a `//` comment or trailing comma
+        // to opencode.json. With serde_json, HK silently empties the MCP
+        // list; we must match upstream's lenient parser.
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().join(".config/opencode");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("opencode.json"),
+            r#"{
+                // The fastest way to remember why a server is here.
+                "mcp": {
+                    "github": {
+                        "type": "local",
+                        "command": ["bin"],
+                    }, // trailing comma after server entry
+                },
+            }"#,
+        )
+        .unwrap();
+
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers();
+        assert_eq!(servers.len(), 1, "jsonc comments + trailing commas must parse");
+        assert_eq!(servers[0].name, "github");
+    }
+
+    #[test]
+    fn read_mcp_servers_picks_jsonc_when_present() {
+        // jsonc-only users had no MCP visibility at all under the old hardcoded
+        // opencode.json path. With smart selection in mcp_config_path(), HK
+        // now reads the file the user actually maintains.
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().join(".config/opencode");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("opencode.jsonc"),
+            r#"{
+                // jsonc-only setup
+                "mcp": { "alpha": { "type": "local", "command": ["bin"] } }
+            }"#,
+        )
+        .unwrap();
+
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        assert!(adapter.mcp_config_path().ends_with("opencode.jsonc"));
+        let servers = adapter.read_mcp_servers();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "alpha");
+    }
+
+    #[test]
+    fn mcp_config_path_prefers_jsonc_when_both_exist() {
+        // OpenCode loads .json first then .jsonc, with .jsonc keys overriding
+        // .json on conflict. HK reads (and writes) the file whose values are
+        // actually in effect: .jsonc when both exist, .json otherwise.
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().join(".config/opencode");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join("opencode.json"), "{}").unwrap();
+
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        assert!(adapter.mcp_config_path().ends_with("opencode.json"));
+
+        std::fs::write(config_dir.join("opencode.jsonc"), "{}").unwrap();
+        assert!(adapter.mcp_config_path().ends_with("opencode.jsonc"));
+    }
+
+    #[test]
+    fn mcp_config_path_for_project_scope_picks_existing_jsonc() {
+        // Default trait impl would always join `opencode.json` to project_path,
+        // missing jsonc-only projects. The override probes disk state.
+        let tmp = tempfile::tempdir().unwrap();
+        let project_path = tmp.path().join("my-project");
+        std::fs::create_dir_all(&project_path).unwrap();
+        std::fs::write(project_path.join("opencode.jsonc"), "{}").unwrap();
+
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        let scope = ConfigScope::Project {
+            name: "my-project".into(),
+            path: project_path.to_string_lossy().into_owned(),
+        };
+        let resolved = adapter.mcp_config_path_for(&scope).unwrap();
+        assert!(resolved.ends_with("opencode.jsonc"));
+    }
+
+    #[test]
+    fn mcp_config_path_for_falls_back_to_json_when_neither_exists() {
+        // New-install case: both files absent. Default to .json so write
+        // paths target a strict-JSON file (avoids exercising jsonc round-trip
+        // until the Tier 2 CST follow-up lands).
+        let tmp = tempfile::tempdir().unwrap();
+        let project_path = tmp.path().join("fresh-project");
+        std::fs::create_dir_all(&project_path).unwrap();
+
+        let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
+        let scope = ConfigScope::Project {
+            name: "fresh-project".into(),
+            path: project_path.to_string_lossy().into_owned(),
+        };
+        let resolved = adapter.mcp_config_path_for(&scope).unwrap();
+        assert!(resolved.ends_with("opencode.json"));
     }
 }

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -132,14 +132,18 @@ pub fn ensure_path_injection(entry: &mut crate::adapter::McpServerEntry) {
 /// here keeps that knowledge in one place and forces explicit handling of
 /// every JSON variant via the compiler-checked match.
 ///
-/// Toml is excluded — Codex's TOML format takes a separate code path in each
-/// caller and never reaches this function.
+/// Toml and Opencode are excluded — both formats route to dedicated
+/// functions (`*_toml` / `*_opencode`) before this helper is reached.
+/// Centralizing the format → key map this way forces every variant to be
+/// considered when a new MCP-supporting agent is added.
 fn json_top_key(format: McpFormat) -> &'static str {
     match format {
         McpFormat::McpServers => "mcpServers",
         McpFormat::Servers => "servers",
-        McpFormat::Opencode => "mcp",
         McpFormat::Toml => unreachable!("Toml format uses a separate TOML code path"),
+        McpFormat::Opencode => {
+            unreachable!("Opencode format routes through dedicated CST helpers")
+        }
     }
 }
 
@@ -252,7 +256,7 @@ fn deploy_mcp_server_toml(config_path: &Path, entry: &McpServerEntry) -> Result<
     Ok(())
 }
 
-/// JSON-based MCP deploy for OpenCode (`~/.config/opencode/opencode.json`).
+/// JSON-based MCP deploy for OpenCode (`~/.config/opencode/opencode.json[c]`).
 /// Schema reference: https://opencode.ai/config.json (McpLocalConfig).
 ///
 /// Differs from `mcpServers`/`servers` agents in four ways:
@@ -264,42 +268,53 @@ fn deploy_mcp_server_toml(config_path: &Path, entry: &McpServerEntry) -> Result<
 ///
 /// `additionalProperties: false` upstream means we must not emit any
 /// extra fields (e.g. no separate `args`/`env`).
+///
+/// Goes through `locked_modify_jsonc` so existing user comments and
+/// formatting in opencode.jsonc (or opencode.json — OpenCode's loader
+/// runs both through jsonc-parser) survive a deploy. Replaces an
+/// existing same-named entry in place rather than re-appending.
 fn deploy_mcp_server_opencode(
     config_path: &Path,
     entry: &McpServerEntry,
 ) -> Result<(), HkError> {
-    locked_modify_json(config_path, |config| {
-        let servers = config
-            .as_object_mut()
-            .ok_or_else(|| HkError::ConfigCorrupted("Config is not an object".into()))?
-            .entry("mcp")
-            .or_insert_with(|| serde_json::json!({}));
-
-        let mut command_array = vec![serde_json::Value::String(entry.command.clone())];
-        command_array.extend(entry.args.iter().cloned().map(serde_json::Value::String));
-
-        let mut server_obj = serde_json::Map::new();
-        server_obj.insert("type".into(), serde_json::Value::String("local".into()));
-        server_obj.insert("command".into(), serde_json::Value::Array(command_array));
-        if !entry.env.is_empty() {
-            server_obj.insert(
-                "environment".into(),
-                serde_json::Value::Object(
-                    entry
-                        .env
-                        .iter()
-                        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-                        .collect(),
-                ),
-            );
+    let value = build_opencode_mcp_value(entry);
+    locked_modify_jsonc(config_path, |root| {
+        let mcp = root.object_value_or_set("mcp");
+        let cst_value = to_cst_input(&value);
+        if let Some(existing) = mcp.get(&entry.name) {
+            existing.set_value(cst_value);
+        } else {
+            mcp.append(&entry.name, cst_value);
         }
-
-        servers
-            .as_object_mut()
-            .ok_or_else(|| HkError::ConfigCorrupted("mcp is not an object".into()))?
-            .insert(entry.name.clone(), serde_json::Value::Object(server_obj));
         Ok(())
     })
+}
+
+/// Build the `serde_json::Value` shape OpenCode's `McpLocalConfig` schema
+/// expects for one server entry. Shared by `deploy_mcp_server_opencode`
+/// (cross-agent install path) and intentionally also reachable as the
+/// "regenerate from McpServerEntry" reference. Schema invariants are
+/// documented at the parent function — keep them in sync.
+fn build_opencode_mcp_value(entry: &McpServerEntry) -> serde_json::Value {
+    let mut command_array = vec![serde_json::Value::String(entry.command.clone())];
+    command_array.extend(entry.args.iter().cloned().map(serde_json::Value::String));
+
+    let mut server_obj = serde_json::Map::new();
+    server_obj.insert("type".into(), serde_json::Value::String("local".into()));
+    server_obj.insert("command".into(), serde_json::Value::Array(command_array));
+    if !entry.env.is_empty() {
+        server_obj.insert(
+            "environment".into(),
+            serde_json::Value::Object(
+                entry
+                    .env
+                    .iter()
+                    .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                    .collect(),
+            ),
+        );
+    }
+    serde_json::Value::Object(server_obj)
 }
 
 /// Deploy a hook config entry into the target agent's config file.
@@ -458,6 +473,7 @@ pub fn remove_mcp_server(
             )?;
             Ok(())
         }
+        McpFormat::Opencode => remove_mcp_server_opencode(config_path, server_name),
         _ => locked_modify_json(config_path, |config| {
             let key = json_top_key(format);
             if let Some(servers) = config.get_mut(key).and_then(|v| v.as_object_mut()) {
@@ -466,6 +482,22 @@ pub fn remove_mcp_server(
             Ok(())
         }),
     }
+}
+
+/// Remove `server_name` from OpenCode's `mcp` block while preserving the
+/// rest of the file verbatim (comments, formatting, sibling entries).
+/// No-op if the server isn't present. Per the design decision in this PR,
+/// any leading user-comments next to the removed entry stay in place — HK
+/// never edits user comment text, only its own data entries.
+fn remove_mcp_server_opencode(config_path: &Path, server_name: &str) -> Result<(), HkError> {
+    locked_modify_jsonc(config_path, |root| {
+        if let Some(mcp) = root.object_value("mcp")
+            && let Some(prop) = mcp.get(server_name)
+        {
+            prop.remove();
+        }
+        Ok(())
+    })
 }
 
 /// Remove a specific hook command from a config file by event, matcher, and command.
@@ -618,6 +650,7 @@ pub fn restore_mcp_server(
             };
             deploy_mcp_server_toml(config_path, &mcp_entry)
         }
+        McpFormat::Opencode => restore_mcp_server_opencode(config_path, server_name, entry),
         _ => {
             let key = json_top_key(format);
             locked_modify_json(config_path, |config| {
@@ -634,6 +667,28 @@ pub fn restore_mcp_server(
             })
         }
     }
+}
+
+/// Restore a previously-saved entry into OpenCode's `mcp` block while
+/// preserving the rest of the file verbatim. Creates the `mcp` block if
+/// absent. Replaces an existing entry with the same name in place (rare
+/// but possible if the user re-enables an entry that's also been
+/// re-installed by another path).
+fn restore_mcp_server_opencode(
+    config_path: &Path,
+    server_name: &str,
+    entry: &serde_json::Value,
+) -> Result<(), HkError> {
+    locked_modify_jsonc(config_path, |root| {
+        let mcp = root.object_value_or_set("mcp");
+        let cst_value = to_cst_input(entry);
+        if let Some(existing) = mcp.get(server_name) {
+            existing.set_value(cst_value);
+        } else {
+            mcp.append(server_name, cst_value);
+        }
+        Ok(())
+    })
 }
 
 /// Restore a previously disabled hook entry into the config file.
@@ -1061,12 +1116,41 @@ pub fn read_mcp_server_config(
                 None => Ok(None),
             }
         }
+        McpFormat::Opencode => read_mcp_server_config_opencode(config_path, server_name),
         _ => {
             let config = read_or_create_json(config_path)?;
             let key = json_top_key(format);
             Ok(config.get(key).and_then(|v| v.get(server_name)).cloned())
         }
     }
+}
+
+/// Read a single OpenCode MCP entry's value as `serde_json::Value`. Tolerant
+/// of jsonc syntax (`//` comments, trailing commas) since OpenCode's loader
+/// accepts the same superset for both `opencode.json` and `opencode.jsonc`.
+/// Returns `None` if the file lacks `mcp` or that specific entry. Read-only,
+/// no advisory lock — locks would only matter if we were modifying.
+fn read_mcp_server_config_opencode(
+    config_path: &Path,
+    server_name: &str,
+) -> Result<Option<serde_json::Value>, HkError> {
+    use jsonc_parser::cst::CstRootNode;
+    let content = std::fs::read_to_string(config_path)?;
+    if content.is_empty() {
+        return Ok(None);
+    }
+    let cst = CstRootNode::parse(&content, &Default::default())
+        .map_err(|e| HkError::ConfigCorrupted(format!("Failed to parse jsonc: {e}")))?;
+    let Some(root) = cst.object_value() else {
+        return Ok(None);
+    };
+    let Some(prop) = root
+        .object_value("mcp")
+        .and_then(|mcp| mcp.get(server_name))
+    else {
+        return Ok(None);
+    };
+    Ok(prop.to_serde_value())
 }
 
 /// Read a hook entry's full JSON value from a config file.
@@ -1182,6 +1266,90 @@ fn atomic_write(path: &Path, content: &str) -> Result<(), HkError> {
     Ok(())
 }
 
+/// Convert a `serde_json::Value` into the `CstInputValue` shape that
+/// `jsonc-parser`'s CST mutation API expects. Used by OpenCode write paths
+/// to feed existing serde-shaped entries (read off McpServerEntry, restored
+/// off SQLite undo log, etc.) through CST `append` / `set_value`.
+///
+/// Note on key ordering: `serde_json::Value::Object` maps to
+/// `serde_json::Map`, which is alphabetically sorted unless the
+/// `preserve_order` feature is enabled (it isn't, here). New entries
+/// therefore land with alphabetized keys — the same behavior as the
+/// existing `to_string_pretty` path, so this isn't a regression.
+fn to_cst_input(v: &serde_json::Value) -> jsonc_parser::cst::CstInputValue {
+    use jsonc_parser::cst::CstInputValue;
+    match v {
+        serde_json::Value::Null => CstInputValue::Null,
+        serde_json::Value::Bool(b) => CstInputValue::Bool(*b),
+        serde_json::Value::Number(n) => CstInputValue::Number(n.to_string()),
+        serde_json::Value::String(s) => CstInputValue::String(s.clone()),
+        serde_json::Value::Array(arr) => {
+            CstInputValue::Array(arr.iter().map(to_cst_input).collect())
+        }
+        serde_json::Value::Object(obj) => CstInputValue::Object(
+            obj.iter().map(|(k, v)| (k.clone(), to_cst_input(v))).collect(),
+        ),
+    }
+}
+
+/// Read-modify-write a jsonc-flavored config file with an exclusive advisory
+/// file lock, preserving comments and formatting outside the modified area.
+///
+/// Mirrors `locked_modify_json`'s lock-and-rewrite semantics (no rename, so
+/// the advisory lock isn't dropped mid-write), but parses with the CST API
+/// instead of `serde_json::Value`. The closure receives the root `CstObject`
+/// and operates on it via `get` / `append` / `object_value_or_set` / etc.
+/// Comments and whitespace surrounding unmodified entries are kept verbatim.
+///
+/// Used today only by OpenCode write paths — both `opencode.json` and
+/// `opencode.jsonc` flow through here. Other agents' formats stay on
+/// `locked_modify_json` (strict JSON), so the CST dependency only loads
+/// when a McpFormat::Opencode dispatch lands here.
+fn locked_modify_jsonc<F>(path: &Path, modify: F) -> Result<(), HkError>
+where
+    F: FnOnce(&jsonc_parser::cst::CstObject) -> Result<(), HkError>,
+{
+    use jsonc_parser::cst::CstRootNode;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    file.lock_exclusive()?;
+
+    let mut content = String::new();
+    (&file).read_to_string(&mut content)?;
+    // Empty file → seed with "{}" so CstRootNode::parse always sees an
+    // object root. Avoids bailing on a freshly-created config file whose
+    // first write would otherwise be the root entry itself.
+    let seed = if content.is_empty() { "{}" } else { content.as_str() };
+
+    let cst = CstRootNode::parse(seed, &Default::default())
+        .map_err(|e| HkError::ConfigCorrupted(format!("Failed to parse jsonc: {e}")))?;
+    // Fail fast if root is non-object (e.g. user wrote `[1,2,3]` at top
+    // level). `object_value_or_set` would silently destroy the array — we
+    // refuse to do that.
+    let root_obj = cst
+        .object_value()
+        .ok_or_else(|| HkError::ConfigCorrupted("Config root is not an object".into()))?;
+
+    modify(&root_obj)?;
+
+    let output = cst.to_string();
+    (&file).seek(SeekFrom::Start(0))?;
+    file.set_len(0)?;
+    (&file).write_all(output.as_bytes())?;
+    (&file).flush()?;
+
+    file.unlock()?;
+    Ok(())
+}
+
 /// Read-modify-write a JSON config file with an exclusive advisory file lock.
 fn locked_modify_json<F>(path: &Path, modify: F) -> Result<(), HkError>
 where
@@ -1222,6 +1390,159 @@ where
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    // ----- jsonc / OpenCode-specific tests -----
+    // Helper tests pin `locked_modify_jsonc` round-trip and edge cases.
+    // End-to-end tests pin the public MCP API (deploy/remove/restore)
+    // through `McpFormat::Opencode` for the comment-preservation contract.
+
+    #[test]
+    fn locked_modify_jsonc_round_trip_preserves_comments() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("opencode.jsonc");
+        let original = "{\n  // hello\n  \"a\": 1, // trailing line comment\n  \"b\": [1, 2,], /* block */\n}\n";
+        std::fs::write(&path, original).unwrap();
+
+        locked_modify_jsonc(&path, |_root| Ok(())).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn locked_modify_jsonc_appends_into_mcp_keeping_neighbor_comments() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("opencode.jsonc");
+        std::fs::write(
+            &path,
+            "{\n  // top note\n  \"model\": \"x\",\n  \"mcp\": {\n    // about github\n    \"github\": {\"type\": \"local\", \"command\": [\"a\"]}\n  }\n}\n",
+        )
+        .unwrap();
+
+        locked_modify_jsonc(&path, |root| {
+            let mcp = root.object_value_or_set("mcp");
+            mcp.append(
+                "filesystem",
+                to_cst_input(&serde_json::json!({"type": "local", "command": ["b"]})),
+            );
+            Ok(())
+        })
+        .unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("// top note"), "top-level comment dropped");
+        assert!(written.contains("// about github"), "mcp child comment dropped");
+        assert!(written.contains("\"github\""), "existing entry lost");
+        assert!(written.contains("\"filesystem\""), "appended entry missing");
+    }
+
+    #[test]
+    fn locked_modify_jsonc_rejects_non_object_root() {
+        // Refuse to silently overwrite a top-level array — better to error
+        // than to destroy data. Mirrors locked_modify_json's behavior.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("weird.jsonc");
+        std::fs::write(&path, "[1, 2, 3]").unwrap();
+
+        let err = locked_modify_jsonc(&path, |_| Ok(()));
+        assert!(matches!(err, Err(HkError::ConfigCorrupted(_))));
+        // File untouched.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "[1, 2, 3]");
+    }
+
+    #[test]
+    fn locked_modify_jsonc_seeds_empty_file_with_object() {
+        // First-time write to an empty/non-existent file: seed with `{}`
+        // so the helper has a valid object root to operate on.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("fresh.jsonc");
+
+        locked_modify_jsonc(&path, |root| {
+            root.append("mcp", to_cst_input(&serde_json::json!({})));
+            Ok(())
+        })
+        .unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("\"mcp\""));
+        let _: serde_json::Value = serde_json::from_str(&written).unwrap();
+    }
+
+    #[test]
+    fn test_remove_mcp_server_opencode_preserves_comments() {
+        // End-to-end: remove only the targeted entry; surrounding user
+        // comments and sibling entries stay verbatim. The comment that
+        // was directly above the removed entry stays as an "orphan" by
+        // design — HK never edits user comment text.
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("opencode.jsonc");
+        std::fs::write(
+            &config,
+            "{\n  // top note\n  \"model\": \"x\",\n  \"mcp\": {\n    // about github\n    \"github\": {\"type\": \"local\", \"command\": [\"a\"]},\n    // about filesystem\n    \"filesystem\": {\"type\": \"local\", \"command\": [\"b\"]}\n  }\n}\n",
+        )
+        .unwrap();
+
+        remove_mcp_server(&config, "github", McpFormat::Opencode).unwrap();
+
+        let written = std::fs::read_to_string(&config).unwrap();
+        assert!(written.contains("// top note"));
+        assert!(written.contains("// about filesystem"), "sibling comment dropped");
+        assert!(written.contains("\"filesystem\""), "sibling entry lost");
+        assert!(!written.contains("\"github\""), "target entry not removed");
+    }
+
+    #[test]
+    fn test_restore_mcp_server_opencode_preserves_comments() {
+        // End-to-end: restoring a previously-saved entry into mcp keeps
+        // every other comment, formatting, and sibling intact. Mirrors
+        // the HK toggle flow (disable → restore).
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("opencode.jsonc");
+        std::fs::write(
+            &config,
+            "{\n  // top note\n  \"model\": \"x\",\n  \"mcp\": {\n    // about github\n    \"github\": {\"type\": \"local\", \"command\": [\"a\"]}\n  }\n}\n",
+        )
+        .unwrap();
+
+        let saved = serde_json::json!({"type": "local", "command": ["b"]});
+        restore_mcp_server(&config, "filesystem", &saved, McpFormat::Opencode).unwrap();
+
+        let written = std::fs::read_to_string(&config).unwrap();
+        assert!(written.contains("// top note"));
+        assert!(written.contains("// about github"));
+        assert!(written.contains("\"github\""), "existing entry lost");
+        assert!(written.contains("\"filesystem\""), "restored entry missing");
+    }
+
+    #[test]
+    fn test_deploy_mcp_server_opencode_preserves_comments() {
+        // End-to-end guarantee for the deploy path (cross-agent install
+        // into OpenCode): existing user comments and formatting outside
+        // the touched mcp entry survive intact.
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("opencode.jsonc");
+        std::fs::write(
+            &config,
+            "{\n  // top note kept\n  \"model\": \"claude-opus-4\",\n  \"mcp\": {\n    // about github\n    \"github\": {\"type\": \"local\", \"command\": [\"existing\"]}\n  }\n}\n",
+        )
+        .unwrap();
+
+        let entry = McpServerEntry {
+            name: "filesystem".into(),
+            command: "npx".into(),
+            args: vec!["-y".into(), "@mcp/fs".into()],
+            env: std::collections::HashMap::new(),
+            enabled: true,
+        };
+        deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
+
+        let written = std::fs::read_to_string(&config).unwrap();
+        assert!(written.contains("// top note kept"), "top-level comment dropped");
+        assert!(written.contains("// about github"), "mcp child comment dropped");
+        assert!(written.contains("\"github\""), "existing entry lost");
+        assert!(written.contains("\"filesystem\""), "deployed entry missing");
+        assert!(written.contains("\"npx\""), "deployed entry's command missing");
+    }
+
+    // ----- existing tests below -----
 
     #[test]
     fn test_deploy_skill_directory() {

--- a/crates/hk-core/src/scanner.rs
+++ b/crates/hk-core/src/scanner.rs
@@ -884,72 +884,77 @@ pub fn scan_project_extensions(
     }
 
     // --- Project-scoped MCP servers ---
-    if let Some(rel) = adapter.project_mcp_config_relpath() {
-        let mcp_path = project_path.join(&rel);
-        if mcp_path.is_file() {
-            let mcp_path_str = mcp_path.to_string_lossy().to_string();
-            let config_created = file_created_time(&mcp_path);
-            let config_modified = file_modified_time(&mcp_path);
-            for server in adapter.read_mcp_servers_from(&mcp_path) {
-                let cmd_basename = Path::new(&server.command)
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .to_string();
+    // Resolve via `mcp_config_path_for(scope)` instead of joining
+    // `project_mcp_config_relpath()` directly. The default trait impl is
+    // equivalent for adapters that use a single canonical filename (Claude,
+    // Cursor, etc.), but it gives OpenCode a hook to prefer an existing
+    // opencode.jsonc over opencode.json — without this, jsonc-only projects
+    // would silently miss the is_file() gate below.
+    if let Some(mcp_path) = adapter.mcp_config_path_for(&scope)
+        && mcp_path.is_file()
+    {
+        let mcp_path_str = mcp_path.to_string_lossy().to_string();
+        let config_created = file_created_time(&mcp_path);
+        let config_modified = file_modified_time(&mcp_path);
+        for server in adapter.read_mcp_servers_from(&mcp_path) {
+            let cmd_basename = Path::new(&server.command)
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
 
-                let mut permissions = Vec::new();
-                if !server.env.is_empty() {
-                    permissions.push(Permission::Env {
-                        keys: server.env.keys().cloned().collect(),
-                    });
-                }
-                permissions.push(Permission::Shell {
-                    commands: vec![cmd_basename.clone()],
-                });
-
-                let description = if cmd_basename == "npx" || cmd_basename == "uvx" {
-                    let pkg = server.args.iter().rfind(|a| !a.starts_with('-'));
-                    match pkg {
-                        Some(p) => format!("Runs {} via {}", p, cmd_basename),
-                        None => format!("Runs via {}", cmd_basename),
-                    }
-                } else {
-                    format!("Runs {}", cmd_basename)
-                };
-
-                let id = stable_id_with_scope(&server.name, "mcp", adapter.name(), &scope);
-                all.push(Extension {
-                    id,
-                    kind: ExtensionKind::Mcp,
-                    name: server.name,
-                    description,
-                    source: Source {
-                        origin: SourceOrigin::Agent,
-                        url: None,
-                        version: None,
-                        commit_hash: None,
-                    },
-                    agents: vec![adapter.name().to_string()],
-                    tags: vec![],
-                    pack: None,
-                    permissions,
-                    // Reflect the agent's enabled state — see global-scope
-                    // counterpart above for the cross-adapter invariant.
-                    enabled: server.enabled,
-                    trust_score: None,
-                    installed_at: config_created,
-                    updated_at: config_modified,
-                    // Surface the project's MCP config file so the UI's Paths
-                    // panel can locate this entry on disk. Global MCP/hook
-                    // entries leave this as None and the UI falls back to the
-                    // adapter's global config path lookup.
-                    source_path: Some(mcp_path_str.clone()),
-                    cli_parent_id: None,
-                    cli_meta: None,
-                    install_meta: None,
-                    scope: scope.clone(),
+            let mut permissions = Vec::new();
+            if !server.env.is_empty() {
+                permissions.push(Permission::Env {
+                    keys: server.env.keys().cloned().collect(),
                 });
             }
+            permissions.push(Permission::Shell {
+                commands: vec![cmd_basename.clone()],
+            });
+
+            let description = if cmd_basename == "npx" || cmd_basename == "uvx" {
+                let pkg = server.args.iter().rfind(|a| !a.starts_with('-'));
+                match pkg {
+                    Some(p) => format!("Runs {} via {}", p, cmd_basename),
+                    None => format!("Runs via {}", cmd_basename),
+                }
+            } else {
+                format!("Runs {}", cmd_basename)
+            };
+
+            let id = stable_id_with_scope(&server.name, "mcp", adapter.name(), &scope);
+            all.push(Extension {
+                id,
+                kind: ExtensionKind::Mcp,
+                name: server.name,
+                description,
+                source: Source {
+                    origin: SourceOrigin::Agent,
+                    url: None,
+                    version: None,
+                    commit_hash: None,
+                },
+                agents: vec![adapter.name().to_string()],
+                tags: vec![],
+                pack: None,
+                permissions,
+                // Reflect the agent's enabled state — see global-scope
+                // counterpart above for the cross-adapter invariant.
+                enabled: server.enabled,
+                trust_score: None,
+                installed_at: config_created,
+                updated_at: config_modified,
+                // Surface the project's MCP config file so the UI's Paths
+                // panel can locate this entry on disk. Global MCP/hook
+                // entries leave this as None and the UI falls back to the
+                // adapter's global config path lookup.
+                source_path: Some(mcp_path_str.clone()),
+                cli_parent_id: None,
+                cli_meta: None,
+                install_meta: None,
+                scope: scope.clone(),
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- HK silently emptied OpenCode users' MCP list whenever their `opencode.json[c]` had a `//` comment or trailing comma — `serde_json::from_str` rejects what OpenCode itself happily parses (its loader runs both extensions through jsonc-parser). Now `OpencodeAdapter::parse_json` matches upstream, and `mcp_config_path[_for]` smart-picks an existing `.jsonc` over `.json` (matches OpenCode's load-order precedence).
- Disable / Enable / Delete / cross-agent install of an OpenCode MCP entry no longer destroys user comments and formatting. Each `McpFormat::Opencode` dispatch routes to a dedicated function backed by a new `locked_modify_jsonc` helper that round-trips the file through jsonc-parser's CST API; everything outside the touched entry stays verbatim.
- Other JSON-format agents (Claude `.mcp.json`, Cursor, Antigravity, Copilot, Gemini) keep their strict `serde_json` path — accidentally accepting jsonc syntax in their configs would surface entries the agent itself can't load.

## Design notes
- Format-driven dispatch, not filename sniffing: `McpFormat::Opencode` goes through `*_opencode` functions, regardless of `.json` vs `.jsonc` extension. `json_top_key`'s Opencode arm is hardened to `unreachable!()` so any future regression that re-routes through the generic JSON path fails loudly.
- Scanner gains `mcp_config_path_for(&scope)` instead of joining `project_mcp_config_relpath()` directly. Default trait impl is no-op for adapters with a single canonical filename — only OpenCode overrides to probe disk state, so jsonc-only projects are now discoverable.
- A comment line directly above a removed entry is left in place by design — HK never edits user comment text, only its own data entries. The orphan is the user's content to keep or clean up.
- New dep: `jsonc-parser` 0.32 with `serde + serde_json + cst` features. Same library OpenCode uses (TS twin); also Deno's pinned dep. Active, 1.5M dl/90d.

## Test plan
- [x] `cargo test -p hk-core --lib` — 376 passed (12 new)
- [x] `cargo clippy -p hk-core --lib --tests -- -D warnings` clean
- [x] `cargo build --workspace` — hk-core / hk-web / hk-desktop / hk-cli all pass
- [x] Manual UI smoke test on `/private/tmp/hk-opencode-test/opencode.jsonc` (with `//` comments + trailing comma):
  - [x] HK reads all 3 MCP entries (was 0 before fix)
  - [x] Disable preserves all comments and sibling entries
  - [x] Enable preserves all comments and sibling entries
  - [x] Delete preserves all comments and sibling entries
- [ ] Cross-agent deploy into OpenCode at project scope: not exercised manually (frontend `projectScopeBlocked` gate); covered by unit test `test_deploy_mcp_server_opencode_preserves_comments` and shares CST code path with restore/enable

## Out of scope (explicit)
- Read-merge of co-existing `.json` and `.jsonc` (HK picks `.jsonc` when both present, matching OpenCode's load-order winner; merging both into a single read is roadmap'd as a P2 follow-up).
- Comment-attached-to-entry tracking on remove: HK leaves orphans intact; programmatic distinction between "section header" and "entry note" comments is not attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)