### PR TITLE
feat(extensions): show per-instance scope and git revision in detail panel

### DIFF
--- a/src/components/extensions/detail-paths.tsx
+++ b/src/components/extensions/detail-paths.tsx
@@ -1,16 +1,42 @@
-import { FolderOpen, Link } from "lucide-react";
+import { FolderOpen, GitCommitHorizontal, Link } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type {
+  ConfigScope,
   ExtensionContent as ExtContent,
   GroupedExtension,
 } from "@/lib/types";
-import { agentDisplayName, sortAgentNames } from "@/lib/types";
+import { agentDisplayName, instanceVersion } from "@/lib/types";
 
 interface DetailPathsProps {
   group: GroupedExtension;
   instanceData: Map<string, ExtContent>;
   skillLocations: [string, string, string | null][];
   agentOrder: readonly string[];
+}
+
+function instanceDir(sourcePath: string): string {
+  return sourcePath.replace(/\/SKILL\.md(\.disabled)?$/, "");
+}
+
+function ScopePill({
+  scope,
+  globalLabel,
+}: {
+  scope: ConfigScope;
+  globalLabel: string;
+}) {
+  const isGlobal = scope.type === "global";
+  const classes = isGlobal
+    ? "bg-blue-500/15 text-blue-700 ring-blue-500/25 dark:text-blue-300"
+    : "bg-emerald-500/15 text-emerald-700 ring-emerald-500/25 dark:text-emerald-300";
+  return (
+    <span
+      className={`inline-block max-w-[160px] truncate rounded-full px-2 py-0.5 text-[10px] font-medium ring-1 ring-inset ${classes}`}
+      title={isGlobal ? undefined : scope.name}
+    >
+      {isGlobal ? globalLabel : scope.name}
+    </span>
+  );
 }
 
 export function DetailPaths({
@@ -20,125 +46,123 @@ export function DetailPaths({
   agentOrder,
 }: DetailPathsProps) {
   const { t } = useTranslation("extensions");
+  const { t: tc } = useTranslation("common");
   if (group.kind === "cli" || group.instances.length === 0) return null;
 
   // skillLocations is scope-agnostic on purpose (the get_skill_locations
   // API surfaces every place a skill named X exists, used by other UIs).
-  // For the detail panel we only care about paths that actually belong to
-  // *this* group's instances — otherwise a project-level skill row would
-  // mistakenly show its same-named global cousin's path. Build a set of
-  // directories referenced by this group's instances' source_path and
-  // filter skillLocations against it.
-  const instanceDirs = new Set(
-    group.instances
-      .map((inst) => inst.source_path)
-      .filter((p): p is string => !!p)
-      .map((p) => p.replace(/\/SKILL\.md(\.disabled)?$/, "")),
+  // We render one card per instance; each card resolves its physical
+  // path(s) by matching skillLocations against this instance's source_path
+  // dir, falling back to instanceData for instances without on-disk scan
+  // results.
+  const hasAnyVersion = group.instances.some(
+    (i) => instanceVersion(i) !== null,
   );
-  const filteredLocations =
-    instanceDirs.size > 0
-      ? skillLocations.filter(([, dir]) => instanceDirs.has(dir))
-      : skillLocations;
 
+  // Sort instances by agent order, then global-before-project, then by
+  // project name. Stable so multi-scope on the same agent clusters.
+  const agentRank = new Map(agentOrder.map((a, i) => [a, i] as const));
+  const sortedInstances = [...group.instances].sort((a, b) => {
+    const aAgent = a.agents[0] ?? "unknown";
+    const bAgent = b.agents[0] ?? "unknown";
+    const aRank = agentRank.get(aAgent) ?? Number.MAX_SAFE_INTEGER;
+    const bRank = agentRank.get(bAgent) ?? Number.MAX_SAFE_INTEGER;
+    if (aRank !== bRank) return aRank - bRank;
+    if (a.scope.type !== b.scope.type)
+      return a.scope.type === "global" ? -1 : 1;
+    if (a.scope.type === "project" && b.scope.type === "project")
+      return a.scope.name.localeCompare(b.scope.name);
+    return 0;
+  });
   return (
     <div className="mt-4">
       <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
         {t("detailPaths.paths")}
       </h4>
       <div className="space-y-3">
-        {(() => {
-          // Group instances by agent, sorted by agent order
-          const byAgent = new Map<string, typeof group.instances>();
-          for (const inst of group.instances) {
-            const agent = inst.agents[0] ?? "unknown";
-            const list = byAgent.get(agent) ?? [];
-            list.push(inst);
-            byAgent.set(agent, list);
-          }
-          const sortedAgentNames = sortAgentNames(
-            [...byAgent.keys()],
-            agentOrder,
-          );
-          return sortedAgentNames.map((agentName) => {
-            // biome-ignore lint/style/noNonNullAssertion: agentName came from byAgent.keys(), so the value exists by construction.
-            const instances = byAgent.get(agentName)!;
-            const firstData = instanceData.get(instances[0].id);
-            const agentLocations = filteredLocations.filter(
-              ([a]) => a === agentName,
-            );
-            // Collect unique event names for hooks
-            const hookEvents =
-              group.kind === "hook"
-                ? [
-                    ...new Set(
-                      instances
-                        .map((inst) => {
-                          const parts = inst.name.split(":");
-                          return parts.length >= 1 ? parts[0] : "";
-                        })
-                        .filter(Boolean),
-                    ),
-                  ]
+        {sortedInstances.map((inst) => {
+          const agent = inst.agents[0] ?? "unknown";
+          const data = instanceData.get(inst.id);
+          const dir = inst.source_path ? instanceDir(inst.source_path) : null;
+          const locations = dir
+            ? skillLocations.filter(([a, d]) => a === agent && d === dir)
+            : [];
+          const version = instanceVersion(inst);
+          // Hooks: surface this instance's event matcher (first colon-separated
+          // segment of inst.name; the wire format is `event:matcher:command`).
+          const hookEvent =
+            group.kind === "hook" ? inst.name.split(":")[0] : null;
+          // Normalize path display into a single list: prefer scan-discovered
+          // locations (each carries its own symlink), fall back to
+          // instanceData when the scanner found nothing for this instance.
+          const paths: { path: string; symlink: string | null }[] =
+            locations.length > 0
+              ? locations.map(([, p, s]) => ({
+                  path: p,
+                  symlink: s ?? data?.symlink_target ?? null,
+                }))
+              : data?.path
+                ? [{ path: data.path, symlink: data?.symlink_target ?? null }]
                 : [];
-            return (
+          return (
+            <div
+              key={inst.id}
+              className="rounded-lg border border-border bg-card p-3"
+            >
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                <span className="font-medium">{agentDisplayName(agent)}</span>
+                <ScopePill
+                  scope={inst.scope}
+                  globalLabel={tc("scope.global")}
+                />
+                {hasAnyVersion &&
+                  (version ? (
+                    <span
+                      className="inline-flex items-center gap-1 rounded bg-muted/70 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+                      title={t("detailPaths.revisionTooltip")}
+                    >
+                      <GitCommitHorizontal size={11} className="opacity-70" />
+                      {version}
+                    </span>
+                  ) : (
+                    <span
+                      className="text-xs text-muted-foreground/50"
+                      title={t("detailPaths.versionUnknownTooltip")}
+                    >
+                      —
+                    </span>
+                  ))}
+              </div>
               <div
-                key={agentName}
-                className="rounded-lg border border-border bg-card p-3"
+                className={`mt-1.5 space-y-1 ${!group.enabled ? "opacity-50" : ""}`}
               >
-                <span className="text-sm font-medium">
-                  {agentDisplayName(agentName)}
-                </span>
-                <div
-                  className={`mt-1.5 space-y-1 ${!group.enabled ? "opacity-50" : ""}`}
-                >
-                  {agentLocations.length > 0 ? (
-                    agentLocations.map(([, path, symlink]) => (
-                      <div key={path}>
-                        <div className="flex items-start gap-2 text-muted-foreground">
-                          <FolderOpen size={12} className="mt-0.5 shrink-0" />
-                          <span className="break-all text-xs">{path}</span>
-                        </div>
-                        {(symlink ?? firstData?.symlink_target) && (
-                          <div className="flex items-start gap-2 text-muted-foreground/70">
-                            <Link size={12} className="mt-0.5 shrink-0" />
-                            <span className="break-all text-xs italic">
-                              {symlink ?? firstData?.symlink_target}
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    ))
-                  ) : firstData?.path ? (
-                    <>
-                      <div className="flex items-start gap-2 text-muted-foreground">
-                        <FolderOpen size={12} className="mt-0.5 shrink-0" />
-                        <span className="break-all text-xs">
-                          {firstData.path}
+                {paths.map(({ path, symlink }) => (
+                  <div key={path}>
+                    <div className="flex items-start gap-2 text-muted-foreground">
+                      <FolderOpen size={12} className="mt-0.5 shrink-0" />
+                      <span className="break-all text-xs">{path}</span>
+                    </div>
+                    {symlink && (
+                      <div className="flex items-start gap-2 text-muted-foreground/70">
+                        <Link size={12} className="mt-0.5 shrink-0" />
+                        <span className="break-all text-xs italic">
+                          {symlink}
                         </span>
                       </div>
-                      {firstData?.symlink_target && (
-                        <div className="flex items-start gap-2 text-muted-foreground/70">
-                          <Link size={12} className="mt-0.5 shrink-0" />
-                          <span className="break-all text-xs italic">
-                            {firstData.symlink_target}
-                          </span>
-                        </div>
-                      )}
-                    </>
-                  ) : null}
-                  {hookEvents.length > 0 && (
-                    <div className="flex items-center gap-2 text-muted-foreground mt-0.5">
-                      <span className="text-xs">
-                        {t("detailPaths.event", { count: hookEvents.length })}:{" "}
-                        {hookEvents.join(", ")}
-                      </span>
-                    </div>
-                  )}
-                </div>
+                    )}
+                  </div>
+                ))}
+                {hookEvent && (
+                  <div className="flex items-center gap-2 text-muted-foreground mt-0.5">
+                    <span className="text-xs">
+                      {t("detailPaths.event", { count: 1 })}: {hookEvent}
+                    </span>
+                  </div>
+                )}
               </div>
-            );
-          });
-        })()}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/lib/i18n/locales/en/extensions.json
+++ b/src/lib/i18n/locales/en/extensions.json
@@ -155,7 +155,9 @@
   "detailPaths": {
     "paths": "Paths",
     "event_one": "Event",
-    "event_other": "Events"
+    "event_other": "Events",
+    "revisionTooltip": "Repo commit when installed",
+    "versionUnknownTooltip": "Not installed via HarnessKit; version unknown"
   },
   "cli": {
     "title": "CLI Details",

--- a/src/lib/i18n/locales/zh/extensions.json
+++ b/src/lib/i18n/locales/zh/extensions.json
@@ -155,7 +155,9 @@
   "detailPaths": {
     "paths": "路径",
     "event_one": "事件",
-    "event_other": "事件"
+    "event_other": "事件",
+    "revisionTooltip": "安装时该仓库的 commit",
+    "versionUnknownTooltip": "未通过 HarnessKit 安装，版本未知"
   },
   "cli": {
     "title": "CLI 详情",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -116,6 +116,18 @@ export function logicalExtensionName(ext: Extension): string {
   return ext.name;
 }
 
+/** Display version for a single extension instance.
+ *  Prefers semver (source.version, set by registry/marketplace installs) over
+ *  git short hash (install_meta.revision, set by git installs). Returns null
+ *  for sources that don't track a version (local file skills, agent-bundled
+ *  defaults, etc.) so the caller can decide whether to show a placeholder. */
+export function instanceVersion(inst: Extension): string | null {
+  if (inst.source.version) return inst.source.version;
+  if (inst.install_meta?.revision)
+    return inst.install_meta.revision.slice(0, 7);
+  return null;
+}
+
 /** Authoritative "where did this come from" URL for grouping purposes.
  *  Resolution order: source.url → install_meta.url → pack (synthesized to a
  *  GitHub URL so extractDeveloper handles it uniformly). `pack` is a


### PR DESCRIPTION
## Summary

Addresses issue #39 (comment 2): show per-agent version info in the Extensions Detail Panel so version drift across agents is visible.

The fix turned out structural — pills/cards used to key by agent alone, but the data model has one Extension instance per `(agent, scope)`. A multi-scope install on the same agent (e.g., Claude global + Claude project) used to collapse into one row and lose drift signal. The `PATHS` section now renders one card per instance.

### What changed in the UI

Each card header shows three elements:
- **Agent name**
- **Scope pill** — blue "Global" or emerald with the project name (always shown; project name has hover tooltip + max-width truncation)
- **Version chip** — `font-mono` + `GitCommitHorizontal` icon, tooltip clarifies it's the **repo commit at install time** (not a per-skill semver, since Anthropic's optional `metadata.version` is rarely populated in practice). Missing versions show `—` with a tooltip explaining the row wasn't installed via HarnessKit.

The top `AGENTS` pill row is intentionally unchanged — version/scope only appear in `PATHS`.

### What's a known follow-up (not in this PR)

A skill scanned by HK but never installed through HK has `install_meta = null` and renders `—`, even when a sibling row symlinked to the same physical files shows a hash. Tracked in `project_source_url_unification_roadmap.md` for a follow-up PR: scanner should backfill `revision` via `git rev-parse HEAD` when the source path is a git checkout.

## Test plan

- [x] Single-scope global, no version data → cards show `Agent · [Global]` with no chip (verify `—` doesn't appear when no instance in the group has a version)
- [x] Multi-agent with versions → each card shows its own hash chip; differing hashes are visually distinguishable
- [x] Multi-scope on same agent (e.g., Claude global + Claude project) → two separate cards, each with its own scope pill (project shows project name)
- [x] Long project name → pill truncates with `...`, hover tooltip shows full name
- [ ] Hook with multiple events bound to same agent → renders one card per event (intentional; per-instance display)
- [x] Light & dark mode → blue/emerald pills readable in both
- [x] Hover behaviors: version chip → "Repo commit when installed"; `—` → "Not installed via HarnessKit; version unknown"
- [x] zh locale: tooltips render Chinese strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)