### PR TITLE
fix(extensions): scope-aware delete and symlink-aware lifecycle

### DIFF
--- a/crates/hk-core/src/service.rs
+++ b/crates/hk-core/src/service.rs
@@ -9,32 +9,49 @@ use crate::{
 };
 use parking_lot::Mutex;
 
-/// Common post-install flow: scan affected agents, sync to store, set install meta,
-/// update pack, audit the installed extension(s), and persist audit results.
-///
-/// This extracts the duplicated 30-50 line pattern found in install_from_local,
-/// install_from_git, install_from_marketplace, scan_git_repo, and install_scanned_skills.
+/// Compare two filesystem paths, resolving symlinks where possible so that
+/// e.g. `~/.gemini/antigravity/skills` (symlink) and `~/.claude/skills`
+/// (target) are recognized as the same install location. Falls back to
+/// textual equality when either path can't be canonicalized (doesn't yet
+/// exist, permission error, etc.) so non-existent paths still compare
+/// correctly against each other.
+fn paths_equal(a: &std::path::Path, b: &std::path::Path) -> bool {
+    if a == b {
+        return true;
+    }
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => false,
+    }
+}
+
 /// Whether `adapter` scans the directory `dir` for skills under `scope`.
 /// Used to identify cross-vendor sibling adapters that share an install
 /// target (notably the `~/.agents/skills/` and `<repo>/.agents/skills`
-/// paths declared by multiple adapters).
+/// paths declared by multiple adapters, plus user-created symlinks across
+/// agent skill dirs).
 fn adapter_scans_dir(
     adapter: &dyn AgentAdapter,
     dir: &std::path::Path,
     scope: &ConfigScope,
 ) -> bool {
     match scope {
-        ConfigScope::Global => adapter.skill_dirs().iter().any(|d| d == dir),
+        ConfigScope::Global => adapter.skill_dirs().iter().any(|d| paths_equal(d, dir)),
         ConfigScope::Project { path, .. } => {
             let project_path = std::path::Path::new(path);
             adapter
                 .project_skill_dirs()
                 .iter()
-                .any(|rel| project_path.join(rel) == dir)
+                .any(|rel| paths_equal(&project_path.join(rel), dir))
         }
     }
 }
 
+/// Common post-install flow: scan affected agents, sync to store, set install meta,
+/// update pack, audit the installed extension(s), and persist audit results.
+///
+/// This extracts the duplicated 30-50 line pattern found in install_from_local,
+/// install_from_git, install_from_marketplace, scan_git_repo, and install_scanned_skills.
 pub fn post_install_sync(
     store: &Store,
     adapters: &[Box<dyn AgentAdapter>],
@@ -512,19 +529,63 @@ pub struct ExtensionContent {
 /// Disk and DB are mutated in two separately-locked phases so I/O does not
 /// hold the store mutex. The DB delete happens last; if disk removal fails
 /// the row stays so the next scan can recover.
+/// Find other skill rows whose source_path resolves (via symlinks) to the
+/// same physical file as `target`. Used by `delete_extension` to cascade
+/// the DB cleanup: deleting `~/.gemini/antigravity/skills/X/SKILL.md`
+/// (which is a symlink into `~/.claude/skills/X/SKILL.md`) physically
+/// removes both, so Claude's row must come along too. Canonicalization
+/// is done before Phase 2 of delete_extension so the target file still
+/// exists on disk; once it's gone canonicalize would fail.
+fn find_canonical_skill_siblings(
+    store: &Store,
+    target: &Extension,
+) -> Result<Vec<String>, HkError> {
+    let Some(target_path) = target.source_path.as_deref() else {
+        return Ok(Vec::new());
+    };
+    let Ok(target_canon) = std::fs::canonicalize(target_path) else {
+        return Ok(Vec::new());
+    };
+    let candidates = store.find_ids_by_name_and_kind(&target.name, "skill")?;
+    let mut siblings = Vec::new();
+    for cand_id in candidates {
+        if cand_id == target.id {
+            continue;
+        }
+        let Ok(Some(cand)) = store.get_extension(&cand_id) else {
+            continue;
+        };
+        let Some(cand_path) = cand.source_path.as_deref() else {
+            continue;
+        };
+        if std::fs::canonicalize(cand_path).ok().as_ref() == Some(&target_canon) {
+            siblings.push(cand_id);
+        }
+    }
+    Ok(siblings)
+}
+
 pub fn delete_extension(
     store: &Mutex<Store>,
     adapters: &[Box<dyn AgentAdapter>],
     id: &str,
 ) -> Result<(), HkError> {
-    // Phase 1: read metadata under the lock, then drop it before any I/O.
-    let (ext, projects) = {
+    // Phase 1: read metadata + find canonical siblings under the lock, then
+    // drop it before any I/O. An empty Option from get_extension is treated
+    // as success so the delete contract is idempotent — a parallel batch
+    // delete can ask to remove a row that an earlier cascade already cleared.
+    let (ext, projects, sibling_ids) = {
         let store = store.lock();
-        let ext = store
-            .get_extension(id)?
-            .ok_or_else(|| HkError::NotFound("Extension not found".into()))?;
+        let Some(ext) = store.get_extension(id)? else {
+            return Ok(());
+        };
         let projects = store.list_project_tuples();
-        (ext, projects)
+        let sibling_ids = if matches!(ext.kind, ExtensionKind::Skill) {
+            find_canonical_skill_siblings(&store, &ext)?
+        } else {
+            Vec::new()
+        };
+        (ext, projects, sibling_ids)
     };
 
     // Phase 2: filesystem / config-file mutation. No DB access here.
@@ -676,8 +737,18 @@ pub fn delete_extension(
         }
     }
 
-    // Phase 3: DB delete, only after disk side succeeded.
-    store.lock().delete_extension(id)
+    // Phase 3: DB delete, only after disk side succeeded. Cascade to any
+    // canonical-path siblings — their on-disk files were the same inode
+    // (the user reached them through a different agent's symlinked
+    // skill_dir) so they're already gone after Phase 2.
+    {
+        let store = store.lock();
+        store.delete_extension(id)?;
+        for sib_id in &sibling_ids {
+            let _ = store.delete_extension(sib_id);
+        }
+    }
+    Ok(())
 }
 
 /// Read the rich on-disk content for an extension (skill text, MCP server
@@ -1178,6 +1249,129 @@ mod tests {
         assert!(same_scope(&p1, &p1_alias));
         assert!(!same_scope(&g, &p1));
         assert!(!same_scope(&p1, &p2));
+    }
+
+    #[test]
+    fn paths_equal_textual_match_for_nonexistent_paths() {
+        // Falls back to textual eq when canonicalize fails (paths don't exist).
+        let p = std::path::Path::new("/nonexistent/path/x");
+        assert!(paths_equal(p, p));
+    }
+
+    #[test]
+    fn paths_equal_different_nonexistent_paths_not_equal() {
+        // Different non-existent paths return false (canonicalize fails, no fallback match).
+        let a = std::path::Path::new("/nonexistent/a");
+        let b = std::path::Path::new("/nonexistent/b");
+        assert!(!paths_equal(a, b));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn paths_equal_resolves_symlink_to_same_target() {
+        // The fix at issue: a symlink dir and its target should compare equal.
+        // Mirrors the user-visible bug where Antigravity's skill_dir is a
+        // symlink into Claude's skill_dir and cross-vendor propagation missed
+        // the connection due to textual-only comparison.
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert!(paths_equal(&target, &link));
+        assert!(paths_equal(&link, &target));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn paths_equal_distinct_real_dirs_not_equal() {
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        std::fs::create_dir(&a).unwrap();
+        std::fs::create_dir(&b).unwrap();
+        assert!(!paths_equal(&a, &b));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn canonical_siblings_finds_symlinked_row() {
+        // Mirrors the user-visible bug: Antigravity's skill_dir is a symlink
+        // pointing into Claude's skill_dir. Deleting Claude's row must
+        // cascade to Antigravity's row because the physical file is shared.
+        let tmp = TempDir::new().unwrap();
+        let claude_dir = tmp.path().join("claude/skills/code-review");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let claude_md = claude_dir.join("SKILL.md");
+        std::fs::write(&claude_md, "shared").unwrap();
+
+        let antigravity_parent = tmp.path().join("gemini/antigravity");
+        std::fs::create_dir_all(&antigravity_parent).unwrap();
+        let antigravity_skills = antigravity_parent.join("skills");
+        std::os::unix::fs::symlink(tmp.path().join("claude/skills"), &antigravity_skills)
+            .unwrap();
+        let antigravity_md = antigravity_skills.join("code-review/SKILL.md");
+        // Symlinked path should resolve to the same inode as claude_md.
+        assert_eq!(
+            std::fs::canonicalize(&antigravity_md).unwrap(),
+            std::fs::canonicalize(&claude_md).unwrap()
+        );
+
+        let (store, _dir) = test_store();
+        let mut claude_row = make_skill(ConfigScope::Global, Some(meta()));
+        claude_row.id = "claude-row".into();
+        claude_row.name = "code-review".into();
+        claude_row.source_path = Some(claude_md.to_string_lossy().to_string());
+        store.insert_extension(&claude_row).unwrap();
+
+        let mut antigrav_row = claude_row.clone();
+        antigrav_row.id = "antigrav-row".into();
+        antigrav_row.agents = vec!["antigravity".into()];
+        antigrav_row.source_path = Some(antigravity_md.to_string_lossy().to_string());
+        store.insert_extension(&antigrav_row).unwrap();
+
+        let siblings = find_canonical_skill_siblings(&store, &claude_row).unwrap();
+        assert_eq!(siblings, vec!["antigrav-row".to_string()]);
+    }
+
+    #[test]
+    fn canonical_siblings_skips_unrelated_rows() {
+        // Same name + kind but distinct physical paths must NOT cascade.
+        let tmp = TempDir::new().unwrap();
+        let a_dir = tmp.path().join("a/code-review");
+        let b_dir = tmp.path().join("b/code-review");
+        std::fs::create_dir_all(&a_dir).unwrap();
+        std::fs::create_dir_all(&b_dir).unwrap();
+        let a_md = a_dir.join("SKILL.md");
+        let b_md = b_dir.join("SKILL.md");
+        std::fs::write(&a_md, "a").unwrap();
+        std::fs::write(&b_md, "b").unwrap();
+
+        let (store, _dir) = test_store();
+        let mut a_row = make_skill(ConfigScope::Global, Some(meta()));
+        a_row.id = "a-row".into();
+        a_row.name = "code-review".into();
+        a_row.source_path = Some(a_md.to_string_lossy().to_string());
+        store.insert_extension(&a_row).unwrap();
+
+        let mut b_row = a_row.clone();
+        b_row.id = "b-row".into();
+        b_row.agents = vec!["codex".into()];
+        b_row.source_path = Some(b_md.to_string_lossy().to_string());
+        store.insert_extension(&b_row).unwrap();
+
+        let siblings = find_canonical_skill_siblings(&store, &a_row).unwrap();
+        assert!(siblings.is_empty());
+    }
+
+    #[test]
+    fn canonical_siblings_returns_empty_when_no_source_path() {
+        let (store, _dir) = test_store();
+        let target = make_skill(ConfigScope::Global, None);
+        // source_path = None → can't canonicalize → empty.
+        let siblings = find_canonical_skill_siblings(&store, &target).unwrap();
+        assert!(siblings.is_empty());
     }
 
     #[test]

--- a/src/components/extensions/delete-dialog.tsx
+++ b/src/components/extensions/delete-dialog.tsx
@@ -8,11 +8,14 @@ import type {
   Extension,
   GroupedExtension,
 } from "@/lib/types";
-import { agentDisplayName } from "@/lib/types";
+import { agentDisplayName, instanceDir } from "@/lib/types";
 
 type DeleteItem = {
   key: string;
   agents: string[];
+  /** Instance IDs this item represents — passed to the backend so deletion
+   *  is scoped per-row, not per-agent (which collapses multi-scope rows). */
+  ids: string[];
   paths: string[];
   mcps: string[];
   shared: boolean;
@@ -24,23 +27,37 @@ type DeleteItem = {
 /**
  * Build path-based delete items from skill locations.
  * Each item = one physical path, with agent names as the primary label.
+ * IDs are resolved by matching (agent, source_path dir) against group instances
+ * so a multi-scope skill (same agent, two scopes, two source_paths) produces
+ * two distinct items — preventing the old "delete from agent X" from silently
+ * removing rows in other scopes for the same agent.
  */
 function buildPathItems(
   locations: [string, string, string | null][],
+  instances: GroupedExtension["instances"],
 ): DeleteItem[] {
-  const pathMap = new Map<string, { agents: string[]; symlink?: string }>();
+  const pathMap = new Map<
+    string,
+    { agents: string[]; ids: string[]; symlink?: string }
+  >();
   for (const [agent, path, symlinkTarget] of locations) {
-    const entry = pathMap.get(path) ?? { agents: [] };
+    const entry = pathMap.get(path) ?? { agents: [], ids: [] };
     if (!entry.agents.includes(agent)) entry.agents.push(agent);
+    for (const inst of instances) {
+      if (!inst.agents.includes(agent)) continue;
+      if (instanceDir(inst) !== path) continue;
+      if (!entry.ids.includes(inst.id)) entry.ids.push(inst.id);
+    }
     if (symlinkTarget) entry.symlink = symlinkTarget;
     pathMap.set(path, entry);
   }
 
   const items: DeleteItem[] = [];
-  for (const [path, { agents, symlink }] of pathMap) {
+  for (const [path, { agents, ids, symlink }] of pathMap) {
     items.push({
       key: `path:${path}`,
       agents,
+      ids,
       paths: [path],
       mcps: [],
       shared: agents.length > 1,
@@ -85,6 +102,7 @@ function buildAgentItems(
     return {
       key: `agent:${inst.agents[0]}`,
       agents: [...inst.agents],
+      ids: [inst.id],
       paths: configPath ? [configPath] : [],
       mcps: [],
       shared: false,
@@ -111,7 +129,7 @@ export function DeleteDialog({
   deleting: boolean;
   deleteAgents: Set<string>;
   setDeleteAgents: (s: Set<string>) => void;
-  onDelete: (agents: string[]) => void;
+  onDelete: (ids: string[]) => void;
   onClose: () => void;
   childExtensions?: Extension[];
   skillLocations?: [string, string, string | null][];
@@ -224,7 +242,7 @@ export function DeleteDialog({
 
             <button
               disabled={deleting}
-              onClick={() => onDelete(group.agents)}
+              onClick={() => onDelete(group.instances.map((i) => i.id))}
               className="w-full flex items-center justify-center gap-1.5 rounded-lg bg-destructive px-3 py-2 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
             >
               {deleting ? (
@@ -255,13 +273,10 @@ export function DeleteDialog({
   // API surfaces every place a skill named X exists). For deletion we
   // must restrict to paths belonging to *this* group's instances, or the
   // dialog lists e.g. a global same-named skill alongside a project one.
-  // The actual delete is keyed on agent names so it stays safe regardless,
-  // but the visible path list would mislead the user.
+  // Delete is keyed on instance ids built per-(agent, source_path) — see
+  // buildPathItems — so multi-scope rows are not accidentally collapsed.
   const instanceDirs = new Set(
-    group.instances
-      .map((i) => i.source_path)
-      .filter((p): p is string => !!p)
-      .map((p) => p.replace(/\/SKILL\.md(\.disabled)?$/, "")),
+    group.instances.map(instanceDir).filter((p): p is string => !!p),
   );
   const filteredSkillLocations =
     skillLocations && instanceDirs.size > 0
@@ -274,7 +289,7 @@ export function DeleteDialog({
   // is what lets TS narrow inside the true branch — cleaner than a `!`.
   const items: DeleteItem[] =
     usePathBased && filteredSkillLocations
-      ? buildPathItems(filteredSkillLocations)
+      ? buildPathItems(filteredSkillLocations, group.instances)
       : buildAgentItems(
           group.instances,
           instanceData,
@@ -473,7 +488,7 @@ export function DeleteDialog({
           {isSingle ? (
             <button
               disabled={deleting}
-              onClick={() => onDelete(items[0].agents)}
+              onClick={() => onDelete(items[0].ids)}
               className="w-full flex items-center justify-center gap-1.5 rounded-lg bg-destructive px-3 py-2 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
             >
               {deleting ? (
@@ -489,13 +504,13 @@ export function DeleteDialog({
             <button
               disabled={deleting || selectedKeys.size === 0}
               onClick={() => {
-                const agents = new Set<string>();
+                const ids = new Set<string>();
                 for (const item of items) {
                   if (selectedKeys.has(item.key)) {
-                    for (const a of item.agents) agents.add(a);
+                    for (const id of item.ids) ids.add(id);
                   }
                 }
-                onDelete(Array.from(agents));
+                onDelete(Array.from(ids));
               }}
               className="w-full flex items-center justify-center gap-1.5 rounded-lg bg-destructive px-3 py-2 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
             >

--- a/src/components/extensions/detail-paths.tsx
+++ b/src/components/extensions/detail-paths.tsx
@@ -5,17 +5,13 @@ import type {
   ExtensionContent as ExtContent,
   GroupedExtension,
 } from "@/lib/types";
-import { agentDisplayName, instanceVersion } from "@/lib/types";
+import { agentDisplayName, instanceDir, instanceVersion } from "@/lib/types";
 
 interface DetailPathsProps {
   group: GroupedExtension;
   instanceData: Map<string, ExtContent>;
   skillLocations: [string, string, string | null][];
   agentOrder: readonly string[];
-}
-
-function instanceDir(sourcePath: string): string {
-  return sourcePath.replace(/\/SKILL\.md(\.disabled)?$/, "");
 }
 
 function ScopePill({
@@ -83,7 +79,7 @@ export function DetailPaths({
         {sortedInstances.map((inst) => {
           const agent = inst.agents[0] ?? "unknown";
           const data = instanceData.get(inst.id);
-          const dir = inst.source_path ? instanceDir(inst.source_path) : null;
+          const dir = instanceDir(inst);
           const locations = dir
             ? skillLocations.filter(([a, d]) => a === agent && d === dir)
             : [];

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -51,7 +51,7 @@ export function ExtensionDetail() {
   const updateExtension = useExtensionStore((s) => s.updateExtension);
   const updatePack = useExtensionStore((s) => s.updatePack);
   const installToAgent = useExtensionStore((s) => s.installToAgent);
-  const deleteFromAgents = useExtensionStore((s) => s.deleteFromAgents);
+  const deleteInstances = useExtensionStore((s) => s.deleteInstances);
   const extensions = useExtensionStore((s) => s.extensions);
   const group = grouped().find((g) => g.groupKey === selectedId);
   /** Per-instance content data keyed by instance id */
@@ -372,8 +372,19 @@ export function ExtensionDetail() {
               agentOrder,
             );
             const AGENTS_WITHOUT_HOOKS = new Set(["antigravity", "opencode"]);
+            // "Install to Agent" implicitly targets Global scope (see
+            // service::install_to_agent v1). Filter by which agents already
+            // have a GLOBAL instance, not just any instance — otherwise a
+            // skill that exists only in project scope (e.g., user deleted
+            // the global row but kept the project copy) hides its agent
+            // from the install list and you can't recreate the global row.
+            const agentsWithGlobalInstance = new Set(
+              group.instances
+                .filter((i) => i.scope.type === "global")
+                .flatMap((i) => i.agents),
+            );
             const otherAgents = detectedAgents.filter(
-              (a) => !group.agents.includes(a.name),
+              (a) => !agentsWithGlobalInstance.has(a.name),
             );
             if (otherAgents.length === 0) return null;
             return (
@@ -585,18 +596,28 @@ export function ExtensionDetail() {
                 : undefined
             }
             skillLocations={group.kind === "skill" ? skillLocations : undefined}
-            onDelete={async (agents) => {
+            onDelete={async (ids) => {
               setDeleting(true);
               try {
-                await deleteFromAgents(group.groupKey, agents);
-                toast.success(
-                  agents.length === group.agents.length
-                    ? t("detail.deleteSuccess")
-                    : t("detail.deleteFromAgentsSuccess", {
-                        agents: agents.map(agentDisplayName).join(", "),
-                      }),
-                );
-                if (agents.length === group.agents.length) setSelectedId(null);
+                await deleteInstances(group.groupKey, ids);
+                const isFullDelete = ids.length === group.instances.length;
+                if (isFullDelete) {
+                  toast.success(t("detail.deleteSuccess"));
+                  setSelectedId(null);
+                } else {
+                  const affectedAgents = Array.from(
+                    new Set(
+                      group.instances
+                        .filter((i) => ids.includes(i.id))
+                        .flatMap((i) => i.agents),
+                    ),
+                  );
+                  toast.success(
+                    t("detail.deleteFromAgentsSuccess", {
+                      agents: affectedAgents.map(agentDisplayName).join(", "),
+                    }),
+                  );
+                }
               } catch {
                 toast.error(t("detail.deleteFailed"));
               } finally {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -128,6 +128,16 @@ export function instanceVersion(inst: Extension): string | null {
   return null;
 }
 
+/** Directory containing this instance's primary file. For skills, `source_path`
+ *  points at the SKILL.md file (or SKILL.md.disabled); strip that suffix to
+ *  get the dir. For other kinds source_path is already a dir-like path so the
+ *  regex is a no-op. Returns null when source_path is missing. */
+export function instanceDir(inst: Extension): string | null {
+  return inst.source_path
+    ? inst.source_path.replace(/\/SKILL\.md(\.disabled)?$/, "")
+    : null;
+}
+
 /** Authoritative "where did this come from" URL for grouping purposes.
  *  Resolution order: source.url → install_meta.url → pack (synthesized to a
  *  GitHub URL so extractDeveloper handles it uniformly). `pack` is a

--- a/src/stores/extension-store.ts
+++ b/src/stores/extension-store.ts
@@ -81,7 +81,7 @@ interface ExtensionState {
     targetAgents: string[],
     targetScope: ConfigScope,
   ) => Promise<void>;
-  deleteFromAgents: (groupKey: string, agents: string[]) => Promise<void>;
+  deleteInstances: (groupKey: string, ids: string[]) => Promise<void>;
   grouped: () => GroupedExtension[];
   filtered: () => GroupedExtension[];
 }
@@ -489,7 +489,7 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
     await get().rescanAndFetch();
   },
 
-  async deleteFromAgents(groupKey, agentNames) {
+  async deleteInstances(groupKey, instanceIds) {
     const group = get()
       .grouped()
       .find((g) => g.groupKey === groupKey);
@@ -500,6 +500,8 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
     if (group.kind === "cli") {
       // CLI uninstall: no optimistic removal, no undo — execute directly
       // so the dialog stays visible with a spinner during the operation.
+      // CLI deletion is all-or-nothing (cannot uninstall from a subset
+      // of agents), so the caller's id list is ignored here.
       const children = findCliChildren(
         get().extensions,
         group.instances[0]?.id,
@@ -520,9 +522,8 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
       return;
     }
 
-    toDelete = group.instances.filter((e) =>
-      e.agents.some((a) => agentNames.includes(a)),
-    );
+    const idSet = new Set(instanceIds);
+    toDelete = group.instances.filter((e) => idSet.has(e.id));
 
     if (toDelete.length === 0) return;
     const ids = new Set(toDelete.map((e) => e.id));


### PR DESCRIPTION
## Summary

Five related bugs in the multi-scope + symlinked-agent-dir extension lifecycle, surfaced while testing cross-agent installs where one agent's skill dir is a symlink into another's (e.g., `~/.gemini/antigravity/skills/` → `~/.claude/skills/`).

### 1. Install propagation missed symlinked siblings
`adapter_scans_dir` compared adapter skill dirs textually, so install propagation never recognized two adapters as sharing a path when one was a symlink. New `paths_equal` helper canonicalizes before comparing; falls back to textual equality when either path can't be canonicalized.

### 2. Delete left orphan rows for symlinked siblings
Deleting a skill physically removed files that another agent's row was symlinked to, but that agent's row stayed in the DB (protected by the `has_install_meta` stale-removal guard). Added `find_canonical_skill_siblings` and cascade DB delete in `delete_extension`. `delete_extension` is now idempotent so parallel batch deletes don't fail when an earlier cascade already cleared a row.

### 3. Delete from one agent collapsed multi-scope rows
The delete dialog passed agent names to the store, which filtered `group.instances` by agent membership alone — so picking "delete from Claude Code" also removed the project-scope Claude row of the same skill. Dialog now passes per-`(agent, source_path)` instance ids; the store filters by id.

### 4. "Install to Agent" hid agents that only had a project-scope row
The filter was "agents not in `group.agents`", but a project-only row would block re-installing the same skill to that agent's global scope. Now filters by "agents without a global-scope instance".

### 5. Drive-by refactor
Three call sites stripped `/SKILL.md(.disabled)?$` inline. Hoisted into a shared `instanceDir(inst)` helper in `types.ts` (separate commit, zero behavior change).

## Notes for reviewers

- Split into two commits: pure refactor first, fixes second. The fix commit bundles all four because they share root causes (textual path comparison + scope-blind UI logic) and an interleaved code path.
- Legacy DB rows orphaned from before this fix won't be auto-cleaned — the cascade only runs on new deletes. Users can clear them manually via the Delete dialog (which now works correctly), or wait for an optional future startup-cleanup pass (intentionally not added here to avoid wrongly deleting rows whose `source_path` is on temporarily-unmounted storage).

## Test plan

- [x] Install code-review to Claude global → install to Antigravity (symlinked) — both rows pick up the install_meta hash via cross-vendor propagation.
- [x] Delete Claude global only — project-scope Claude row survives, Antigravity row cascade-deletes along with Claude global (canonical-equal).
- [x] Delete project-scope Claude — global Claude row survives (symmetric check).
- [x] With only project-scope Claude row present, "Install to Agent" lists Claude Code as a target.
- [x] Delete an MCP server from a single agent — only that agent's row is removed (verifies the dialog-id contract on non-skill kinds).
- [x] `cargo test -p hk-core` (407 lib + 8 integration pass); `npm test` (149 pass); `npx tsc --noEmit` clean; `biome check src/` clean.
- [ ] Hooks: deleting a hook bound to multiple events should still leave each event's instance independently controllable (not directly retested this round; covered by existing toggle_integration suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)