### PR TITLE
fix(marketplace): drop stale fetch results when tab changed mid-flight

### DIFF
--- a/src/stores/marketplace-store.ts
+++ b/src/stores/marketplace-store.ts
@@ -247,21 +247,24 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
       if (tab === "cli") {
         const trending = await api.listCliMarketplace();
         saveToDisk(trending);
+        // If the user switched tabs while we were fetching, only persist
+        // the cache — touching `trending`/`trendingLoading` would clobber
+        // the new tab's live state.
+        const stillCurrent = get().tab === tab;
         set({
-          trending,
-          trendingLoading: false,
           trendingCache: { ...get().trendingCache, cli: trending },
           trendingFetchedAt: { ...get().trendingFetchedAt, cli: Date.now() },
+          ...(stillCurrent ? { trending, trendingLoading: false } : {}),
         });
         return;
       }
       const trending = await api.trendingMarketplace(tab, 10);
       saveToDisk(trending);
+      const stillCurrent = get().tab === tab;
       set({
-        trending,
-        trendingLoading: false,
         trendingCache: { ...get().trendingCache, [tab]: trending },
         trendingFetchedAt: { ...get().trendingFetchedAt, [tab]: Date.now() },
+        ...(stillCurrent ? { trending, trendingLoading: false } : {}),
       });
       // Pre-fetch preview + audit for skill items in background
       if (tab === "skill") {
@@ -269,6 +272,9 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
       }
     } catch (e) {
       console.error("Failed to load marketplace trending data:", e);
+      // Skip the disk fallback if the user already switched tabs —
+      // would otherwise clobber the new tab's live state.
+      if (get().tab !== tab) return;
       // Fallback to last successful fetch from disk
       const cached = loadFromDisk();
       set({ trending: cached, trendingLoading: false });


### PR DESCRIPTION
## Summary

Follow-up to #50. When a slow CLI fetch resolved after the user already
switched away, `loadTrending` would unconditionally overwrite
`trending`/`trendingLoading`, briefly showing CLI items in the Skills tab.

This guards the post-await `set()`s with `get().tab === tab`:

- Always persist `trendingCache` + `trendingFetchedAt` so the data is
  available next time the user comes back.
- Only update the live display state (`trending`, `trendingLoading`) when
  still on the originating tab.
- The catch branch bails entirely — the disk fallback shouldn't clobber
  the new tab either.

## Test plan

- [x] Slow CLI fetch + switch away mid-flight: Skills tab no longer shows
      CLI items after the late resolve.
- [x] Coming back to CLI tab afterwards loads from cache instantly (no
      refetch), confirming the stale fetch's cache write still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)