### PR TITLE
feat: scan project-level subagents across 6 agents

### DIFF
--- a/crates/hk-core/src/adapter/claude.rs
+++ b/crates/hk-core/src/adapter/claude.rs
@@ -217,16 +217,6 @@ impl AgentAdapter for ClaudeAdapter {
             self.base_dir().join("settings.local.json"),
             self.base_dir().join("keybindings.json"),
         ];
-        // ~/.claude/agents/*.md
-        let agents_dir = self.base_dir().join("agents");
-        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "md") {
-                    files.push(p);
-                }
-            }
-        }
         // ~/.claude/commands/*.md (legacy, still functional)
         let commands_dir = self.base_dir().join("commands");
         if let Ok(entries) = std::fs::read_dir(&commands_dir) {
@@ -240,6 +230,21 @@ impl AgentAdapter for ClaudeAdapter {
         // ~/.claude/output-styles/*.md
         let styles_dir = self.base_dir().join("output-styles");
         if let Ok(entries) = std::fs::read_dir(&styles_dir) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.extension().is_some_and(|e| e == "md") {
+                    files.push(p);
+                }
+            }
+        }
+        files
+    }
+
+    fn global_subagent_files(&self) -> Vec<PathBuf> {
+        // ~/.claude/agents/*.md
+        let mut files = Vec::new();
+        let agents_dir = self.base_dir().join("agents");
+        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
             for entry in entries.flatten() {
                 let p = entry.path();
                 if p.extension().is_some_and(|e| e == "md") {
@@ -271,6 +276,10 @@ impl AgentAdapter for ClaudeAdapter {
             ".claude/settings.local.json".into(),
             ".mcp.json".into(),
         ]
+    }
+
+    fn project_subagent_patterns(&self) -> Vec<String> {
+        vec![".claude/agents/*.md".into()]
     }
 
     fn project_ignore_patterns(&self) -> Vec<String> {
@@ -478,5 +487,40 @@ mod tests {
 
         let project_ignore = adapter.project_ignore_patterns();
         assert!(project_ignore.is_empty());
+    }
+
+    #[test]
+    fn test_claude_subagent_methods() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = ClaudeAdapter::with_home(tmp.path().to_path_buf());
+
+        // Missing agents/ dir → empty.
+        assert!(adapter.global_subagent_files().is_empty());
+
+        // Populate agents/ with one .md and one non-.md (must be filtered).
+        let agents_dir = adapter.base_dir().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(agents_dir.join("reviewer.md"), "# reviewer").unwrap();
+        std::fs::write(agents_dir.join("notes.txt"), "ignore me").unwrap();
+
+        let subagents = adapter.global_subagent_files();
+        assert!(subagents.iter().any(|p| p.ends_with("agents/reviewer.md")));
+        assert!(
+            !subagents.iter().any(|p| p.ends_with("notes.txt")),
+            "non-.md files in agents/ must be filtered"
+        );
+
+        // Subagent dir contents must NOT leak into settings anymore.
+        let settings = adapter.global_settings_files();
+        assert!(
+            !settings.iter().any(|p| p.ends_with("agents/reviewer.md")),
+            "agents/ moved to global_subagent_files; must not appear in settings"
+        );
+
+        // Project pattern is the canonical .claude/agents/*.md.
+        assert_eq!(
+            adapter.project_subagent_patterns(),
+            vec![".claude/agents/*.md".to_string()]
+        );
     }
 }

--- a/crates/hk-core/src/adapter/claude.rs
+++ b/crates/hk-core/src/adapter/claude.rs
@@ -242,17 +242,7 @@ impl AgentAdapter for ClaudeAdapter {
 
     fn global_subagent_files(&self) -> Vec<PathBuf> {
         // ~/.claude/agents/*.md
-        let mut files = Vec::new();
-        let agents_dir = self.base_dir().join("agents");
-        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "md") {
-                    files.push(p);
-                }
-            }
-        }
-        files
+        super::files_with_ext(&self.base_dir().join("agents"), "md").collect()
     }
 
     fn project_markers(&self) -> Vec<ProjectMarker> {

--- a/crates/hk-core/src/adapter/codex.rs
+++ b/crates/hk-core/src/adapter/codex.rs
@@ -79,6 +79,22 @@ impl AgentAdapter for CodexAdapter {
         ]
     }
 
+    fn global_subagent_files(&self) -> Vec<PathBuf> {
+        // ~/.codex/agents/*.toml (Codex CLI subagents)
+        // Source: https://developers.openai.com/codex/subagents
+        let mut files = Vec::new();
+        let agents_dir = self.base_dir().join("agents");
+        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.extension().is_some_and(|e| e == "toml") {
+                    files.push(p);
+                }
+            }
+        }
+        files
+    }
+
     fn global_memory_files(&self) -> Vec<PathBuf> {
         let mut files = Vec::new();
         let memories_dir = self.base_dir().join("memories");
@@ -103,6 +119,10 @@ impl AgentAdapter for CodexAdapter {
 
     fn project_settings_patterns(&self) -> Vec<String> {
         vec![".codex/config.toml".into()]
+    }
+
+    fn project_subagent_patterns(&self) -> Vec<String> {
+        vec![".codex/agents/*.toml".into()]
     }
 
     fn project_skill_dirs(&self) -> Vec<String> {
@@ -485,5 +505,33 @@ enabled = false
         assert_eq!(hooks.len(), 1);
         assert_eq!(hooks[0].event, "PreToolUse");
         assert_eq!(hooks[0].command, "echo test");
+    }
+
+    #[test]
+    fn test_codex_subagent_methods() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
+
+        // Missing agents/ dir → empty.
+        assert!(adapter.global_subagent_files().is_empty());
+
+        // Codex subagents are TOML, not Markdown.
+        // Source: https://developers.openai.com/codex/subagents
+        let agents_dir = adapter.base_dir().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(agents_dir.join("reviewer.toml"), "name = \"reviewer\"").unwrap();
+        fs::write(agents_dir.join("notes.md"), "ignore — wrong ext").unwrap();
+
+        let subagents = adapter.global_subagent_files();
+        assert!(subagents.iter().any(|p| p.ends_with("agents/reviewer.toml")));
+        assert!(
+            !subagents.iter().any(|p| p.ends_with("notes.md")),
+            ".md files in Codex agents/ must be filtered (Codex uses .toml)"
+        );
+
+        assert_eq!(
+            adapter.project_subagent_patterns(),
+            vec![".codex/agents/*.toml".to_string()]
+        );
     }
 }

--- a/crates/hk-core/src/adapter/codex.rs
+++ b/crates/hk-core/src/adapter/codex.rs
@@ -82,17 +82,7 @@ impl AgentAdapter for CodexAdapter {
     fn global_subagent_files(&self) -> Vec<PathBuf> {
         // ~/.codex/agents/*.toml (Codex CLI subagents)
         // Source: https://developers.openai.com/codex/subagents
-        let mut files = Vec::new();
-        let agents_dir = self.base_dir().join("agents");
-        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "toml") {
-                    files.push(p);
-                }
-            }
-        }
-        files
+        super::files_with_ext(&self.base_dir().join("agents"), "toml").collect()
     }
 
     fn global_memory_files(&self) -> Vec<PathBuf> {

--- a/crates/hk-core/src/adapter/copilot.rs
+++ b/crates/hk-core/src/adapter/copilot.rs
@@ -170,21 +170,13 @@ impl AgentAdapter for CopilotAdapter {
         // Per Copilot docs the canonical naming is `<name>.agent.md`; require
         // the `.agent` segment so plain `.md` notes left in this dir aren't
         // misclassified as subagents.
-        let mut files = Vec::new();
-        let agents_dir = self.base_dir().join("agents");
-        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "md")
-                    && p.file_stem()
-                        .and_then(|s| s.to_str())
-                        .is_some_and(|stem| stem.ends_with(".agent"))
-                {
-                    files.push(p);
-                }
-            }
-        }
-        files
+        super::files_with_ext(&self.base_dir().join("agents"), "md")
+            .filter(|p| {
+                p.file_stem()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|stem| stem.ends_with(".agent"))
+            })
+            .collect()
     }
 
     fn project_markers(&self) -> Vec<ProjectMarker> {

--- a/crates/hk-core/src/adapter/copilot.rs
+++ b/crates/hk-core/src/adapter/copilot.rs
@@ -152,22 +152,34 @@ impl AgentAdapter for CopilotAdapter {
             self.base_dir().join("config.json"),
             self.vscode_user_dir().join("mcp.json"),
         ];
-        // ~/.copilot/agents/*.agent.md
-        let agents_dir = self.base_dir().join("agents");
-        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "md") {
-                    files.push(p);
-                }
-            }
-        }
         // ~/.copilot/hooks/*.json
         let hooks_dir = self.base_dir().join("hooks");
         if let Ok(entries) = std::fs::read_dir(&hooks_dir) {
             for entry in entries.flatten() {
                 let p = entry.path();
                 if p.extension().is_some_and(|e| e == "json") {
+                    files.push(p);
+                }
+            }
+        }
+        files
+    }
+
+    fn global_subagent_files(&self) -> Vec<PathBuf> {
+        // ~/.copilot/agents/*.agent.md
+        // Per Copilot docs the canonical naming is `<name>.agent.md`; require
+        // the `.agent` segment so plain `.md` notes left in this dir aren't
+        // misclassified as subagents.
+        let mut files = Vec::new();
+        let agents_dir = self.base_dir().join("agents");
+        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.extension().is_some_and(|e| e == "md")
+                    && p.file_stem()
+                        .and_then(|s| s.to_str())
+                        .is_some_and(|stem| stem.ends_with(".agent"))
+                {
                     files.push(p);
                 }
             }
@@ -195,6 +207,10 @@ impl AgentAdapter for CopilotAdapter {
             "copilot/mcp-config.json".into(),
             ".github/hooks/*.json".into(),
         ]
+    }
+
+    fn project_subagent_patterns(&self) -> Vec<String> {
+        vec![".github/agents/*.agent.md".into()]
     }
 
     fn project_ignore_patterns(&self) -> Vec<String> {
@@ -471,5 +487,51 @@ mod tests {
         assert_eq!(plugins[0].name, "my-plugin");
         assert_eq!(plugins[0].source, "user/my-repo");
         assert!(plugins[0].path.is_some());
+    }
+
+    #[test]
+    fn test_copilot_subagent_methods() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = CopilotAdapter::with_home(tmp.path().to_path_buf());
+
+        assert!(adapter.global_subagent_files().is_empty());
+
+        // Copilot subagent files use the `*.agent.md` naming convention.
+        // The filter requires the `.agent` stem segment so plain `*.md` files
+        // left in agents/ are not misclassified as subagents.
+        let agents_dir = adapter.base_dir().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(agents_dir.join("reviewer.agent.md"), "# reviewer").unwrap();
+        std::fs::write(agents_dir.join("draft.md"), "scratch note, not a subagent").unwrap();
+        std::fs::write(agents_dir.join("notes.txt"), "ignore me").unwrap();
+
+        let subagents = adapter.global_subagent_files();
+        assert!(
+            subagents
+                .iter()
+                .any(|p| p.ends_with("agents/reviewer.agent.md")),
+            "*.agent.md must be picked up"
+        );
+        assert!(
+            !subagents.iter().any(|p| p.ends_with("draft.md")),
+            "plain *.md without .agent stem must be filtered"
+        );
+        assert!(
+            !subagents.iter().any(|p| p.ends_with("notes.txt")),
+            "non-.md files in agents/ must be filtered"
+        );
+
+        let settings = adapter.global_settings_files();
+        assert!(
+            !settings
+                .iter()
+                .any(|p| p.ends_with("agents/reviewer.agent.md")),
+            "agents/ moved to global_subagent_files; must not appear in settings"
+        );
+
+        assert_eq!(
+            adapter.project_subagent_patterns(),
+            vec![".github/agents/*.agent.md".to_string()]
+        );
     }
 }

--- a/crates/hk-core/src/adapter/cursor.rs
+++ b/crates/hk-core/src/adapter/cursor.rs
@@ -165,17 +165,7 @@ impl AgentAdapter for CursorAdapter {
 
     fn global_subagent_files(&self) -> Vec<PathBuf> {
         // ~/.cursor/agents/*.md
-        let mut files = Vec::new();
-        let agents_dir = self.base_dir().join("agents");
-        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "md") {
-                    files.push(p);
-                }
-            }
-        }
-        files
+        super::files_with_ext(&self.base_dir().join("agents"), "md").collect()
     }
 
     fn project_markers(&self) -> Vec<ProjectMarker> {

--- a/crates/hk-core/src/adapter/cursor.rs
+++ b/crates/hk-core/src/adapter/cursor.rs
@@ -156,12 +156,16 @@ impl AgentAdapter for CursorAdapter {
     }
 
     fn global_settings_files(&self) -> Vec<PathBuf> {
-        let mut files = vec![
+        vec![
             self.base_dir().join("mcp.json"),
             self.base_dir().join("permissions.json"),
             self.base_dir().join("hooks.json"),
-        ];
+        ]
+    }
+
+    fn global_subagent_files(&self) -> Vec<PathBuf> {
         // ~/.cursor/agents/*.md
+        let mut files = Vec::new();
         let agents_dir = self.base_dir().join("agents");
         if let Ok(entries) = std::fs::read_dir(&agents_dir) {
             for entry in entries.flatten() {
@@ -196,6 +200,10 @@ impl AgentAdapter for CursorAdapter {
 
     fn project_settings_patterns(&self) -> Vec<String> {
         vec![".cursor/mcp.json".into()]
+    }
+
+    fn project_subagent_patterns(&self) -> Vec<String> {
+        vec![".cursor/agents/*.md".into()]
     }
 
     fn project_ignore_patterns(&self) -> Vec<String> {
@@ -291,6 +299,37 @@ impl AgentAdapter for CursorAdapter {
 mod tests {
     use super::super::AgentAdapter;
     use super::*;
+
+    #[test]
+    fn test_cursor_subagent_methods() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = CursorAdapter::with_home(tmp.path().to_path_buf());
+
+        assert!(adapter.global_subagent_files().is_empty());
+
+        let agents_dir = adapter.base_dir().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(agents_dir.join("reviewer.md"), "# reviewer").unwrap();
+        std::fs::write(agents_dir.join("notes.txt"), "ignore me").unwrap();
+
+        let subagents = adapter.global_subagent_files();
+        assert!(subagents.iter().any(|p| p.ends_with("agents/reviewer.md")));
+        assert!(
+            !subagents.iter().any(|p| p.ends_with("notes.txt")),
+            "non-.md files in agents/ must be filtered"
+        );
+
+        let settings = adapter.global_settings_files();
+        assert!(
+            !settings.iter().any(|p| p.ends_with("agents/reviewer.md")),
+            "agents/ moved to global_subagent_files; must not appear in settings"
+        );
+
+        assert_eq!(
+            adapter.project_subagent_patterns(),
+            vec![".cursor/agents/*.md".to_string()]
+        );
+    }
 
     #[test]
     fn read_hooks_cursor_format() {

--- a/crates/hk-core/src/adapter/gemini.rs
+++ b/crates/hk-core/src/adapter/gemini.rs
@@ -142,17 +142,7 @@ impl AgentAdapter for GeminiAdapter {
 
     fn global_subagent_files(&self) -> Vec<PathBuf> {
         // ~/.gemini/agents/*.md
-        let mut files = Vec::new();
-        let agents_dir = self.base_dir().join("agents");
-        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "md") {
-                    files.push(p);
-                }
-            }
-        }
-        files
+        super::files_with_ext(&self.base_dir().join("agents"), "md").collect()
     }
 
     fn project_markers(&self) -> Vec<ProjectMarker> {

--- a/crates/hk-core/src/adapter/gemini.rs
+++ b/crates/hk-core/src/adapter/gemini.rs
@@ -127,22 +127,27 @@ impl AgentAdapter for GeminiAdapter {
                 }
             }
         }
-        // ~/.gemini/agents/*.md
-        let agents_dir = self.base_dir().join("agents");
-        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "md") {
-                    files.push(p);
-                }
-            }
-        }
         // ~/.gemini/policies/*.toml
         let policies_dir = self.base_dir().join("policies");
         if let Ok(entries) = std::fs::read_dir(&policies_dir) {
             for entry in entries.flatten() {
                 let p = entry.path();
                 if p.extension().is_some_and(|e| e == "toml") {
+                    files.push(p);
+                }
+            }
+        }
+        files
+    }
+
+    fn global_subagent_files(&self) -> Vec<PathBuf> {
+        // ~/.gemini/agents/*.md
+        let mut files = Vec::new();
+        let agents_dir = self.base_dir().join("agents");
+        if let Ok(entries) = std::fs::read_dir(&agents_dir) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.extension().is_some_and(|e| e == "md") {
                     files.push(p);
                 }
             }
@@ -164,6 +169,10 @@ impl AgentAdapter for GeminiAdapter {
 
     fn project_settings_patterns(&self) -> Vec<String> {
         vec![".gemini/settings.json".into()]
+    }
+
+    fn project_subagent_patterns(&self) -> Vec<String> {
+        vec![".gemini/agents/*.md".into()]
     }
 
     fn project_ignore_patterns(&self) -> Vec<String> {
@@ -424,5 +433,36 @@ mod tests {
         let adapter = GeminiAdapter::with_home(tmp.path().to_path_buf());
         let plugins = adapter.read_plugins();
         assert!(plugins[0].enabled, "last rule is enable, should be enabled");
+    }
+
+    #[test]
+    fn test_gemini_subagent_methods() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = GeminiAdapter::with_home(tmp.path().to_path_buf());
+
+        assert!(adapter.global_subagent_files().is_empty());
+
+        let agents_dir = adapter.base_dir().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(agents_dir.join("reviewer.md"), "# reviewer").unwrap();
+        std::fs::write(agents_dir.join("notes.txt"), "ignore me").unwrap();
+
+        let subagents = adapter.global_subagent_files();
+        assert!(subagents.iter().any(|p| p.ends_with("agents/reviewer.md")));
+        assert!(
+            !subagents.iter().any(|p| p.ends_with("notes.txt")),
+            "non-.md files in agents/ must be filtered"
+        );
+
+        let settings = adapter.global_settings_files();
+        assert!(
+            !settings.iter().any(|p| p.ends_with("agents/reviewer.md")),
+            "agents/ moved to global_subagent_files; must not appear in settings"
+        );
+
+        assert_eq!(
+            adapter.project_subagent_patterns(),
+            vec![".gemini/agents/*.md".to_string()]
+        );
     }
 }

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -9,7 +9,29 @@ pub mod opencode;
 pub mod windsurf;
 
 use crate::models::ConfigScope;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Return every file directly inside `dir` whose extension equals `ext`
+/// (case-sensitive, no leading dot). Missing or unreadable directories
+/// yield an empty iterator — adapters use this for "scan a fixed subdir"
+/// listings (subagent / mode / theme / command files etc.) and rely on
+/// the silent-empty behavior so a missing optional dir isn't an error.
+///
+/// Returns an iterator (not a Vec) so callers that want to chain extra
+/// predicates pay only one allocation in `.collect()`. Callers that just
+/// need the full list write `.collect()` once.
+pub(crate) fn files_with_ext<'a>(
+    dir: &'a Path,
+    ext: &'a str,
+) -> impl Iterator<Item = PathBuf> + 'a {
+    std::fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flatten() // Option<ReadDir> → entries (or none)
+        .flatten() // Result<DirEntry, _> → DirEntry (skip Err)
+        .map(|entry| entry.path())
+        .filter(move |path| path.extension().is_some_and(|e| e == ext))
+}
 
 /// Represents an MCP server entry parsed from an agent's config
 #[derive(Debug, Clone)]

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -170,6 +170,14 @@ pub trait AgentAdapter: Send + Sync {
         vec![]
     }
 
+    /// Global subagent definition files (absolute paths). Each file in the
+    /// returned list is one subagent persona definition (e.g.
+    /// `~/.claude/agents/foo.md`, `~/.codex/agents/bar.toml`). Distinct from
+    /// settings: subagents define behavior/personality, not config knobs.
+    fn global_subagent_files(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
     /// Relative paths/globs for rules within a project dir (e.g. "CLAUDE.md")
     fn project_rules_patterns(&self) -> Vec<String> {
         vec![]
@@ -182,6 +190,13 @@ pub trait AgentAdapter: Send + Sync {
 
     /// Relative paths/globs for settings within a project dir
     fn project_settings_patterns(&self) -> Vec<String> {
+        vec![]
+    }
+
+    /// Relative paths/globs for subagent definition files within a project dir
+    /// (e.g. `.claude/agents/*.md`, `.codex/agents/*.toml`). Each matched file
+    /// is one subagent persona definition.
+    fn project_subagent_patterns(&self) -> Vec<String> {
         vec![]
     }
 
@@ -344,9 +359,11 @@ mod tests {
             let _ = a.global_rules_files();
             let _ = a.global_memory_files();
             let _ = a.global_settings_files();
+            let _ = a.global_subagent_files();
             let _ = a.project_rules_patterns();
             let _ = a.project_memory_patterns();
             let _ = a.project_settings_patterns();
+            let _ = a.project_subagent_patterns();
             let _ = a.project_ignore_patterns();
             let _ = a.global_workflow_files();
             let _ = a.project_workflow_patterns();

--- a/crates/hk-core/src/adapter/opencode.rs
+++ b/crates/hk-core/src/adapter/opencode.rs
@@ -242,20 +242,25 @@ impl AgentAdapter for OpencodeAdapter {
         // Includes the canonical config file plus the .jsonc variant (only one
         // exists per install, but listing both lets the scanner find either),
         // and every directory whose contents are user-configurable settings:
-        //   - agents/*.md  : agent definitions
         //   - modes/*.md   : agent mode definitions
         //   - themes/*.json: UI themes (palette/styling JSON)
-        // tools/*.ts and plugins/*.ts are intentionally excluded — they are
-        // code, not settings, and have their own discovery paths.
+        // agents/*.md is exposed via `global_subagent_files` (Subagents
+        // category), not Settings. tools/*.ts and plugins/*.ts are
+        // intentionally excluded — they are code, not settings, and have their
+        // own discovery paths.
         let base = self.base_dir();
         let mut files = vec![
             self.mcp_config_path(),       // opencode.json
             base.join("opencode.jsonc"),  // jsonc variant
         ];
-        files.extend(Self::files_with_ext(&base.join("agents"), "md"));
         files.extend(Self::files_with_ext(&base.join("modes"), "md"));
         files.extend(Self::files_with_ext(&base.join("themes"), "json"));
         files
+    }
+
+    fn global_subagent_files(&self) -> Vec<PathBuf> {
+        // ~/.config/opencode/agents/*.md
+        Self::files_with_ext(&self.base_dir().join("agents"), "md")
     }
 
     fn global_workflow_files(&self) -> Vec<PathBuf> {
@@ -291,6 +296,12 @@ impl AgentAdapter for OpencodeAdapter {
         // Slash commands: .opencode/commands/*.md
         // (https://opencode.ai/docs/commands/).
         vec![".opencode/commands/*.md".into()]
+    }
+
+    fn project_subagent_patterns(&self) -> Vec<String> {
+        // Project subagents: .opencode/agents/*.md
+        // (https://opencode.ai/docs/agents/).
+        vec![".opencode/agents/*.md".into()]
     }
 
     fn project_skill_dirs(&self) -> Vec<String> {
@@ -455,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn global_settings_and_workflows_include_configurable_subdirs() {
+    fn global_settings_workflows_and_subagents_include_configurable_subdirs() {
         let tmp = tempfile::tempdir().unwrap();
         let base = tmp.path().join(".config/opencode");
         for sub in ["agents", "modes", "themes", "commands", "tools"] {
@@ -473,22 +484,36 @@ mod tests {
         let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
         let settings = adapter.global_settings_files();
         let workflows = adapter.global_workflow_files();
+        let subagents = adapter.global_subagent_files();
 
-        // Three subdir kinds plus the two top-level config paths.
-        assert!(settings.iter().any(|p| p.ends_with("agents/reviewer.md")));
+        // Settings holds modes/, themes/, and the top-level configs — agents/
+        // moved to its own Subagents category.
         assert!(settings.iter().any(|p| p.ends_with("modes/build.md")));
         assert!(settings.iter().any(|p| p.ends_with("themes/dark.json")));
         assert!(settings.iter().any(|p| p.ends_with("opencode.json")));
         assert!(settings.iter().any(|p| p.ends_with("opencode.jsonc")));
+        assert!(
+            !settings.iter().any(|p| p.ends_with("agents/reviewer.md")),
+            "agents/ must NOT appear under settings anymore — moved to global_subagent_files"
+        );
 
-        // Code-bearing dirs and non-matching extensions are excluded.
+        // Subagents pulls from agents/ only, with extension filtering.
+        assert!(subagents.iter().any(|p| p.ends_with("agents/reviewer.md")));
+        assert!(
+            !subagents.iter().any(|p| p.ends_with("notes.txt")),
+            "files with non-md extensions in agents/ must be filtered"
+        );
+
+        // Code-bearing dirs and stray non-.md files in agents/ are excluded
+        // from settings (the latter never were settings; double-check it
+        // didn't sneak in via the moved scan).
         assert!(
             !settings.iter().any(|p| p.ends_with("tools/lint.ts")),
             "tools/ holds code, must not be in settings"
         );
         assert!(
-            !settings.iter().any(|p| p.ends_with("notes.txt")),
-            "files with non-md extensions in agents/ must be filtered"
+            !settings.iter().any(|p| p.ends_with("agents/notes.txt")),
+            "agents/notes.txt must not appear in settings"
         );
 
         // Workflows still flows through commands/.
@@ -515,6 +540,12 @@ mod tests {
         assert_eq!(
             adapter.project_workflow_patterns(),
             vec![".opencode/commands/*.md".to_string()]
+        );
+
+        // Subagents: .opencode/agents/*.md.
+        assert_eq!(
+            adapter.project_subagent_patterns(),
+            vec![".opencode/agents/*.md".to_string()]
         );
 
         // MCP project config sits inside the same opencode.json, not a

--- a/crates/hk-core/src/adapter/opencode.rs
+++ b/crates/hk-core/src/adapter/opencode.rs
@@ -39,17 +39,6 @@ impl OpencodeAdapter {
         .ok()
     }
 
-    fn files_with_ext(dir: &Path, ext: &str) -> Vec<PathBuf> {
-        let Ok(entries) = std::fs::read_dir(dir) else {
-            return vec![];
-        };
-        entries
-            .flatten()
-            .map(|entry| entry.path())
-            .filter(|path| path.extension().is_some_and(|e| e == ext))
-            .collect()
-    }
-
     fn plugin_name(path: &Path) -> String {
         let file_name = path
             .file_name()
@@ -253,18 +242,18 @@ impl AgentAdapter for OpencodeAdapter {
             self.mcp_config_path(),       // opencode.json
             base.join("opencode.jsonc"),  // jsonc variant
         ];
-        files.extend(Self::files_with_ext(&base.join("modes"), "md"));
-        files.extend(Self::files_with_ext(&base.join("themes"), "json"));
+        files.extend(super::files_with_ext(&base.join("modes"), "md"));
+        files.extend(super::files_with_ext(&base.join("themes"), "json"));
         files
     }
 
     fn global_subagent_files(&self) -> Vec<PathBuf> {
         // ~/.config/opencode/agents/*.md
-        Self::files_with_ext(&self.base_dir().join("agents"), "md")
+        super::files_with_ext(&self.base_dir().join("agents"), "md").collect()
     }
 
     fn global_workflow_files(&self) -> Vec<PathBuf> {
-        Self::files_with_ext(&self.base_dir().join("commands"), "md")
+        super::files_with_ext(&self.base_dir().join("commands"), "md").collect()
     }
 
     fn project_markers(&self) -> Vec<ProjectMarker> {

--- a/crates/hk-core/src/models.rs
+++ b/crates/hk-core/src/models.rs
@@ -374,6 +374,7 @@ pub struct AgentConfigFile {
 pub enum ConfigCategory {
     Rules,
     Memory,
+    Subagents,
     Settings,
     Workflow,
     Ignore,
@@ -384,6 +385,7 @@ impl ConfigCategory {
         match self {
             Self::Rules => "rules",
             Self::Memory => "memory",
+            Self::Subagents => "subagents",
             Self::Settings => "settings",
             Self::Workflow => "workflow",
             Self::Ignore => "ignore",
@@ -394,9 +396,10 @@ impl ConfigCategory {
         match self {
             Self::Rules => 0,
             Self::Memory => 1,
-            Self::Settings => 2,
-            Self::Workflow => 3,
-            Self::Ignore => 4,
+            Self::Subagents => 2,
+            Self::Settings => 3,
+            Self::Workflow => 4,
+            Self::Ignore => 5,
         }
     }
 }
@@ -499,9 +502,19 @@ mod tests {
     fn test_config_category_as_str() {
         assert_eq!(ConfigCategory::Rules.as_str(), "rules");
         assert_eq!(ConfigCategory::Memory.as_str(), "memory");
+        assert_eq!(ConfigCategory::Subagents.as_str(), "subagents");
         assert_eq!(ConfigCategory::Settings.as_str(), "settings");
         assert_eq!(ConfigCategory::Workflow.as_str(), "workflow");
         assert_eq!(ConfigCategory::Ignore.as_str(), "ignore");
+    }
+
+    #[test]
+    fn test_config_category_order() {
+        assert!(ConfigCategory::Rules.order() < ConfigCategory::Memory.order());
+        assert!(ConfigCategory::Memory.order() < ConfigCategory::Subagents.order());
+        assert!(ConfigCategory::Subagents.order() < ConfigCategory::Settings.order());
+        assert!(ConfigCategory::Settings.order() < ConfigCategory::Workflow.order());
+        assert!(ConfigCategory::Workflow.order() < ConfigCategory::Ignore.order());
     }
 
     #[test]

--- a/crates/hk-core/src/models.rs
+++ b/crates/hk-core/src/models.rs
@@ -404,6 +404,23 @@ impl ConfigCategory {
     }
 }
 
+impl std::str::FromStr for ConfigCategory {
+    /// Returns `Err` for unknown strings; callers decide the fallback policy
+    /// (existing custom-config parsers do `.parse().unwrap_or(Settings)`).
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "rules" => Ok(Self::Rules),
+            "memory" => Ok(Self::Memory),
+            "subagents" => Ok(Self::Subagents),
+            "settings" => Ok(Self::Settings),
+            "workflow" => Ok(Self::Workflow),
+            "ignore" => Ok(Self::Ignore),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ConfigScope {
@@ -515,6 +532,28 @@ mod tests {
         assert!(ConfigCategory::Subagents.order() < ConfigCategory::Settings.order());
         assert!(ConfigCategory::Settings.order() < ConfigCategory::Workflow.order());
         assert!(ConfigCategory::Workflow.order() < ConfigCategory::Ignore.order());
+    }
+
+    #[test]
+    fn test_config_category_from_str_round_trip() {
+        // Every variant's `as_str()` must parse back to itself — this is the
+        // sole guard that catches a missed arm when adding a new variant.
+        for cat in [
+            ConfigCategory::Rules,
+            ConfigCategory::Memory,
+            ConfigCategory::Subagents,
+            ConfigCategory::Settings,
+            ConfigCategory::Workflow,
+            ConfigCategory::Ignore,
+        ] {
+            assert_eq!(
+                cat.as_str().parse::<ConfigCategory>(),
+                Ok(cat),
+                "{:?} round-trip failed",
+                cat
+            );
+        }
+        assert!("not-a-category".parse::<ConfigCategory>().is_err());
     }
 
     #[test]

--- a/crates/hk-core/src/scanner.rs
+++ b/crates/hk-core/src/scanner.rs
@@ -1830,9 +1830,10 @@ pub fn scan_agent_configs(
     let mut configs = Vec::new();
 
     // --- Global files ---
-    let global_groups: [(ConfigCategory, Vec<std::path::PathBuf>); 4] = [
+    let global_groups: [(ConfigCategory, Vec<std::path::PathBuf>); 5] = [
         (ConfigCategory::Rules, adapter.global_rules_files()),
         (ConfigCategory::Memory, adapter.global_memory_files()),
+        (ConfigCategory::Subagents, adapter.global_subagent_files()),
         (ConfigCategory::Settings, adapter.global_settings_files()),
         (ConfigCategory::Workflow, adapter.global_workflow_files()),
     ];
@@ -1847,9 +1848,13 @@ pub fn scan_agent_configs(
     }
 
     // --- Project files ---
-    let project_groups: [(ConfigCategory, Vec<String>); 5] = [
+    let project_groups: [(ConfigCategory, Vec<String>); 6] = [
         (ConfigCategory::Rules, adapter.project_rules_patterns()),
         (ConfigCategory::Memory, adapter.project_memory_patterns()),
+        (
+            ConfigCategory::Subagents,
+            adapter.project_subagent_patterns(),
+        ),
         (
             ConfigCategory::Settings,
             adapter.project_settings_patterns(),

--- a/crates/hk-core/src/scanner.rs
+++ b/crates/hk-core/src/scanner.rs
@@ -2629,6 +2629,103 @@ mod config_tests {
     }
 
     #[test]
+    fn test_scan_agent_configs_subagents_global_and_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        let global_agents = home.join(".claude/agents");
+        fs::create_dir_all(&global_agents).unwrap();
+        fs::write(global_agents.join("reviewer.md"), "# global reviewer").unwrap();
+        // Filtered (wrong extension).
+        fs::write(global_agents.join("scratch.txt"), "ignore").unwrap();
+
+        let project = home.join("myproject");
+        let project_agents = project.join(".claude/agents");
+        fs::create_dir_all(&project_agents).unwrap();
+        fs::write(project_agents.join("planner.md"), "# project planner").unwrap();
+
+        let adapter = ClaudeAdapter::with_home(home.to_path_buf());
+        let projects = vec![(
+            "myproject".to_string(),
+            project.to_string_lossy().to_string(),
+        )];
+        let configs = scan_agent_configs(&adapter, &projects);
+
+        let subagents: Vec<_> = configs
+            .iter()
+            .filter(|c| c.category == ConfigCategory::Subagents)
+            .collect();
+        assert_eq!(subagents.len(), 2, "expected one global + one project subagent");
+
+        let global = subagents
+            .iter()
+            .find(|c| matches!(c.scope, ConfigScope::Global))
+            .expect("global subagent missing");
+        assert_eq!(global.file_name, "reviewer.md");
+
+        let project_entry = subagents
+            .iter()
+            .find(|c| matches!(&c.scope, ConfigScope::Project { .. }))
+            .expect("project subagent missing");
+        assert_eq!(project_entry.file_name, "planner.md");
+
+        // Settings must not contain agent files anymore — guards against the
+        // pre-PR behavior where global agents/*.md leaked into Settings.
+        let settings: Vec<_> = configs
+            .iter()
+            .filter(|c| c.category == ConfigCategory::Settings)
+            .collect();
+        assert!(
+            settings.iter().all(|c| !c.path.contains("/agents/")),
+            "agent definition files must not appear under Settings category"
+        );
+    }
+
+    #[test]
+    fn test_scan_agent_configs_subagents_codex_toml() {
+        use crate::adapter::codex::CodexAdapter;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        let global_agents = home.join(".codex/agents");
+        fs::create_dir_all(&global_agents).unwrap();
+        fs::write(global_agents.join("reviewer.toml"), "name = \"reviewer\"").unwrap();
+
+        let project = home.join("myproject");
+        let project_agents = project.join(".codex/agents");
+        fs::create_dir_all(&project_agents).unwrap();
+        fs::write(project_agents.join("planner.toml"), "name = \"planner\"").unwrap();
+
+        let adapter = CodexAdapter::with_home(home.to_path_buf());
+        let projects = vec![(
+            "myproject".to_string(),
+            project.to_string_lossy().to_string(),
+        )];
+        let configs = scan_agent_configs(&adapter, &projects);
+
+        let subagents: Vec<_> = configs
+            .iter()
+            .filter(|c| c.category == ConfigCategory::Subagents)
+            .collect();
+        assert_eq!(
+            subagents.len(),
+            2,
+            "Codex .toml subagents must be scanned at both global and project scope"
+        );
+        assert!(
+            subagents.iter().any(|c| c.file_name == "reviewer.toml"
+                && matches!(c.scope, ConfigScope::Global)),
+            "reviewer.toml must be scoped Global"
+        );
+        assert!(
+            subagents.iter().any(|c| c.file_name == "planner.toml"
+                && matches!(&c.scope, ConfigScope::Project { .. })),
+            "planner.toml must be scoped Project"
+        );
+    }
+
+    #[test]
     fn test_parse_skill_frontmatter_with_bins_inline() {
         let content = "---\nname: wecomcli-send\ndescription: Send messages\nbins: [\"wecom-cli\"]\n---\nBody";
         let (name, desc, bins) = parse_skill_frontmatter(content).unwrap();

--- a/crates/hk-desktop/src/commands/agents.rs
+++ b/crates/hk-desktop/src/commands/agents.rs
@@ -96,6 +96,7 @@ pub fn list_agent_configs(state: State<AppState>) -> Result<Vec<AgentDetail>, Hk
                 let category = match category_str.as_str() {
                     "rules" => ConfigCategory::Rules,
                     "memory" => ConfigCategory::Memory,
+                    "subagents" => ConfigCategory::Subagents,
                     "workflow" => ConfigCategory::Workflow,
                     "ignore" => ConfigCategory::Ignore,
                     _ => ConfigCategory::Settings,

--- a/crates/hk-desktop/src/commands/agents.rs
+++ b/crates/hk-desktop/src/commands/agents.rs
@@ -93,14 +93,9 @@ pub fn list_agent_configs(state: State<AppState>) -> Result<Vec<AgentDetail>, Hk
                 if existing_paths.contains(&canonical) {
                     continue;
                 }
-                let category = match category_str.as_str() {
-                    "rules" => ConfigCategory::Rules,
-                    "memory" => ConfigCategory::Memory,
-                    "subagents" => ConfigCategory::Subagents,
-                    "workflow" => ConfigCategory::Workflow,
-                    "ignore" => ConfigCategory::Ignore,
-                    _ => ConfigCategory::Settings,
-                };
+                let category = category_str
+                    .parse::<ConfigCategory>()
+                    .unwrap_or(ConfigCategory::Settings);
                 let scope = scope_json
                     .as_deref()
                     .and_then(|s| serde_json::from_str::<ConfigScope>(s).ok())

--- a/crates/hk-web/src/handlers/agents.rs
+++ b/crates/hk-web/src/handlers/agents.rs
@@ -123,6 +123,7 @@ pub async fn list_agent_configs(
                     let category = match category_str.as_str() {
                         "rules" => ConfigCategory::Rules,
                         "memory" => ConfigCategory::Memory,
+                        "subagents" => ConfigCategory::Subagents,
                         "workflow" => ConfigCategory::Workflow,
                         "ignore" => ConfigCategory::Ignore,
                         _ => ConfigCategory::Settings,

--- a/crates/hk-web/src/handlers/agents.rs
+++ b/crates/hk-web/src/handlers/agents.rs
@@ -120,14 +120,9 @@ pub async fn list_agent_configs(
                     if existing_paths.contains(&canonical) {
                         continue;
                     }
-                    let category = match category_str.as_str() {
-                        "rules" => ConfigCategory::Rules,
-                        "memory" => ConfigCategory::Memory,
-                        "subagents" => ConfigCategory::Subagents,
-                        "workflow" => ConfigCategory::Workflow,
-                        "ignore" => ConfigCategory::Ignore,
-                        _ => ConfigCategory::Settings,
-                    };
+                    let category = category_str
+                        .parse::<ConfigCategory>()
+                        .unwrap_or(ConfigCategory::Settings);
                     let scope = scope_json
                         .as_deref()
                         .and_then(|s| serde_json::from_str::<ConfigScope>(s).ok())

--- a/src/components/agents/agent-detail.tsx
+++ b/src/components/agents/agent-detail.tsx
@@ -20,6 +20,7 @@ const CATEGORY_ORDER: ConfigCategory[] = [
   "settings",
   "workflow",
   "rules",
+  "subagents",
   "memory",
   "ignore",
 ];

--- a/src/components/agents/agent-detail.tsx
+++ b/src/components/agents/agent-detail.tsx
@@ -6,6 +6,7 @@ import { isDesktop } from "@/lib/transport";
 import {
   agentDisplayName,
   type ConfigCategory,
+  CONFIG_CATEGORY_ORDER,
   type ConfigScope,
   type ExtensionCounts,
   scopeLabel,
@@ -15,15 +16,6 @@ import { useExtensionStore } from "@/stores/extension-store";
 import { ConfigSection } from "./config-section";
 import { ExtensionsSummaryCard } from "./extensions-summary-card";
 import { SectionAnchorRail } from "./section-anchor-rail";
-
-const CATEGORY_ORDER: ConfigCategory[] = [
-  "settings",
-  "workflow",
-  "rules",
-  "subagents",
-  "memory",
-  "ignore",
-];
 
 export function AgentDetail() {
   const agentDetails = useAgentConfigStore((s) => s.agentDetails);
@@ -80,7 +72,7 @@ export function AgentDetail() {
     (f) => f.custom_id == null && matchesScope(f.scope),
   );
   const byCategory = new Map<ConfigCategory, typeof agent.config_files>();
-  for (const cat of CATEGORY_ORDER) byCategory.set(cat, []);
+  for (const cat of CONFIG_CATEGORY_ORDER) byCategory.set(cat, []);
   for (const file of nonCustomFiles) {
     const list = byCategory.get(file.category);
     if (list) list.push(file);
@@ -231,7 +223,7 @@ export function AgentDetail() {
         </div>
       ) : (
         <>
-          {CATEGORY_ORDER.map((cat) => {
+          {CONFIG_CATEGORY_ORDER.map((cat) => {
             const files = byCategory.get(cat) ?? [];
             // When the active scope hides everything in a category, collapse
             // the section instead of rendering a "0" header. Always show

--- a/src/components/agents/config-section.tsx
+++ b/src/components/agents/config-section.tsx
@@ -1,4 +1,5 @@
 import {
+  Bot,
   Brain,
   ChevronDown,
   ChevronRight,
@@ -17,6 +18,7 @@ import { ConfigFileEntry } from "./config-file-entry";
 const CATEGORY_ICONS: Record<string, React.ElementType> = {
   rules: FileText,
   memory: Brain,
+  subagents: Bot,
   settings: Settings,
   workflow: Workflow,
   ignore: EyeOff,

--- a/src/components/agents/section-anchor-rail.tsx
+++ b/src/components/agents/section-anchor-rail.tsx
@@ -1,4 +1,8 @@
 import { useEffect, useState } from "react";
+import {
+  CONFIG_CATEGORY_LABELS,
+  CONFIG_CATEGORY_ORDER,
+} from "@/lib/types";
 
 interface SectionAnchor {
   id: string;
@@ -6,14 +10,15 @@ interface SectionAnchor {
 }
 
 /** Catalog of every anchor the rail knows about. The rail filters this list
- *  down to sections that are actually rendered in the current page. */
+ *  down to sections that are actually rendered in the current page. The
+ *  ConfigCategory portion is derived from `CONFIG_CATEGORY_ORDER` so a
+ *  category added there auto-propagates here; `custom` and `extensions` are
+ *  synthetic UI-only anchors that don't correspond to a ConfigCategory. */
 const SECTION_CATALOG: SectionAnchor[] = [
-  { id: "section-settings", label: "Settings" },
-  { id: "section-workflow", label: "Workflow" },
-  { id: "section-rules", label: "Rules" },
-  { id: "section-subagents", label: "Subagents" },
-  { id: "section-memory", label: "Memory" },
-  { id: "section-ignore", label: "Ignore" },
+  ...CONFIG_CATEGORY_ORDER.map((c) => ({
+    id: `section-${c}`,
+    label: CONFIG_CATEGORY_LABELS[c],
+  })),
   { id: "section-custom", label: "Custom" },
   { id: "section-extensions", label: "Extensions" },
 ];

--- a/src/components/agents/section-anchor-rail.tsx
+++ b/src/components/agents/section-anchor-rail.tsx
@@ -11,6 +11,7 @@ const SECTION_CATALOG: SectionAnchor[] = [
   { id: "section-settings", label: "Settings" },
   { id: "section-workflow", label: "Workflow" },
   { id: "section-rules", label: "Rules" },
+  { id: "section-subagents", label: "Subagents" },
   { id: "section-memory", label: "Memory" },
   { id: "section-ignore", label: "Ignore" },
   { id: "section-custom", label: "Custom" },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -253,6 +253,18 @@ export const CONFIG_CATEGORY_LABELS: Record<ConfigCategory, string> = {
   ignore: "Ignore",
 };
 
+/** Canonical visual order for config categories across all UI surfaces.
+ * Single source of truth — the agent detail render order and the
+ * section-anchor rail catalog both derive from this. */
+export const CONFIG_CATEGORY_ORDER: ConfigCategory[] = [
+  "settings",
+  "workflow",
+  "rules",
+  "subagents",
+  "memory",
+  "ignore",
+];
+
 export interface FileEntry {
   name: string;
   path: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -195,6 +195,7 @@ export interface AgentInfo {
 export type ConfigCategory =
   | "rules"
   | "memory"
+  | "subagents"
   | "settings"
   | "workflow"
   | "ignore";
@@ -246,6 +247,7 @@ export interface AgentDetail {
 export const CONFIG_CATEGORY_LABELS: Record<ConfigCategory, string> = {
   rules: "Rules",
   memory: "Memory",
+  subagents: "Subagents",
   settings: "Settings",
   workflow: "Workflows",
   ignore: "Ignore",


### PR DESCRIPTION
## Summary

- New **Subagents** ConfigCategory: 6 adapters (claude/codex/cursor/gemini/copilot/opencode) scan their `agents/*` directories at both global and project scope; previously only global was partially covered (under Settings) and project was completely invisible.
- **Behavior change for existing users**: `~/.{agent}/agents/*.md` files visually relocate from Settings section to a new Subagents section in the agent detail panel. Codex's `~/.codex/agents/*.toml` is scanned for the first time.
- **Bug fix**: Copilot filter tightened from `*.md` to require `*.agent.md` naming, matching the documented Copilot CLI convention. Anchor-rail "Workflow" label normalized to "Workflows" for consistency with the section header.

## Scope per adapter

| Agent | Global subagent path | Project subagent path |
|---|---|---|
| claude | `~/.claude/agents/*.md` (was Settings) | `.claude/agents/*.md` (NEW) |
| codex | `~/.codex/agents/*.toml` (NEW) | `.codex/agents/*.toml` (NEW) |
| cursor | `~/.cursor/agents/*.md` (was Settings) | `.cursor/agents/*.md` (NEW) |
| gemini | `~/.gemini/agents/*.md` (was Settings) | `.gemini/agents/*.md` (NEW) |
| copilot | `~/.copilot/agents/*.agent.md` (was Settings, filter tightened) | `.github/agents/*.agent.md` (NEW) |
| opencode | `~/.config/opencode/agents/*.md` (was Settings) | `.opencode/agents/*.md` (NEW) |

windsurf and antigravity have no native subagent concept — left untouched.

## Architecture

5 commits, each independently bisect-able:

1. `feat(core)` — ConfigCategory::Subagents variant + trait methods (`global_subagent_files` / `project_subagent_patterns`) with empty defaults + scanner integration
2. `feat(adapters)` — 6 adapter impls, OpenCode test updated for category move, parsers in hk-web/hk-desktop accept `"subagents"` string, 6 adapter unit tests, 2 scanner integration tests
3. `refactor(adapter)` — extract `pub(crate) fn files_with_ext(dir, ext) -> impl Iterator<Item = PathBuf>` to adapter/mod.rs (was OpenCode-private). All 6 subagent paths use it; OpenCode's 4 existing callsites migrated. Iterator return lets Copilot's `*.agent.md` stem filter chain freely without double allocation.
4. `feat(ui)` — wire `ConfigCategory::Subagents` through frontend (TypeScript union, label record, render order, icon=Bot, anchor rail). Without this, backend-tagged subagent files would be silently dropped.
5. `refactor` — dedupe pre-existing category-table duplication: introduce `CONFIG_CATEGORY_ORDER` as single source of truth (was duplicated between agent-detail.tsx and section-anchor-rail.tsx); add `impl FromStr for ConfigCategory` with round-trip parity test, eliminating identical 6-arm parsers in hk-web/hk-desktop.

## Test coverage

- **Backend** (385 tests pass): 6 adapter unit tests covering empty/happy/wrong-ext/no-leak invariants per agent; 2 scanner integration tests covering Claude `.md` (with global+project scope assertions) and Codex `.toml`; round-trip parity test for `as_str() ↔ FromStr`; default-impl test extended to cover the 2 new trait methods.
- **Frontend** (148 tests pass, tsc clean): no test added — pre-existing 5 categories don't have render-level tests; adding only for subagents would be inconsistent. Type-system parity (`Record<ConfigCategory, ...>`) enforces table completeness at compile time.

## Manual testing — all 6 adapters verified end-to-end

✅ **Hands-on UI tested for every adapter at both Global and Project scope** using temporary fixture files:

- **Global**: created `code-reviewer.{md,toml,agent.md}` in each adapter's user-scope `agents/` dir (`~/.claude/agents/`, `~/.codex/agents/`, `~/.cursor/agents/`, `~/.gemini/agents/`, `~/.copilot/agents/`, `~/.config/opencode/agents/`)
- **Project**: created `planner.{md,toml,agent.md}` in `/private/tmp/hk-subagent-test/.{agent}/agents/` (Copilot at `.github/agents/`)
- **Copilot filter regression**: stray `~/.copilot/agents/note.md` (no `.agent` stem) confirmed NOT to appear under Subagents
- All fixtures cleaned up post-test

Verified visually for all 6 adapters:
- Subagents section renders with Bot icon at correct position (between Rules and Memory)
- Files appear in their respective scope (Global / Project)
- Codex's `~/.codex/agents/*.toml` visible for the first time (was completely unscanned before this PR)
- 5 adapters' `agents/*.md` correctly migrated out of Settings into Subagents
- Anchor rail shows clickable "Subagents" link; "Workflow" label now "Workflows"
- Section collapse/expand state persists across reload
- No regression in Settings/Workflow/Rules/Memory/Ignore sections

## Test plan

- [x] CI passes on all platforms
- [x] Local: existing user with `~/.claude/agents/foo.md` opens HK → file appears under **Subagents** in Claude detail panel (Global scope), not Settings
- [x] Local: project with `.claude/agents/bar.md` opens HK → file appears under Subagents (Project scope)
- [x] Local: Codex user with `~/.codex/agents/baz.toml` opens HK → first-time appearance under Codex Subagents
- [x] Local: Copilot user with `~/.copilot/agents/foo.agent.md` opens HK → appears under Subagents; a stray `note.md` (no `.agent` stem) does NOT appear (intended tightening)
- [x] Anchor rail shows "Subagents" link, click jumps to the section
- [x] Section collapse/expand state persists across reload (existing localStorage behavior for new category)
- [x] No regression in existing Settings/Workflow/Rules/Memory/Ignore sections

## Roadmap follow-ups (not in this PR)

- `project_adapter_readdir_helper_extract_roadmap.md` — 5 pre-existing same-shape `read_dir + ext filter` loops elsewhere (claude commands/output-styles, gemini commands/policies, copilot hooks, codex memories) can migrate to `files_with_ext` in a separate cleanup PR (~-50 lines)
- `project_opencode_jsonc_dual_file_merge_roadmap.md` — unrelated, prior P2 follow-up to PR #41