### PR TITLE
perf(marketplace): reduce tab-switch lag with async CLI list and expl…

### DIFF
--- a/crates/hk-desktop/src/commands/install.rs
+++ b/crates/hk-desktop/src/commands/install.rs
@@ -220,7 +220,14 @@ pub async fn scan_git_repo(
         let clone_dir = temp.path().join("repo");
 
         let output = std::process::Command::new("git")
-            .args(["clone", "--depth", "1", "--", &url, &clone_dir.to_string_lossy()])
+            .args([
+                "clone",
+                "--depth",
+                "1",
+                "--",
+                &url,
+                &clone_dir.to_string_lossy(),
+            ])
             .output()
             .map_err(|e| HkError::CommandFailed(format!("Failed to run git clone: {}", e)))?;
 
@@ -289,7 +296,9 @@ pub async fn scan_git_repo(
                         checked_at: None,
                         check_error: None,
                     };
-                    let pack = meta.url.as_deref()
+                    let pack = meta
+                        .url
+                        .as_deref()
                         .and_then(hk_core::scanner::extract_pack_from_url);
                     let store = store_clone.lock();
                     service::post_install_sync(
@@ -392,7 +401,11 @@ pub async fn install_scanned_skills(
                         url: Some(pending.url.clone()),
                         url_resolved: None,
                         branch: None,
-                        subpath: if sid.is_empty() { None } else { Some(sid.clone()) },
+                        subpath: if sid.is_empty() {
+                            None
+                        } else {
+                            Some(sid.clone())
+                        },
                         revision: result.revision.clone(),
                         remote_revision: None,
                         checked_at: None,
@@ -464,7 +477,14 @@ pub async fn install_new_repo_skills(
             .map_err(|e| HkError::Internal(format!("Failed to create temp directory: {e}")))?;
         let clone_dir = temp.path().join("repo");
         let output = std::process::Command::new("git")
-            .args(["clone", "--depth", "1", "--", &url, &clone_dir.to_string_lossy()])
+            .args([
+                "clone",
+                "--depth",
+                "1",
+                "--",
+                &url,
+                &clone_dir.to_string_lossy(),
+            ])
             .output()
             .map_err(|e| HkError::CommandFailed(format!("Failed to run git clone: {e}")))?;
         if !output.status.success() {
@@ -490,13 +510,13 @@ pub async fn install_new_repo_skills(
             std::fs::create_dir_all(&target_dir)?;
 
             for sid in &skill_ids {
-                let skill_id_opt = if sid.is_empty() { None } else { Some(sid.as_str()) };
-                let result = manager::install_from_clone(
-                    &clone_dir,
-                    &target_dir,
-                    skill_id_opt,
-                    &url,
-                )?;
+                let skill_id_opt = if sid.is_empty() {
+                    None
+                } else {
+                    Some(sid.as_str())
+                };
+                let result =
+                    manager::install_from_clone(&clone_dir, &target_dir, skill_id_opt, &url)?;
                 results.push((agent_name.clone(), sid.clone(), result));
             }
         }
@@ -513,7 +533,11 @@ pub async fn install_new_repo_skills(
                         url: Some(url.clone()),
                         url_resolved: None,
                         branch: None,
-                        subpath: if sid.is_empty() { None } else { Some(sid.clone()) },
+                        subpath: if sid.is_empty() {
+                            None
+                        } else {
+                            Some(sid.clone())
+                        },
                         revision: result.revision.clone(),
                         remote_revision: None,
                         checked_at: None,
@@ -536,7 +560,11 @@ pub async fn install_new_repo_skills(
                     url: Some(url.clone()),
                     url_resolved: None,
                     branch: None,
-                    subpath: if sid.is_empty() { None } else { Some(sid.clone()) },
+                    subpath: if sid.is_empty() {
+                        None
+                    } else {
+                        Some(sid.clone())
+                    },
                     revision: result.revision.clone(),
                     remote_revision: None,
                     checked_at: None,
@@ -593,7 +621,8 @@ pub fn get_cli_with_children(
 }
 
 #[tauri::command]
-pub fn list_cli_marketplace() -> Result<Vec<marketplace::MarketplaceItem>, HkError> {
-    Ok(marketplace::list_cli_registry())
+pub async fn list_cli_marketplace() -> Result<Vec<marketplace::MarketplaceItem>, HkError> {
+    tauri::async_runtime::spawn_blocking(marketplace::list_cli_registry)
+        .await
+        .map_err(|e| HkError::Internal(e.to_string()))
 }
-

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -312,8 +312,8 @@ export default function MarketplacePage() {
     fetchAgents();
   }, [fetchAgents]);
   useEffect(() => {
-    loadTrending();
-  }, [loadTrending]);
+    loadTrending(tab);
+  }, [tab, loadTrending]);
   useEffect(() => {
     if (selectedItem) detailPanelRef.current?.focus({ preventScroll: true });
   }, [selectedItem]);

--- a/src/stores/marketplace-store.ts
+++ b/src/stores/marketplace-store.ts
@@ -37,7 +37,7 @@ interface MarketplaceState {
   setTab: (tab: TabKind) => void;
   setQuery: (query: string) => void;
   search: () => Promise<void>;
-  loadTrending: () => Promise<void>;
+  loadTrending: (tab?: TabKind) => Promise<void>;
   selectItem: (item: MarketplaceItem) => void;
   closePreview: () => void;
   install: (
@@ -182,8 +182,8 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
       query: "",
       selectedItem: null,
       trending: trendingCache[tab],
+      trendingLoading: trendingCache[tab].length === 0,
     });
-    get().loadTrending();
   },
   setQuery(query) {
     set({ query });
@@ -214,8 +214,9 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
       set({ results: [], loading: false });
     }
   },
-  async loadTrending() {
-    const { tab, trendingFetchedAt } = get();
+  async loadTrending(tabOverride) {
+    const tab = tabOverride ?? get().tab;
+    const { trendingFetchedAt } = get();
     if (Date.now() - trendingFetchedAt[tab] < TRENDING_TTL) return;
     // Clear detail caches on refresh so stale data doesn't linger
     set({

--- a/src/stores/marketplace-store.ts
+++ b/src/stores/marketplace-store.ts
@@ -175,14 +175,18 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
   auditCache: new Map(),
   cliReadmeCache: new Map(),
   setTab(tab) {
-    const { trendingCache } = get();
+    const { trendingCache, tab: prevTab } = get();
     set({
       tab,
       results: [],
       query: "",
       selectedItem: null,
       trending: trendingCache[tab],
-      trendingLoading: trendingCache[tab].length === 0,
+      // Only flag loading when tab actually changes — otherwise the
+      // [tab]-keyed useEffect in marketplace.tsx won't refire and the
+      // spinner would be stuck (e.g. user clicks the active tab after
+      // a failed fetch left trendingCache[tab] empty).
+      trendingLoading: tab !== prevTab && trendingCache[tab].length === 0,
     });
   },
   setQuery(query) {


### PR DESCRIPTION
## Summary

- Made `list_cli_marketplace` async via `spawn_blocking` so the Tauri event loop
  is not blocked during CLI registry loading
- Moved `loadTrending` trigger from the store's `setTab` into the component
  `useEffect`, passing `tab` explicitly to avoid stale state

## Test plan

- [x] First switch to AGENT-first CLI tab no longer causes noticeable UI lag
- [x] Trending section updates correctly when switching between tabs
- [x] CLI marketplace list loads asynchronously without blocking the UI

## Before

<img width="1072" height="648" alt="PixPin_2026-05-13_11-15-11" src="https://github.com/user-attachments/assets/fa071ff0-1eaf-46f8-b97e-3b8f2b7ccaa3" />

## After

<img width="1066" height="636" alt="PixPin_2026-05-13_11-16-08" src="https://github.com/user-attachments/assets/47a30ceb-3c17-4a77-a494-fbae8973df8d" />
