### PR TITLE
ci(release): prepend highlights from release-notes/<tag>.md

### DIFF
--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -1,0 +1,45 @@
+# Release Notes
+
+Hand-written highlights for each release.
+
+## How it works
+
+Before tagging a release `vX.Y.Z`, drop a file `vX.Y.Z.md` here containing
+the Highlights section (and anything else you want at the top of the
+release body).
+
+The Release workflow (`.github/workflows/release.yml`, `Generate changelog`
+step) prepends this file's content to the auto-generated PR list, so the
+content shows up in:
+
+- The GitHub release page body
+- `latest.json`'s `notes` field — i.e. the in-app updater dialog
+
+If the file doesn't exist, the workflow falls back to just the auto PR
+list (existing behavior).
+
+## Example
+
+`v1.5.0.md`:
+
+```markdown
+## ✨ Highlights
+
+- **Faster Check Updates** — repos are now cloned in parallel
+- **Manual source binding** — bind any locally-installed skill to its
+  upstream GitHub repo from the detail panel
+
+---
+```
+
+The trailing `---` separates highlights from the auto PR list.
+
+## Release flow
+
+1. Write `.github/release-notes/v<tag>.md`
+2. `bash scripts/bump-version.sh <tag>`
+3. `git add -A && git commit -m "release: v<tag>"`
+4. `git push`
+5. `git tag v<tag> && git push origin v<tag>`
+6. Workflow auto-generates draft release with highlights prepended
+7. Publish the draft on GitHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,14 @@ jobs:
           if [ -z "$BODY" ]; then
             BODY="Bug fixes and improvements."
           fi
+          # Prepend hand-written highlights from .github/release-notes/<tag>.md
+          # so they appear both on the GitHub release page and in latest.json
+          # (which feeds the in-app updater dialog).
+          HIGHLIGHTS_FILE=".github/release-notes/${{ github.ref_name }}.md"
+          if [ -s "$HIGHLIGHTS_FILE" ]; then
+            HIGHLIGHTS=$(cat "$HIGHLIGHTS_FILE")
+            BODY="$(printf '%s\n\n%s' "$HIGHLIGHTS" "$BODY")"
+          fi
           {
             echo "body<<CHANGELOG_EOF"
             echo "$BODY"


### PR DESCRIPTION
## Summary

Make the in-app updater dialog show release Highlights without any manual fix-up after publishing.

**Problem**: `release.yml` `Generate changelog` step builds the body from `gh api .../generate-notes`, which only produces a PR list — no Highlights. Manually editing the GitHub draft body adds them on the release page, but does not write back into `latest.json.notes`, so the in-app updater dialog stays Highlights-less. v1.4.0 was patched by hand (`gh release download latest.json` → edit → `--clobber` upload).

**Fix**: Have the changelog step look for `.github/release-notes/<tag>.md` and prepend its contents to the body before writing `$GITHUB_OUTPUT`. The same body feeds both the draft release (`gh api`) and tauri-action's `releaseBody`, so Highlights now appear on the release page **and** in `latest.json.notes` automatically.

- `-s` test → file missing or empty falls back to existing behavior, no-op for releases without a highlights file
- Added `.github/release-notes/README.md` documenting the convention and the full release flow (including the `scripts/bump-version.sh` step)

## Test plan

- [ ] Next release: write `.github/release-notes/v<tag>.md`, run `bump-version.sh`, commit, tag, push
- [ ] Verify GitHub release page body has Highlights prepended above the auto PR list
- [ ] `curl -L .../latest.json | jq -r .notes` contains Highlights
- [ ] In-app Check for Updates dialog shows Highlights
- [ ] Release without a highlights file (any future patch) — workflow still produces the auto PR list as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)