### PR TITLE
feat(i18n): add "follow system" language preference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@tauri-apps/plugin-updater": "^2.10.1",
         "clsx": "^2.1.0",
         "i18next": "^26.1.0",
-        "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^1.7.0",
         "puppeteer": "^24.41.0",
         "react": "^19.0.0",
@@ -3540,15 +3539,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/i18next-browser-languagedetector": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
-      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/import-fresh": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@tauri-apps/plugin-updater": "^2.10.1",
     "clsx": "^2.1.0",
     "i18next": "^26.1.0",
-    "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.7.0",
     "puppeteer": "^24.41.0",
     "react": "^19.0.0",

--- a/src/lib/__tests__/i18n.test.ts
+++ b/src/lib/__tests__/i18n.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function setNavigatorLanguage(
+  language: string,
+  languages: string[] = [language],
+): void {
+  Object.defineProperty(window.navigator, "language", {
+    configurable: true,
+    value: language,
+  });
+  Object.defineProperty(window.navigator, "languages", {
+    configurable: true,
+    value: languages,
+  });
+}
+
+describe("i18n language preference helpers", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+    setNavigatorLanguage("en-US");
+  });
+
+  it("defaults to system preference when storage is empty", async () => {
+    const { getStoredLanguagePreference } = await import("../i18n");
+    expect(getStoredLanguagePreference()).toBe("system");
+  });
+
+  it("keeps explicit language preferences from storage", async () => {
+    localStorage.setItem("hk-language", "zh");
+    const { getStoredLanguagePreference } = await import("../i18n");
+    expect(getStoredLanguagePreference()).toBe("zh");
+  });
+
+  it("treats invalid stored values as system", async () => {
+    localStorage.setItem("hk-language", "ja");
+    const { getStoredLanguagePreference } = await import("../i18n");
+    expect(getStoredLanguagePreference()).toBe("system");
+  });
+
+  it("maps system locales to supported languages", async () => {
+    const { mapLocaleToSupportedLanguage } = await import("../i18n");
+    expect(mapLocaleToSupportedLanguage("zh-CN")).toBe("zh");
+    expect(mapLocaleToSupportedLanguage("en-GB")).toBe("en");
+    expect(mapLocaleToSupportedLanguage("ja-JP")).toBeNull();
+  });
+
+  it("resolves system preference from navigator languages", async () => {
+    setNavigatorLanguage("fr-FR", ["fr-FR", "zh-CN"]);
+    const { resolveLanguagePreference } = await import("../i18n");
+    expect(resolveLanguagePreference("system")).toBe("zh");
+  });
+
+  it("falls back to English for unsupported system locales", async () => {
+    setNavigatorLanguage("ja-JP");
+    const { resolveLanguagePreference } = await import("../i18n");
+    expect(resolveLanguagePreference("system")).toBe("en");
+  });
+
+  it("applies system preference without overwriting the stored setting", async () => {
+    setNavigatorLanguage("zh-CN");
+    const { applyLanguagePreference, default: i18n } = await import("../i18n");
+
+    await applyLanguagePreference("system");
+
+    expect(localStorage.getItem("hk-language")).toBe("system");
+    expect(i18n.resolvedLanguage).toBe("zh");
+  });
+
+  it("applies explicit preferences directly", async () => {
+    setNavigatorLanguage("en-US");
+    const { applyLanguagePreference, default: i18n } = await import("../i18n");
+
+    await applyLanguagePreference("zh");
+
+    expect(localStorage.getItem("hk-language")).toBe("zh");
+    expect(i18n.resolvedLanguage).toBe("zh");
+  });
+});

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,9 +1,10 @@
 import i18n from "i18next";
-import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 
 export const SUPPORTED_LANGUAGES = ["en", "zh"] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+export const LANGUAGE_PREFERENCES = ["system", ...SUPPORTED_LANGUAGES] as const;
+export type LanguagePreference = (typeof LANGUAGE_PREFERENCES)[number];
 
 export const LANGUAGE_STORAGE_KEY = "hk-language";
 
@@ -27,26 +28,74 @@ for (const [path, content] of Object.entries(localeModules)) {
 // Derive namespace list from the English locale (source of truth)
 const NAMESPACES = Object.keys(resources.en ?? {});
 
-i18n
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
-    resources,
-    fallbackLng: "en",
-    supportedLngs: SUPPORTED_LANGUAGES,
-    defaultNS: "common",
-    ns: NAMESPACES,
-    interpolation: {
-      escapeValue: false,
-    },
-    detection: {
-      // localStorage only — do NOT auto-detect from navigator.language.
-      // The product default is English; users opt into other languages
-      // via Settings, which persists their choice in localStorage.
-      order: ["localStorage"],
-      lookupLocalStorage: LANGUAGE_STORAGE_KEY,
-      caches: ["localStorage"],
-    },
-  });
+function isLanguagePreference(
+  value: string | null | undefined,
+): value is LanguagePreference {
+  return (LANGUAGE_PREFERENCES as readonly string[]).includes(value ?? "");
+}
+
+export function mapLocaleToSupportedLanguage(
+  locale: string | null | undefined,
+): SupportedLanguage | null {
+  if (!locale) return null;
+
+  const normalized = locale.toLowerCase();
+  if (normalized === "zh" || normalized.startsWith("zh-")) return "zh";
+  if (normalized === "en" || normalized.startsWith("en-")) return "en";
+  return null;
+}
+
+export function detectSystemLanguage(): SupportedLanguage {
+  if (typeof navigator === "undefined") return "en";
+
+  const candidates = navigator.languages?.length
+    ? navigator.languages
+    : [navigator.language];
+
+  for (const candidate of candidates) {
+    const mapped = mapLocaleToSupportedLanguage(candidate);
+    if (mapped) return mapped;
+  }
+
+  return "en";
+}
+
+export function getStoredLanguagePreference(): LanguagePreference {
+  if (typeof localStorage === "undefined") return "system";
+
+  const value = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  return isLanguagePreference(value) ? value : "system";
+}
+
+export function resolveLanguagePreference(
+  preference: LanguagePreference,
+): SupportedLanguage {
+  return preference === "system" ? detectSystemLanguage() : preference;
+}
+
+export async function applyLanguagePreference(
+  preference: LanguagePreference,
+): Promise<void> {
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, preference);
+  }
+
+  await i18n.changeLanguage(resolveLanguagePreference(preference));
+}
+
+const initialPreference = getStoredLanguagePreference();
+const initialLanguage = resolveLanguagePreference(initialPreference);
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: initialLanguage,
+  fallbackLng: "en",
+  supportedLngs: SUPPORTED_LANGUAGES,
+  defaultNS: "common",
+  ns: NAMESPACES,
+  interpolation: {
+    escapeValue: false,
+  },
+});
 
 export default i18n;

--- a/src/lib/i18n/locales/en/settings.json
+++ b/src/lib/i18n/locales/en/settings.json
@@ -2,7 +2,8 @@
   "title": "Settings",
   "language": {
     "label": "Language",
-    "description": "Choose your preferred display language.",
+    "description": "Choose your preferred display language, or follow the system setting.",
+    "system": "Follow System",
     "en": "English",
     "zh": "中文"
   },

--- a/src/lib/i18n/locales/zh/settings.json
+++ b/src/lib/i18n/locales/zh/settings.json
@@ -2,7 +2,8 @@
   "title": "设置",
   "language": {
     "label": "语言",
-    "description": "选择你偏好的显示语言。",
+    "description": "选择你偏好的显示语言，或跟随系统设置。",
+    "system": "跟随系统",
     "en": "English",
     "zh": "中文"
   },

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -16,7 +16,11 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
 import { openDirectoryPicker } from "@/lib/dialog";
-import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "@/lib/i18n";
+import {
+  applyLanguagePreference,
+  getStoredLanguagePreference,
+  type LanguagePreference,
+} from "@/lib/i18n";
 import { api } from "@/lib/invoke";
 import { isDesktop } from "@/lib/transport";
 import { agentDisplayName, type DiscoveredProject } from "@/lib/types";
@@ -59,9 +63,10 @@ const ICON_OPTIONS: { value: AppIcon; label: string; src: string }[] = [
 ];
 
 const LANGUAGE_OPTIONS: {
-  value: SupportedLanguage;
-  labelKey: "language.en" | "language.zh";
+  value: LanguagePreference;
+  labelKey: "language.system" | "language.en" | "language.zh";
 }[] = [
+  { value: "system", labelKey: "language.system" },
   { value: "en", labelKey: "language.en" },
   { value: "zh", labelKey: "language.zh" },
 ];
@@ -160,13 +165,9 @@ function WebUpdateSection() {
 }
 
 export default function SettingsPage() {
-  const { t, i18n } = useTranslation("settings");
+  const { t } = useTranslation("settings");
   const { t: tc } = useTranslation("common");
-  const language = (SUPPORTED_LANGUAGES as readonly string[]).includes(
-    i18n.resolvedLanguage ?? "",
-  )
-    ? (i18n.resolvedLanguage as SupportedLanguage)
-    : "en";
+  const languagePreference = getStoredLanguagePreference();
   const {
     themeName,
     mode,
@@ -784,14 +785,14 @@ export default function SettingsPage() {
                   <button
                     key={opt.value}
                     onClick={() => {
-                      void i18n.changeLanguage(opt.value);
+                      void applyLanguagePreference(opt.value);
                     }}
-                    aria-pressed={language === opt.value}
+                    aria-pressed={languagePreference === opt.value}
                     className={clsx(
                       "px-3 py-1 text-xs font-medium transition-colors duration-200",
                       i === 0 && "rounded-l-lg",
                       i === LANGUAGE_OPTIONS.length - 1 && "rounded-r-lg",
-                      language === opt.value
+                      languagePreference === opt.value
                         ? "bg-primary text-primary-foreground shadow-sm"
                         : "text-muted-foreground hover:bg-accent",
                     )}


### PR DESCRIPTION
## Summary

Language selector now offers a "Follow System" option that resolves zh-CN → 中文, en-* → English, falling back to English for unsupported locales.

## What changed

- Replaced `i18next-browser-languagedetector` with manual locale detection via `navigator.language`
- Language selector: three buttons — Follow System, English, 中文
- Preference persisted in localStorage under the same `hk-language` key

##  How to test

  1. Set "Follow System" with OS language Chinese → UI renders 中文
  2. Set "Follow System" with OS language English/Japanese → UI renders English
  3. Pick "中文" explicitly → persists across refresh; ignores OS language