### PR TITLE
style(audit): smooth expanded card hover edge

### DIFF
--- a/src/pages/audit.tsx
+++ b/src/pages/audit.tsx
@@ -568,7 +568,9 @@ export default function AuditPage() {
                         ? t("finding.collapseAria", { name: group.name })
                         : t("finding.expandAria", { name: group.name })
                     }
-                    className="flex w-full cursor-pointer items-center justify-between rounded-xl px-4 py-3 transition-all duration-150 hover:bg-muted/50 hover:shadow-sm"
+                    className={`flex w-full cursor-pointer items-center justify-between px-4 py-3 transition-all duration-150 hover:bg-muted/50 hover:shadow-sm ${
+                      isOpen ? "rounded-t-xl rounded-b-none" : "rounded-xl"
+                    }`}
                   >
                     <div className="flex items-center gap-3">
                       <ChevronRight

--- a/src/pages/audit.tsx
+++ b/src/pages/audit.tsx
@@ -568,9 +568,10 @@ export default function AuditPage() {
                         ? t("finding.collapseAria", { name: group.name })
                         : t("finding.expandAria", { name: group.name })
                     }
-                    className={`flex w-full cursor-pointer items-center justify-between px-4 py-3 transition-all duration-150 hover:bg-muted/50 hover:shadow-sm ${
-                      isOpen ? "rounded-t-xl rounded-b-none" : "rounded-xl"
-                    }`}
+                    className={clsx(
+                      "flex w-full cursor-pointer items-center justify-between px-4 py-3 transition-all duration-150 hover:bg-muted/50 hover:shadow-sm",
+                      isOpen ? "rounded-t-xl rounded-b-none" : "rounded-xl",
+                    )}
                   >
                     <div className="flex items-center gap-3">
                       <ChevronRight


### PR DESCRIPTION
## Summary

Adjust the Security Audit card header styling so expanded SKILL cards no longer show a rounded hover background against the top divider.

## Why

When an audit card is expanded, hovering the header kept the bottom border radius, which created a visual gap between the header background and the divider line.

## Before

<img width="2150" height="316" alt="image" src="https://github.com/user-attachments/assets/3399ef56-46d9-4c07-ad21-3dab5f746f33" />

## After

<img width="2104" height="300" alt="image" src="https://github.com/user-attachments/assets/c2ab5930-de6e-4971-90bb-88f1da2c8775" />
