### PR TITLE
fix: resolve Antigravity skill path mapping and UI scope bleeding

### DIFF
--- a/crates/hk-core/src/adapter/antigravity.rs
+++ b/crates/hk-core/src/adapter/antigravity.rs
@@ -61,7 +61,28 @@ impl AgentAdapter for AntigravityAdapter {
         // ~/.agents/skills/ — cross-loading from Gemini CLI requires a manual
         // symlink per Google's own guidance.
         // Source: https://codelabs.developers.google.com/getting-started-with-antigravity-skills
-        vec![self.base_dir().join("skills")]
+        let mut dirs = vec![self.base_dir().join("skills")];
+
+        // Antigravity supports custom skill paths via skills.txt in its base directory.
+        let skills_txt = self.base_dir().join("skills.txt");
+        if let Ok(content) = std::fs::read_to_string(&skills_txt) {
+            for line in content.lines() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                let path = if let Some(stripped) = line.strip_prefix("~/") {
+                    self.home.join(stripped)
+                } else {
+                    PathBuf::from(line)
+                };
+                if !dirs.contains(&path) {
+                    dirs.push(path);
+                }
+            }
+        }
+
+        dirs
     }
     fn project_skill_dirs(&self) -> Vec<String> {
         // Antigravity 1.18.4+ migrated from `.agent/` (singular) to `.agents/`

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -258,11 +258,16 @@ export default function MarketplacePage() {
     agentName: string,
     activeScope: ScopeValue,
   ) => {
-    const key = `${item.id}:${agentName}`;
-    if (installed.has(key)) return true;
-
     const targetKey =
       activeScope.type === "all" ? null : scopeKey(activeScope as ConfigScope);
+
+    if (targetKey !== null) {
+      if (installed.has(`${item.id}:${agentName}:${targetKey}`)) return true;
+    } else {
+      for (const k of installed) {
+        if (k.startsWith(`${item.id}:${agentName}:`)) return true;
+      }
+    }
 
     return extensions.some((ext) => {
       if (!ext.agents.includes(agentName)) return false;
@@ -279,8 +284,9 @@ export default function MarketplacePage() {
         ext.source.url;
       let extSource = "";
       if (extUrl) {
-        const match = extUrl.match(/github\.com\/([^/]+\/[^/]+)/);
-        extSource = match ? match[1].replace(/\.git$/, "") : extUrl;
+        const cleanUrl = extUrl.split(/[?#]/)[0];
+        const match = cleanUrl.match(/github\.com[:/]([^/]+\/[^/]+)/);
+        extSource = match ? match[1].replace(/\.git$/, "") : cleanUrl;
       }
       if (!extSource && ext.pack) extSource = ext.pack;
 
@@ -288,6 +294,7 @@ export default function MarketplacePage() {
       // lowercase while scanner preserves original casing. Compare lowered
       // on both sides to avoid false negatives.
       const itemSourceLower = item.source.toLowerCase();
+      if (!itemSourceLower) return false;
       const matchSource =
         extSource.toLowerCase() === itemSourceLower ||
         (ext.pack ?? "").toLowerCase() === itemSourceLower;
@@ -347,7 +354,8 @@ export default function MarketplacePage() {
       // Refresh extension store so audit page can resolve names immediately
       useExtensionStore.getState().fetch();
       const key = `${item.id}:${targetAgent ?? ""}`;
-      setInstalled((prev) => new Set(prev).add(key));
+      const installedKey = `${key}:${scopeKey(targetScope)}`;
+      setInstalled((prev) => new Set(prev).add(installedKey));
       toast.success(
         result.was_update
           ? t("toast.updated", { name: item.name })


### PR DESCRIPTION
### Summary

This PR addresses three distinct bugs related to skill path resolution and optimistic UI caching within the Marketplace. 

Specifically, it ensures that Antigravity's custom skill paths are correctly mapped, fixes a UI bug where installed states bleed across scopes, and strengthens the Git URL parsing to eliminate false negatives.

### Changes

1. **Antigravity Custom Skill Paths Resolution**: 
   - **Problem**: HarnessKit previously hardcoded the Antigravity `skills` directory to `~/.gemini/antigravity/skills`. However, Antigravity supports a custom path configuration via `skills.txt`, which was being ignored. As a result, users installing skills to custom paths (e.g., `~/.antigravity/skills`) wouldn't see the installation path in the Extension details UI.
   - **Fix**: The `AntigravityAdapter` now actively checks for and parses `~/.gemini/antigravity/skills.txt`. It extracts custom paths, expands `~/` to the absolute home directory, and appends them to the `skill_dirs` scan list.

2. **Fix Optimistic UI Scope Bleed**:
   - **Problem**: The UI cache used for immediate visual feedback post-installation (`installed` state) used a simple key format: `${item.id}:${agentName}`. Because this key lacked scope context, a user installing a skill in a specific `Project` scope would see it incorrectly marked as "Installed" when switching to the `Global` scope or another project.
   - **Fix**: The cache keys in `setInstalled` and `isItemInstalled` now correctly encode the `targetScope` (e.g., `${item.id}:${agentName}:${scope}`). In "All Scopes" mode, the check dynamically iterates to match any scope prefix. The temporary 500ms flash animation state (`justInstalled`) was intentionally left unscoped to preserve the visual feedback seamlessly.

3. **Strengthen Git URL Parsing (False Negatives Fix)**:
   - **Problem**: The regex used to match Git repository URLs was fragile. It failed entirely on SSH URLs (`git@github.com:owner/repo.git`), and it incorrectly captured query parameters and branch hashes (e.g., `repo.git#main`), preventing the trailing `.git` from being stripped and causing mismatches against the clean registry source.
   - **Fix**: Replaced the regex with `/github\.com[:/]([^/]+\/[^/]+)/` to support SSH endpoints. Added a preprocessing step to strip fragment hashes and query parameters (`split(/[?#]/)[0]`) before matching. Lastly, added an empty-source short-circuit to prevent empty local scripts from falsely matching corrupted registry entries.

### Screenshots

#### Before (Missing Path & False Installation States)
<!-- Please insert your Before screenshot here -->
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/5cd5b9a8-f2b7-4786-ab90-33a8111bd127" />

#### After (Correct Paths & Strict Scoping)
<!-- Please insert your After screenshot here -->
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/0bec4c85-a63b-4e96-93f0-85f3befc1459" />

Resolves #63
