### PR TITLE
fix(kits): show kind counts for cross-machine imported kits

### DIFF
--- a/crates/hk-core/src/kits/service.rs
+++ b/crates/hk-core/src/kits/service.rs
@@ -49,15 +49,43 @@ pub fn list_kits(store: &Mutex<Store>) -> Result<Vec<KitSummary>, HkError> {
         let assets = store.list_kit_assets(&row.id)?;
         let cfgs = store.list_kit_config_files(&row.id)?;
         let syncs = store.list_sync_records_for_kit(&row.id)?;
+        // Resolve each asset's kind. Prefer the local extensions table
+        // (O(1) in-memory lookup). Fall back to the kit's manifest when
+        // an asset's extension_id isn't in our DB — this is the
+        // cross-machine import case: the original author's DB UUIDs
+        // ride along inside kit_assets but won't match anything locally,
+        // so without the fallback every imported kit would show as
+        // "0 skills · 0 MCP" on the Kits page.
+        let needs_manifest_fallback = assets
+            .iter()
+            .any(|a| !kind_by_ext_id.contains_key(&a.extension_id));
+        let manifest_kinds: std::collections::HashMap<String, ExtensionKind> =
+            if needs_manifest_fallback && std::path::Path::new(&row.zip_path).exists() {
+                read_manifest_from_zip(std::path::Path::new(&row.zip_path))
+                    .map(|m| {
+                        m.extensions
+                            .into_iter()
+                            .map(|e| (e.source_extension_id, e.kind))
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            } else {
+                std::collections::HashMap::new()
+            };
         let mut kind_counts = KindCounts::default();
         for a in &assets {
-            match kind_by_ext_id.get(&a.extension_id).copied() {
+            let kind = kind_by_ext_id
+                .get(&a.extension_id)
+                .copied()
+                .or_else(|| manifest_kinds.get(&a.extension_id).copied());
+            match kind {
                 Some(ExtensionKind::Skill) => kind_counts.skill += 1,
                 Some(ExtensionKind::Mcp) => kind_counts.mcp += 1,
                 Some(ExtensionKind::Plugin) => kind_counts.plugin += 1,
                 Some(ExtensionKind::Hook) => kind_counts.hook += 1,
                 Some(ExtensionKind::Cli) => kind_counts.cli += 1,
-                // Unresolvable extension: skip kind tally; extension_count still reflects total.
+                // Truly unresolvable (e.g. corrupt zip): skip kind tally;
+                // extension_count still reflects total.
                 None => {}
             }
         }

--- a/crates/hk-core/src/kits/tests/service.rs
+++ b/crates/hk-core/src/kits/tests/service.rs
@@ -5,7 +5,7 @@ use crate::kits::types::{CreateKitRequest, KitConfigFileRef, PreviewKitConflicts
 use crate::kits::zip_io::{pack_kit, read_manifest_from_zip, PackEntry};
 use crate::models::{ConfigCategory, ConfigScope, Extension, ExtensionKind, Source, SourceOrigin};
 use crate::store::{KitRow, Store};
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
 use serial_test::serial;
 use std::fs;
@@ -488,6 +488,89 @@ fn import_rejects_path_traversal_in_manifest() {
     assert!(
         msg.contains("traversal"),
         "expected traversal-rejection message, got: {msg}"
+    );
+}
+
+#[test]
+#[serial(kit_env)]
+fn list_kits_kind_counts_fall_back_to_manifest_for_cross_machine_imports() {
+    // Simulates the "Bob received Alice's .hk-kit.zip" scenario: the
+    // source_extension_id values inside the manifest reference Alice's
+    // DB UUIDs, which don't exist in Bob's extensions table. Without the
+    // manifest fallback in list_kits, Bob would see "0 skills · 0 MCP"
+    // even though the kit clearly has extensions.
+    let dir = tempdir().unwrap();
+    let _restore = RestoreHome::new();
+    unsafe { std::env::set_var("HOME", dir.path()); }
+    let store = Mutex::new(Store::open(&dir.path().join("hk.db")).unwrap());
+
+    // Hand-craft a manifest with two extensions (a skill + an MCP) whose
+    // source_extension_ids point at UUIDs that aren't in this Store.
+    let alice_skill_id = "00000000-0000-4000-8000-000000000001";
+    let alice_mcp_id = "00000000-0000-4000-8000-000000000002";
+    let manifest = KitManifest {
+        kit_format_version: KIT_FORMAT_VERSION,
+        kit_id: "alice-kit".into(),
+        name: "from-alice".into(),
+        description: "".into(),
+        created_at: Utc::now(),
+        exported_from: "HarnessKit test".into(),
+        extensions: vec![
+            ManifestExtension {
+                name: "skill-a".into(),
+                kind: ExtensionKind::Skill,
+                source_extension_id: alice_skill_id.into(),
+                source_url: None,
+                content_hash: "sha256:placeholder".into(),
+                asset_path: format!("assets/{alice_skill_id}/SKILL.md"),
+                position: 0,
+                source_revision: None,
+                source_branch: None,
+            },
+            ManifestExtension {
+                name: "mcp-a".into(),
+                kind: ExtensionKind::Mcp,
+                source_extension_id: alice_mcp_id.into(),
+                source_url: None,
+                content_hash: "sha256:placeholder".into(),
+                asset_path: format!("assets/{alice_mcp_id}/mcp.json"),
+                position: 1,
+                source_revision: None,
+                source_branch: None,
+            },
+        ],
+        config_files: vec![],
+        secrets_stripped: vec![],
+    };
+    let zip_path = dir.path().join("from-alice.hk-kit.zip");
+    pack_kit(
+        &zip_path,
+        &manifest,
+        &[
+            PackEntry {
+                zip_path: format!("assets/{alice_skill_id}/SKILL.md"),
+                bytes: b"# skill".to_vec(),
+            },
+            PackEntry {
+                zip_path: format!("assets/{alice_mcp_id}/mcp.json"),
+                bytes: b"{}".to_vec(),
+            },
+        ],
+    )
+    .unwrap();
+
+    crate::kits::service::import_kit(&store, &zip_path.to_string_lossy()).unwrap();
+
+    let kits = list_kits(&store).unwrap();
+    let imported = kits.iter().find(|k| k.name == "from-alice").unwrap();
+    assert_eq!(imported.extension_count, 2, "extension_count is fed by asset rows");
+    assert_eq!(
+        imported.kind_counts.skill, 1,
+        "skill kind must be recovered from the manifest fallback",
+    );
+    assert_eq!(
+        imported.kind_counts.mcp, 1,
+        "mcp kind must be recovered from the manifest fallback",
     );
 }
 


### PR DESCRIPTION
## Summary

A Kit shared between users showed \`0 skills · 0 MCP\` on the receiver's Kits page, even though \`extension_count\` was correct — making it look like the import lost its contents.

**Root cause**: \`list_kits\` resolves each asset's kind by looking up \`asset.extension_id\` in the local \`extensions\` table. For locally-built Kits that's fine; for imports the IDs inside \`kit_assets\` are the original author's DB UUIDs and never match locally → every lookup misses → \`kind_counts\` stays zero.

**Fix**: when at least one asset misses the local table, read the Kit's manifest and use \`(source_extension_id → kind)\` from there as fallback. Locally-built Kits don't pay the manifest read.

The manifest fallback mirrors the same lookup pattern \`get_kit_details\` already uses to fill the detail drawer (which is why the drawer was fine but the list-page counts were wrong).

## Test

New \`list_kits_kind_counts_fall_back_to_manifest_for_cross_machine_imports\`: hand-builds a Kit zip whose \`source_extension_id\`s are unknown to the local store (mirrors the cross-machine case), imports it, and asserts \`kind_counts.skill == 1\` and \`kind_counts.mcp == 1\`.

Also drops a pre-existing unused \`TimeZone\` import in the test file.

## Test plan

- [x] Cross-machine import case verified manually (locally simulated by deleting an extension after building the Kit, then export → delete kit → re-import; the deleted extension's UUID is gone from the local extensions table, same effect as receiving the Kit on a new machine)
- [x] \`cargo test --workspace\` (existing 62 kit tests + 1 new = 63, all pass)
- [x] \`cargo clippy -D warnings\` clean
- [x] \`npm test\` / biome lint / tsc all clean

## Release

Target hotfix release: **v1.5.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)