### PR TITLE
fix: prefer install_meta.url over enclosing-repo source.url for grouping

### DIFF
--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -134,6 +134,52 @@ describe("extensionGroupKey", () => {
     );
   });
 
+  it("prefers install_meta.url over a polluted enclosing-repo source.url", () => {
+    // Regression: an agent home (e.g. ~/.claude) is kept inside the user's own
+    // dotfiles git repo, so the scanner walks up and stamps that copy with a
+    // *wrong* source.url (the enclosing backup repo). The other agents' copies
+    // sit in non-git dirs and stay sourceless. All copies were installed from
+    // tw93/waza, so they must group into one row. Pre-fix, source.url won and
+    // the git-backed copy forked into its own dotfiles-repo group.
+    const wazaInstallMeta = {
+      install_type: "marketplace",
+      url: "tw93/waza",
+      url_resolved: null,
+      branch: null,
+      subpath: null,
+      revision: "51222bf",
+      remote_revision: null,
+      checked_at: null,
+      check_error: null,
+    };
+    const claudeCopyPolluted: Extension = {
+      ...baseExt,
+      name: "check",
+      agents: ["claude"],
+      source: {
+        ...baseExt.source,
+        origin: "git",
+        url: "https://github.com/octo-user/dotfiles.git",
+      },
+      install_meta: wazaInstallMeta,
+    };
+    const codexCopySourceless: Extension = {
+      ...baseExt,
+      name: "check",
+      agents: ["codex"],
+      source: { ...baseExt.source, origin: "agent", url: null },
+      install_meta: wazaInstallMeta,
+    };
+    // The polluted Claude copy now resolves to its true origin…
+    expect(extensionGroupKey(claudeCopyPolluted)).toBe(
+      "skill\0check\0tw93/waza",
+    );
+    // …and groups with the sourceless siblings instead of forking off.
+    expect(extensionGroupKey(claudeCopyPolluted)).toBe(
+      extensionGroupKey(codexCopySourceless),
+    );
+  });
+
   it("uses pack as a user-driven tiebreaker for unlinked rows", () => {
     // Real-world case: arxiv-search was deployed to 4 agents but only the
     // agent that received the original `hk install` carries install_meta.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -139,18 +139,28 @@ export function instanceDir(inst: Extension): string | null {
 }
 
 /** Authoritative "where did this come from" URL for grouping purposes.
- *  Resolution order: source.url → install_meta.url → pack (synthesized to a
- *  GitHub URL so extractDeveloper handles it uniformly). `pack` is a
- *  user-editable field on the detail panel; treating it as a tiebreaker
- *  means a user can merge two unlinked rows into one group by typing the
- *  owner/repo identifier (e.g. arxiv-search where only one of four copies
- *  carries install_meta from the original install). Returns `null` when an
- *  extension is truly sourceless (hand-written project skill, agent-bundled
- *  global skill the user never linked, etc.). */
+ *  Resolution order: install_meta.url → source.url → pack (synthesized to a
+ *  GitHub URL so extractDeveloper handles it uniformly).
+ *
+ *  `install_meta.url` (written by HK at install time, not user-editable) is
+ *  the authoritative origin and wins first. `source.url` comes from the
+ *  scanner walking up to the nearest `.git` remote — usually null for
+ *  marketplace skills, but it can be a *wrong* value when the user keeps an
+ *  agent home (e.g. `~/.claude`) under their own dotfiles git repo: the
+ *  enclosing backup remote then masks the real install source and forks one
+ *  skill into two group rows. Preferring install_meta avoids that; source.url
+ *  stays the fallback for git-cloned skills that carry no install_meta.
+ *
+ *  `pack` is a user-editable field on the detail panel; treating it as the
+ *  last tiebreaker means a user can merge two unlinked rows into one group by
+ *  typing the owner/repo identifier (e.g. arxiv-search where only one of four
+ *  copies carries install_meta from the original install). Returns `null`
+ *  when an extension is truly sourceless (hand-written project skill,
+ *  agent-bundled global skill the user never linked, etc.). */
 export function deriveExtensionUrl(ext: Extension): string | null {
   return (
-    ext.source.url ??
     ext.install_meta?.url ??
+    ext.source.url ??
     (ext.pack ? `https://github.com/${ext.pack}` : null)
   );
 }


### PR DESCRIPTION
## Summary

Fixes #75. A skill installed to multiple agents could split into two group rows in the Extensions list when one agent's home directory is kept under the user's own dotfiles git repo.

## Root cause

`deriveExtensionUrl` (the grouping key's developer resolver) used the order `source.url → install_meta.url → pack`. `source.url` comes from the scanner walking up to the nearest `.git` remote. When an agent home such as `~/.claude` sits inside a personal backup repo, the scanner stamps the skill with that enclosing remote (the user's own dotfiles repo), which masked the authoritative `install_meta.url` and forked that copy into its own group — even though all copies were installed from the same source.

## Fix

Flip the resolution order to `install_meta.url → source.url → pack`. `install_meta.url` is written by HK at install time and is not user-editable, so it is the authoritative origin and should win first. `source.url` stays the fallback for git-cloned skills that carry no install_meta. No DB migration needed — grouping is recomputed on every list.

This also makes `deriveExtensionUrl` consistent with `isItemInstalled` (`marketplace.tsx`), which already prefers `install_meta` over `source.url`.

## Test plan

- [x] `npm test` — 224 passing (incl. 1 new regression test for the polluted `source.url` case; verified it fails on the old order and passes on the new)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src/` clean
- [x] Manual (`cargo tauri dev`): a skill deployed across agents collapses from two rows into one, with all agents listed

## Before / After

**Before** (two rows):

<img width="1019" height="629" alt="image" src="https://github.com/user-attachments/assets/04d108cc-96fd-48a1-9986-00bf295b71a3" />

**After** (one row):

<img width="1023" height="644" alt="image" src="https://github.com/user-attachments/assets/d27e2275-bebd-4d98-84a0-a2864eeb918b" />