### PR TITLE
fix(antigravity): correct base_dir + support .agents/ canonical paths

### DIFF
--- a/crates/hk-core/src/adapter/antigravity.rs
+++ b/crates/hk-core/src/adapter/antigravity.rs
@@ -1,6 +1,14 @@
 // MCP config reference: https://antigravity.google/docs/mcp
 // Config file: ~/.gemini/antigravity/mcp_config.json
 // Format: JSON, top-level key "mcpServers", sub-keys: command, args, env, serverUrl, headers, etc.
+//
+// Data directory note: Antigravity has TWO directories on disk:
+//   - ~/.antigravity/         → VS Code-fork IDE shell data (extensions/, argv.json) —
+//                               undocumented by Google, inferred only from product.json
+//                               `dataFolderName: ".antigravity"`. Not used as base_dir.
+//   - ~/.gemini/antigravity/  → AI agent runtime data (skills, mcp_config.json,
+//                               brain/, knowledge/, conversations/) — the path Google's
+//                               docs and codelabs actually reference. Used as base_dir.
 
 use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker};
 use std::path::{Path, PathBuf};
@@ -43,16 +51,17 @@ impl AgentAdapter for AntigravityAdapter {
         true
     }
     fn base_dir(&self) -> PathBuf {
-        self.home.join(".antigravity")
+        self.home.join(".gemini").join("antigravity")
     }
     fn detect(&self) -> bool {
         self.base_dir().exists()
     }
     fn skill_dirs(&self) -> Vec<PathBuf> {
-        vec![
-            self.base_dir().join("skills"),
-            self.home.join(".gemini").join("antigravity").join("skills"),
-        ]
+        // Antigravity does NOT scan ~/.gemini/skills/ (Gemini CLI's path) or
+        // ~/.agents/skills/ — cross-loading from Gemini CLI requires a manual
+        // symlink per Google's own guidance.
+        // Source: https://codelabs.developers.google.com/getting-started-with-antigravity-skills
+        vec![self.base_dir().join("skills")]
     }
     fn project_skill_dirs(&self) -> Vec<String> {
         // Antigravity workspace skills.
@@ -61,16 +70,18 @@ impl AgentAdapter for AntigravityAdapter {
         vec![".agent/skills".into()]
     }
     fn mcp_config_path(&self) -> PathBuf {
-        self.home
-            .join(".gemini")
-            .join("antigravity")
-            .join("mcp_config.json")
+        self.base_dir().join("mcp_config.json")
     }
     fn hook_config_path(&self) -> PathBuf {
-        self.base_dir().join("settings.json")
+        // Antigravity has no hook system — `hook_format() = None` makes this
+        // a dead-code placeholder, never read or written.
+        self.base_dir().join("hooks.unused")
     }
     fn plugin_dirs(&self) -> Vec<PathBuf> {
-        vec![self.base_dir().join("plugins")]
+        // Antigravity has no file-based plugin system. The "plugin" surface
+        // is VS Code-style VSIX extensions in ~/.antigravity/extensions/, a
+        // different extension class than HK's plugin model.
+        vec![]
     }
 
     fn global_rules_files(&self) -> Vec<PathBuf> {
@@ -78,12 +89,7 @@ impl AgentAdapter for AntigravityAdapter {
     }
 
     fn global_settings_files(&self) -> Vec<PathBuf> {
-        vec![
-            self.home
-                .join(".gemini")
-                .join("antigravity")
-                .join("mcp_config.json"),
-        ]
+        vec![self.base_dir().join("mcp_config.json")]
     }
 
     fn project_markers(&self) -> Vec<ProjectMarker> {
@@ -165,8 +171,8 @@ mod tests {
     #[test]
     fn read_hooks_returns_empty() {
         let tmp = tempfile::tempdir().unwrap();
-        // Even with a hooks-like config, Antigravity should return nothing
-        let ag_dir = tmp.path().join(".antigravity");
+        // Even with a hooks-like config in the base_dir, Antigravity should return nothing
+        let ag_dir = tmp.path().join(".gemini").join("antigravity");
         std::fs::create_dir_all(&ag_dir).unwrap();
         std::fs::write(
             ag_dir.join("settings.json"),

--- a/crates/hk-core/src/adapter/antigravity.rs
+++ b/crates/hk-core/src/adapter/antigravity.rs
@@ -64,10 +64,10 @@ impl AgentAdapter for AntigravityAdapter {
         vec![self.base_dir().join("skills")]
     }
     fn project_skill_dirs(&self) -> Vec<String> {
-        // Antigravity workspace skills.
-        // SINGULAR ".agent/skills" (Antigravity convention) — NOT ".agents/skills".
-        // Source: https://codelabs.developers.google.com/getting-started-with-antigravity-skills
-        vec![".agent/skills".into()]
+        // Antigravity 1.18.4+ migrated from `.agent/` (singular) to `.agents/`
+        // (plural). Both still load; `.agents/` is canonical going forward.
+        // Source: https://discuss.ai.google.dev/t/new-folder-for-rules/126165
+        vec![".agents/skills".into(), ".agent/skills".into()]
     }
     fn mcp_config_path(&self) -> PathBuf {
         self.base_dir().join("mcp_config.json")
@@ -93,16 +93,21 @@ impl AgentAdapter for AntigravityAdapter {
     }
 
     fn project_markers(&self) -> Vec<ProjectMarker> {
+        // `.agents/` is canonical (1.18.4+); `.agent/` kept for backward compat.
         vec![
+            ProjectMarker::Dir(".agents/rules"),
+            ProjectMarker::Dir(".agents/skills"),
             ProjectMarker::Dir(".agent/rules"),
             ProjectMarker::Dir(".agent/skills"),
         ]
     }
 
     fn project_rules_patterns(&self) -> Vec<String> {
+        // `.agents/` is canonical (1.18.4+); `.agent/` kept for backward compat.
+        // Source: https://discuss.ai.google.dev/t/new-folder-for-rules/126165
         vec![
             ".agents/rules/*.md".into(),
-            ".agent/rules/*.md".into(), // backward compat
+            ".agent/rules/*.md".into(),
         ]
     }
 

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -457,7 +457,7 @@ mod tests {
             ("cursor", ".cursor/skills"),
             ("windsurf", ".windsurf/skills"),
             ("gemini", ".gemini/skills"),
-            ("antigravity", ".agent/skills"), // Singular — Antigravity convention
+            ("antigravity", ".agents/skills"), // 1.18.4+ canonical; .agent/ kept as backward-compat alias
             ("copilot", ".github/skills"),
             ("opencode", ".opencode/skills"),
         ]


### PR DESCRIPTION
## Summary

- **`base_dir` correction**: Antigravity has two on-disk directories — `~/.antigravity/` (VS Code-fork IDE shell, undocumented by Google) and `~/.gemini/antigravity/` (the AI agent runtime, where every Antigravity-related path Google's docs reference actually lives). HK previously used the IDE shell as `base_dir`, causing `skill_dirs` to write to a directory Antigravity doesn't scan, `plugin_dirs` to point at a fabricated path, and `hook_config_path` to point at a non-existent file. Switch `base_dir` to `~/.gemini/antigravity/`; consolidate skill/MCP/settings paths via `base_dir().join(...)`. Empty `plugin_dirs` (Antigravity has no file-based plugin system; its "plugin" surface is VS Code VSIX extensions). Park `hook_config_path` on an inert placeholder (dead code since `hook_format=None`).
- **`.agents/` canonical path support**: Antigravity 1.18.4+ migrated workspace dirs from `.agent/` (singular) to `.agents/` (plural). Per Google staff on the AI Developers Forum, plural is canonical going forward; singular kept as backward-compat. Update `project_skill_dirs`, `project_markers`, and `project_rules_patterns` to scan/install both forms, plural first.

## Why

Surfaced while triaging issue #22 item 5 (the user's question about whether HK differentiates Gemini CLI from Antigravity). Verification of the install pipeline against Antigravity's actual on-disk paths uncovered: (a) `~/.antigravity/skills/` was never read by Antigravity (HK had been creating an empty orphan directory there during scans), and (b) HK still treated `.agent/` as the only canonical workspace path, missing the `.agents/` migration.

Path facts cross-verified against:
- Official Antigravity codelab "Getting Started": `Global rule: ~/.gemini/GEMINI.md`, `Workspace rules: your-workspace/.agents/rules/`, `Workspace workflows: your-workspace/.agents/workflows/`, `Global workflow: ~/.gemini/antigravity/global_workflows/`
- Official Antigravity Skills codelab: `~/.gemini/antigravity/skills/` (global), `.agent/skills/` (workspace, older convention)
- `antigravity.google/docs/mcp`: `~/.gemini/antigravity/mcp_config.json`
- AI Developers Forum (Google staff Abhijit_Pramanik): "We've moved towards `.agents/`, but we do have backward support for `.agent` still… `.agents` (plural) should be used"
- Antigravity.app `product.json`: `dataFolderName: ".antigravity"` (the IDE shell folder, never user-documented)

## What's NOT in this PR

Saved as roadmap for follow-up PRs:
- **Workflows surface**: officially documented (`.agents/workflows/` + `~/.gemini/antigravity/global_workflows/`) but a new extension kind requiring trait/UI/install-pipeline design — separate PR.
- **Codex adapter follow-ups**: discovered while researching issue #22 (memory path mislabel, skill global path verification, hooks feature flag prompt, project-scope subagent gap) — separate PR.

## Test plan

- [x] `cargo test --workspace` — 402 tests pass (385 hk-core unit + 8 toggle integration + others)
- [x] `npm test` — 148/148 frontend tests pass
- [x] `npm run build` — frontend build clean
- [x] Manual smoke in `npm run tauri dev`:
  - [x] Antigravity detected on home machine (new `base_dir` reachable)
  - [x] Skills section shows `~/.gemini/antigravity/skills/` contents
  - [x] Plugins section empty (no fabricated entries)
  - [x] MCP section shows `mcp_config.json` contents unchanged
  - [x] Rules section shows `~/.gemini/GEMINI.md` (verified by codelab as the shared global rule file)
  - [x] Install-to-Agent (global) lands in `~/.gemini/antigravity/skills/<name>/`
  - [x] Install-to-Agent (project) lands in `<project>/.agents/skills/<name>/` (canonical form)

🤖 Generated with [Claude Code](https://claude.com/claude-code)