### PR TITLE
refactor: dedupe read_dir loops; drive biome lint to clean

### DIFF
--- a/crates/hk-core/src/adapter/claude.rs
+++ b/crates/hk-core/src/adapter/claude.rs
@@ -177,33 +177,20 @@ impl AgentAdapter for ClaudeAdapter {
     fn global_rules_files(&self) -> Vec<PathBuf> {
         let mut files = vec![self.base_dir().join("CLAUDE.md")];
         // Also scan ~/.claude/rules/*.md
-        let rules_dir = self.base_dir().join("rules");
-        if let Ok(entries) = std::fs::read_dir(&rules_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "md") {
-                    files.push(p);
-                }
-            }
-        }
+        files.extend(super::files_with_ext(&self.base_dir().join("rules"), "md"));
         files
     }
 
     fn global_memory_files(&self) -> Vec<PathBuf> {
+        // ~/.claude/projects/*/memory/*.md — outer level iterates project
+        // dirs (no extension filter); inner level reuses the helper.
         let projects_dir = self.base_dir().join("projects");
         let mut files = Vec::new();
         if let Ok(entries) = std::fs::read_dir(&projects_dir) {
             for entry in entries.flatten() {
                 let memory_dir = entry.path().join("memory");
-                if memory_dir.is_dir()
-                    && let Ok(mem_entries) = std::fs::read_dir(&memory_dir)
-                {
-                    for mem_entry in mem_entries.flatten() {
-                        let p = mem_entry.path();
-                        if p.extension().is_some_and(|e| e == "md") {
-                            files.push(p);
-                        }
-                    }
+                if memory_dir.is_dir() {
+                    files.extend(super::files_with_ext(&memory_dir, "md"));
                 }
             }
         }
@@ -218,25 +205,9 @@ impl AgentAdapter for ClaudeAdapter {
             self.base_dir().join("keybindings.json"),
         ];
         // ~/.claude/commands/*.md (legacy, still functional)
-        let commands_dir = self.base_dir().join("commands");
-        if let Ok(entries) = std::fs::read_dir(&commands_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "md") {
-                    files.push(p);
-                }
-            }
-        }
+        files.extend(super::files_with_ext(&self.base_dir().join("commands"), "md"));
         // ~/.claude/output-styles/*.md
-        let styles_dir = self.base_dir().join("output-styles");
-        if let Ok(entries) = std::fs::read_dir(&styles_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "md") {
-                    files.push(p);
-                }
-            }
-        }
+        files.extend(super::files_with_ext(&self.base_dir().join("output-styles"), "md"));
         files
     }
 

--- a/crates/hk-core/src/adapter/codex.rs
+++ b/crates/hk-core/src/adapter/codex.rs
@@ -86,17 +86,12 @@ impl AgentAdapter for CodexAdapter {
     }
 
     fn global_memory_files(&self) -> Vec<PathBuf> {
-        let mut files = Vec::new();
-        let memories_dir = self.base_dir().join("memories");
-        if let Ok(entries) = std::fs::read_dir(&memories_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.is_file() && p.extension().is_some_and(|e| e == "md") {
-                    files.push(p);
-                }
-            }
-        }
-        files
+        // ~/.codex/memories/*.md — explicit `is_file()` preserves prior
+        // semantics (rejects a hypothetical directory whose name ends in
+        // `.md`); cheap parity over a "siblings don't bother" argument.
+        super::files_with_ext(&self.base_dir().join("memories"), "md")
+            .filter(|p| p.is_file())
+            .collect()
     }
 
     fn project_markers(&self) -> Vec<ProjectMarker> {

--- a/crates/hk-core/src/adapter/copilot.rs
+++ b/crates/hk-core/src/adapter/copilot.rs
@@ -153,15 +153,7 @@ impl AgentAdapter for CopilotAdapter {
             self.vscode_user_dir().join("mcp.json"),
         ];
         // ~/.copilot/hooks/*.json
-        let hooks_dir = self.base_dir().join("hooks");
-        if let Ok(entries) = std::fs::read_dir(&hooks_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "json") {
-                    files.push(p);
-                }
-            }
-        }
+        files.extend(super::files_with_ext(&self.base_dir().join("hooks"), "json"));
         files
     }
 

--- a/crates/hk-core/src/adapter/gemini.rs
+++ b/crates/hk-core/src/adapter/gemini.rs
@@ -118,25 +118,9 @@ impl AgentAdapter for GeminiAdapter {
             self.base_dir().join(".env"),
         ];
         // ~/.gemini/commands/*.toml
-        let commands_dir = self.base_dir().join("commands");
-        if let Ok(entries) = std::fs::read_dir(&commands_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "toml") {
-                    files.push(p);
-                }
-            }
-        }
+        files.extend(super::files_with_ext(&self.base_dir().join("commands"), "toml"));
         // ~/.gemini/policies/*.toml
-        let policies_dir = self.base_dir().join("policies");
-        if let Ok(entries) = std::fs::read_dir(&policies_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|e| e == "toml") {
-                    files.push(p);
-                }
-            }
-        }
+        files.extend(super::files_with_ext(&self.base_dir().join("policies"), "toml"));
         files
     }
 

--- a/src/components/agents/agent-detail.tsx
+++ b/src/components/agents/agent-detail.tsx
@@ -5,8 +5,8 @@ import { openDirectoryPicker, openFilePicker } from "@/lib/dialog";
 import { isDesktop } from "@/lib/transport";
 import {
   agentDisplayName,
-  type ConfigCategory,
   CONFIG_CATEGORY_ORDER,
+  type ConfigCategory,
   type ConfigScope,
   type ExtensionCounts,
   scopeLabel,

--- a/src/components/agents/config-file-entry.tsx
+++ b/src/components/agents/config-file-entry.tsx
@@ -14,8 +14,8 @@ import {
 import { useEffect, useRef, useState } from "react";
 import { useScrollPassthrough } from "@/hooks/use-scroll-passthrough";
 import { openDirectoryPicker, openFilePicker } from "@/lib/dialog";
-import type { AgentConfigFile } from "@/lib/types";
 import { isDesktop } from "@/lib/transport";
+import type { AgentConfigFile } from "@/lib/types";
 import { useAgentConfigStore } from "@/stores/agent-config-store";
 
 export function ConfigFileEntry({ file }: { file: AgentConfigFile }) {
@@ -229,6 +229,7 @@ export function ConfigFileEntry({ file }: { file: AgentConfigFile }) {
                 onClick={async (e) => {
                   e.stopPropagation();
                   await updateCustomPath(
+                    // biome-ignore lint/style/noNonNullAssertion: outer JSX gate `file.custom_id != null` (line 178) guarantees this is set; TS narrowing doesn't propagate into the callback.
                     file.custom_id!,
                     editPath.trim(),
                     "",
@@ -300,6 +301,7 @@ export function ConfigFileEntry({ file }: { file: AgentConfigFile }) {
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
+                    // biome-ignore lint/style/noNonNullAssertion: outer JSX gate `file.custom_id != null` (line 289) guarantees this is set; TS narrowing doesn't propagate into the callback.
                     removeCustomPath(file.custom_id!);
                   }}
                   className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-[11px] font-medium text-destructive transition-colors hover:bg-destructive/10"

--- a/src/components/agents/section-anchor-rail.tsx
+++ b/src/components/agents/section-anchor-rail.tsx
@@ -1,8 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  CONFIG_CATEGORY_LABELS,
-  CONFIG_CATEGORY_ORDER,
-} from "@/lib/types";
+import { CONFIG_CATEGORY_LABELS, CONFIG_CATEGORY_ORDER } from "@/lib/types";
 
 interface SectionAnchor {
   id: string;
@@ -33,6 +30,7 @@ export function SectionAnchorRail({ revisionKey }: { revisionKey: string }) {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [presentIds, setPresentIds] = useState<Set<string>>(new Set());
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: revisionKey is a deliberate trigger sentinel — not read in body, only used to force re-discovery. See JSDoc.
   useEffect(() => {
     const present = new Set<string>();
     for (const section of SECTION_CATALOG) {

--- a/src/components/extensions/delete-dialog.tsx
+++ b/src/components/extensions/delete-dialog.tsx
@@ -268,9 +268,12 @@ export function DeleteDialog({
   const usePathBased =
     isSkill && filteredSkillLocations && filteredSkillLocations.length > 0;
 
-  const items: DeleteItem[] = usePathBased
-    ? buildPathItems(filteredSkillLocations!)
-    : buildAgentItems(group.instances, instanceData, group.kind, group.name);
+  // Redundant `filteredSkillLocations` check (already implied by usePathBased)
+  // is what lets TS narrow inside the true branch — cleaner than a `!`.
+  const items: DeleteItem[] =
+    usePathBased && filteredSkillLocations
+      ? buildPathItems(filteredSkillLocations)
+      : buildAgentItems(group.instances, instanceData, group.kind, group.name);
 
   const selectedKeys = deleteAgents;
   const allSelected =

--- a/src/components/extensions/detail-paths.tsx
+++ b/src/components/extensions/detail-paths.tsx
@@ -58,6 +58,7 @@ export function DetailPaths({
             agentOrder,
           );
           return sortedAgentNames.map((agentName) => {
+            // biome-ignore lint/style/noNonNullAssertion: agentName came from byAgent.keys(), so the value exists by construction.
             const instances = byAgent.get(agentName)!;
             const firstData = instanceData.get(instances[0].id);
             const agentLocations = filteredLocations.filter(

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -484,21 +484,23 @@ export function ExtensionDetail() {
                 <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                   Documentation
                 </h4>
-                {isDesktop() &&
-                  activeInstanceId &&
-                  instanceData.get(activeInstanceId)?.path && (
-                    <button
-                      onClick={() =>
-                        api.revealInFileManager(
-                          instanceData.get(activeInstanceId)!.path!,
-                        )
-                      }
-                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      <FolderOpen size={12} />
-                      Open in Finder
-                    </button>
-                  )}
+                {(() => {
+                  const activePath = activeInstanceId
+                    ? instanceData.get(activeInstanceId)?.path
+                    : undefined;
+                  return (
+                    isDesktop() &&
+                    activePath && (
+                      <button
+                        onClick={() => api.revealInFileManager(activePath)}
+                        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        <FolderOpen size={12} />
+                        Open in Finder
+                      </button>
+                    )
+                  );
+                })()}
               </div>
               {/* Agent tabs for switching instance content */}
               {group.instances.length > 1 && (

--- a/src/components/extensions/extension-filters.tsx
+++ b/src/components/extensions/extension-filters.tsx
@@ -68,6 +68,7 @@ export function ExtensionFilters() {
   // packs that only exist globally (and vice versa). We deliberately don't
   // narrow by kind/agent/tag/search — those filter the rows further; the
   // dropdown options should stay stable as the user toggles them.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `extensions` is a trigger sentinel — grouped() reads it via Zustand closure; needed in deps so the memo re-runs on store updates.
   const { scopedPacks, packCounts } = useMemo(() => {
     const counts = new Map<string, number>();
     for (const g of grouped()) {

--- a/src/components/extensions/extension-table.tsx
+++ b/src/components/extensions/extension-table.tsx
@@ -40,6 +40,7 @@ export function ExtensionTable({
   // Subscribe to trigger re-render; accessed via getState() in cell renderers
   useExtensionStore((s) => s.updateStatuses);
   const toggle = useExtensionStore((s) => s.toggle);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `scope` is a trigger sentinel — cell renderers read scope-dependent filter results via getState(); listing it forces a column rebuild on scope change.
   const columns = useMemo(
     () => [
       col.display({
@@ -196,7 +197,7 @@ export function ExtensionTable({
       }),
     ],
     // selectedIds, updateStatuses accessed via getState() inside cell renderers
-    // to avoid recomputing columns on every selection/status change
+    // to avoid recomputing columns on every selection/status change.
     [agentOrder, selectAll, clearSelection, toggleSelected, toggle, scope],
   );
   const sorting = useExtensionStore((s) => s.tableSorting) as SortingState;

--- a/src/components/extensions/new-skills-dialog.tsx
+++ b/src/components/extensions/new-skills-dialog.tsx
@@ -59,10 +59,12 @@ export function NewSkillsDialog({
   >();
   for (const skill of skills) {
     const key = skill.repo_url;
-    if (!grouped.has(key)) {
-      grouped.set(key, { pack: skill.pack, skills: [] });
+    let entry = grouped.get(key);
+    if (!entry) {
+      entry = { pack: skill.pack, skills: [] };
+      grouped.set(key, entry);
     }
-    grouped.get(key)!.skills.push(skill);
+    entry.skills.push(skill);
   }
 
   useEffect(() => {

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -57,7 +57,6 @@ export function AppShell() {
     setSearchParams(params, { replace: true });
   }, [scope, scopeHydrated, searchParams, setSearchParams]);
 
-
   // Window dragging — anywhere outside <main> and interactive elements
   useEffect(() => {
     const onMouseDown = (e: MouseEvent) => {

--- a/src/components/layout/scope-switcher-menu.tsx
+++ b/src/components/layout/scope-switcher-menu.tsx
@@ -85,6 +85,7 @@ export function ScopeSwitcherMenu({ onClose }: { onClose: () => void }) {
     return idx >= 0 ? idx : 0;
   });
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: handleSelect and handleAddProject are new closures each render but only capture stable refs (setScope, onClose, navigate); including them would re-bind the keydown listener every render with no behavioural difference.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "ArrowDown") {
@@ -103,10 +104,6 @@ export function ScopeSwitcherMenu({ onClose }: { onClose: () => void }) {
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-    // handleSelect / handleAddProject are stable enough for this scope —
-    // including activeIndex + navigableItems is sufficient to pick up
-    // changes that affect dispatch.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeIndex, navigableItems]);
 
   const activeKey = navigableItems[activeIndex]?.key;

--- a/src/components/onboarding/onboarding.tsx
+++ b/src/components/onboarding/onboarding.tsx
@@ -294,11 +294,12 @@ function HandAnnotation({
       padding: type === "circle" ? [2, 6, 4, 10] : 2,
       iterations: 1,
       animationDuration: type === "circle" ? 600 : 400,
-      roughness: type === "circle" ? 0.6 : 0.8,
+      // Note: rough-notation hardcodes its own roughness via getOptions(type)
+      // in render.js; any user-supplied `roughness` would be dead config.
       ...(type === "highlight" && {
         color: "color-mix(in oklch, var(--primary) 15%, transparent)",
       }),
-    } as any);
+    });
     const timer = setTimeout(() => a.show(), delay);
     return () => {
       clearTimeout(timer);

--- a/src/components/shared/agent-mascot/opencode-mascot.tsx
+++ b/src/components/shared/agent-mascot/opencode-mascot.tsx
@@ -45,15 +45,71 @@ export function OpencodeMascot({ size }: MascotSvgProps) {
       {/* Click: mosaic pixel tiles */}
       <g className="opencode-mosaic">
         {/* Border strips approximating the outline stroke */}
-        <rect className="oc-tile" x="3" y="0.9" width="18" height="2.2" fill="var(--mascot-icon-color)" />
-        <rect className="oc-tile" x="18.9" y="0.9" width="2.2" height="21.2" fill="var(--mascot-icon-color)" />
-        <rect className="oc-tile" x="3" y="20.9" width="18" height="2.2" fill="var(--mascot-icon-color)" />
-        <rect className="oc-tile" x="2.9" y="0.9" width="2.2" height="21.2" fill="var(--mascot-icon-color)" />
+        <rect
+          className="oc-tile"
+          x="3"
+          y="0.9"
+          width="18"
+          height="2.2"
+          fill="var(--mascot-icon-color)"
+        />
+        <rect
+          className="oc-tile"
+          x="18.9"
+          y="0.9"
+          width="2.2"
+          height="21.2"
+          fill="var(--mascot-icon-color)"
+        />
+        <rect
+          className="oc-tile"
+          x="3"
+          y="20.9"
+          width="18"
+          height="2.2"
+          fill="var(--mascot-icon-color)"
+        />
+        <rect
+          className="oc-tile"
+          x="2.9"
+          y="0.9"
+          width="2.2"
+          height="21.2"
+          fill="var(--mascot-icon-color)"
+        />
         {/* Inner rect split into 2×2 quadrants */}
-        <rect className="oc-tile" x="8"  y="6"  width="4" height="6" fill="var(--mascot-icon-color)" />
-        <rect className="oc-tile" x="12" y="6"  width="4" height="6" fill="var(--mascot-icon-color)" />
-        <rect className="oc-tile" x="8"  y="12" width="4" height="6" fill="var(--mascot-icon-color)" />
-        <rect className="oc-tile" x="12" y="12" width="4" height="6" fill="var(--mascot-icon-color)" />
+        <rect
+          className="oc-tile"
+          x="8"
+          y="6"
+          width="4"
+          height="6"
+          fill="var(--mascot-icon-color)"
+        />
+        <rect
+          className="oc-tile"
+          x="12"
+          y="6"
+          width="4"
+          height="6"
+          fill="var(--mascot-icon-color)"
+        />
+        <rect
+          className="oc-tile"
+          x="8"
+          y="12"
+          width="4"
+          height="6"
+          fill="var(--mascot-icon-color)"
+        />
+        <rect
+          className="oc-tile"
+          x="12"
+          y="12"
+          width="4"
+          height="6"
+          fill="var(--mascot-icon-color)"
+        />
       </g>
     </svg>
   );

--- a/src/hooks/use-scope.ts
+++ b/src/hooks/use-scope.ts
@@ -1,4 +1,4 @@
-import { useScopeStore, type ScopeValue } from "@/stores/scope-store";
+import { type ScopeValue, useScopeStore } from "@/stores/scope-store";
 
 function computeScopeId(scope: ScopeValue): string {
   if (scope.type === "all") return "all";

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -29,7 +29,7 @@ function validateGitUrl(url: string): void {
 }
 
 function validateNonEmpty(value: string, label: string): void {
-  if (!value || !value.trim()) {
+  if (!value?.trim()) {
     throw new Error(`${label} cannot be empty`);
   }
 }

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -65,7 +65,7 @@ async function httpInvoke<T>(
   };
   const token = getAuthToken();
   if (token) {
-    headers["Authorization"] = `Bearer ${token}`;
+    headers.Authorization = `Bearer ${token}`;
   }
 
   const response = await fetch(`/api/${command}`, {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 
+// biome-ignore lint/style/noNonNullAssertion: standard React entry — index.html guarantees a #root mount point.
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />

--- a/src/pages/agents.tsx
+++ b/src/pages/agents.tsx
@@ -60,7 +60,10 @@ export default function AgentsPage() {
     const agent = searchParams.get("agent");
     if (loading || !agent) return;
     const file = searchParams.get("file");
-    const targetScope = resolveDeepLinkScope(searchParams.get("scope"), projects);
+    const targetScope = resolveDeepLinkScope(
+      searchParams.get("scope"),
+      projects,
+    );
     if (!scopesEqual(targetScope, scope)) {
       setScope(targetScope);
       prevScopeRef.current = targetScope;

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -30,8 +30,8 @@ import {
   agentDisplayName,
   type ConfigScope,
   type MarketplaceItem,
-  scopeKey,
   type SkillAuditInfo,
+  scopeKey,
   sortAgents,
 } from "@/lib/types";
 import { useAgentStore } from "@/stores/agent-store";

--- a/src/stores/__tests__/extension-helpers.test.ts
+++ b/src/stores/__tests__/extension-helpers.test.ts
@@ -245,6 +245,7 @@ describe("expandGroupKeys", () => {
     const a = { ...baseExt, id: "ext-1", name: "skill-a" };
     const b = { ...baseExt, id: "ext-2", name: "skill-b" };
     const groups = buildGroups([a, b]);
+    // biome-ignore lint/style/noNonNullAssertion: test asserts the group exists; failing the find should fail the test.
     const keyA = groups.find((g) => g.name === "skill-a")!.groupKey;
 
     const ids = expandGroupKeys(groups, new Set([keyA]));

--- a/src/stores/agent-config-store.ts
+++ b/src/stores/agent-config-store.ts
@@ -114,8 +114,9 @@ export const useAgentConfigStore = create<AgentConfigState>((set, get) => ({
   },
 
   async fetchPreview(path: string) {
-    if (get().previewCache.has(path)) {
-      return get().previewCache.get(path)!;
+    const cached = get().previewCache.get(path);
+    if (cached !== undefined) {
+      return cached;
     }
     if (get().previewLoading.has(path)) {
       return "";


### PR DESCRIPTION
## Summary

- **Mechanical refactor**: 8 pre-existing `read_dir + extension filter` loops (claude rules/commands/output-styles/projects-memory, gemini commands/policies, copilot hooks, codex memories) replaced with calls to the `files_with_ext` helper extracted in PR #42. Behaviour-preserving.
- **Frontend lint cleanup**: biome diagnostics driven from `13 errors + 12 warnings + 1 info` → **0 / 0 / 0**. Mix of `npm run lint:fix` (auto-fix), targeted refactors, and documented `biome-ignore` for legitimate trigger-sentinel patterns.
- No behaviour changes; pure tech-debt cleanup.

## Commits

```
f54bfbd chore(lint): drive biome to clean (0 errors / 0 warnings / 0 info)   (+120 / -51, 21 files)
5816098 refactor(adapter): dedupe remaining read_dir loops with files_with_ext (+16 / -74, 4 files)
```

Each commit is independently bisect-able and tests-clean.

## Commit 1 — Rust read_dir dedup

| Adapter | Function | Replacement |
|---|---|---|
| claude | `global_rules_files` (rules/), `global_settings_files` (commands/, output-styles/), `global_memory_files` (projects/*/memory/ inner loop) | 4 loops → 4 helper calls |
| gemini | `global_settings_files` (commands/, policies/) | 2 loops → 2 helper calls |
| copilot | `global_settings_files` (hooks/) | 1 loop → 1 helper call |
| codex | `global_memory_files` (memories/) | 1 loop → helper + `.filter(\|p\| p.is_file())` to preserve prior `is_file()` defensive check |

Plugin / marketplace recursive multi-level scans intentionally left untouched — they don't fit the `files_with_ext` shape.

Closes the follow-up tracked in `project_adapter_readdir_helper_extract_roadmap.md`.

## Commit 2 — Frontend lint cleanup

### Auto-fix (Step 2 — `npm run lint:fix`, 8 files)
Pure cosmetic: import sorting, formatter pass, blank-line cleanup. Zero behaviour change.

### Manual fixes by category

**Category A — trivial mechanical (2 sites)**
- `transport.ts` `useLiteralKeys`: `headers["Authorization"]` → `.Authorization`
- `invoke.ts` `useOptionalChain`: `!value || !value.trim()` → `!value?.trim()`

**Category D — `noExplicitAny` (1 site, onboarding.tsx)**
- Removed dead `roughness` field from `rough-notation`'s `annotate()` config (library hardcodes its own roughness via `getOptions(type)` in `render.js` and never reads user-supplied values), removed accompanying `as any`.

**Category C — `useExhaustiveDependencies` (4 files, 5 findings)**
Each is a deliberate trigger-sentinel pattern; auto-fix would have broken behaviour. Documented with single-line `biome-ignore`:
- `section-anchor-rail` `revisionKey` (re-discovery sentinel — see component JSDoc)
- `extension-filters` `extensions` (Zustand store closure trigger via `grouped()`)
- `extension-table` `scope` (cell-renderer `getState()` trigger)
- `scope-switcher-menu` `handleSelect` / `handleAddProject` (new closures capturing only stable refs — adding them only churns the keydown listener)

Also replaced an obsolete `eslint-disable-next-line` comment (project uses biome, not eslint).

**Category B — `noNonNullAssertion` (9 sites)**
Per-site judgment call:
- **5 biome-ignore** where the `!` is a TS-narrowing limitation through JSX or by-construction guarantees (React entry pattern, JSX `&&` gates not propagating into callbacks, `Map.get` of own keys, test idiom).
- **4 refactors** where a small rewrite removes the `!` cleanly:
  - `delete-dialog`: redundant `&& filteredSkillLocations` lets TS narrow inside the ternary's true branch
  - `extension-detail`: extracted `activePath` local variable via IIFE wrapper (kills 2 `!`)
  - `new-skills-dialog`: explicit Map get-or-create binding instead of `has()` + `get()!`
  - `agent-config-store`: single `get()` + `cached !== undefined` check (cache stores strings only, so `undefined` ≡ `!has`); also reduces a redundant zustand `get()` call

## Test coverage

- `cargo build --workspace`: clean
- `cargo test --workspace`: **402 tests pass** (385 hk-core + 17 across other crates)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `npx tsc --noEmit`: clean
- `npm run lint` (biome): **0 errors / 0 warnings / 0 info**
- `npx vitest run`: **148 / 148** pass

## Test plan

- [x] CI passes on all platforms
- [x] No visible regression in agent detail panels (Subagents/Settings/Workflow/Rules/Memory/Ignore sections)
- [x] No visible regression in extension detail / delete dialog / new-skills dialog
- [x] Onboarding rough-notation annotations still render correctly (since `roughness` user-config was dead, visuals should be identical)

## Roadmap follow-ups not in this PR

None new. The roadmap entry `project_adapter_readdir_helper_extract_roadmap.md` is now complete and can be retired.