### PR TITLE
fix(web): align Kit routes with frontend transport contract

### DIFF
--- a/crates/hk-web/src/handlers/kits.rs
+++ b/crates/hk-web/src/handlers/kits.rs
@@ -1,5 +1,4 @@
-use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::extract::State;
 use axum::Json;
 use hk_core::kits::install_records;
 use hk_core::kits::service as kit_service;
@@ -11,6 +10,21 @@ use crate::state::WebState;
 
 type Result<T> = std::result::Result<Json<T>, ApiError>;
 
+// The frontend transport posts every command to `/api/{command}` with a JSON
+// body shaped exactly like the Tauri `invoke` args object. Tauri matches body
+// keys to command parameter names, so single-object commands arrive wrapped as
+// `{ "req": {...} }` and id-only commands as `{ "id": "..." }`. These extractor
+// structs mirror that shape so web mode and desktop share one contract.
+#[derive(Deserialize)]
+pub struct ReqBody<T> {
+    pub req: T,
+}
+
+#[derive(Deserialize)]
+pub struct IdBody {
+    pub id: String,
+}
+
 pub async fn list_kits(State(state): State<WebState>) -> Result<Vec<KitSummary>> {
     blocking(move || kit_service::list_kits(&state.store)).await
 }
@@ -21,58 +35,57 @@ pub async fn list_candidates(State(state): State<WebState>) -> Result<KitAssetCa
 
 pub async fn get_details(
     State(state): State<WebState>,
-    Path(id): Path<String>,
+    Json(body): Json<IdBody>,
 ) -> Result<KitDetails> {
-    blocking(move || kit_service::get_kit_details(&state.store, &state.adapters, &id)).await
+    blocking(move || kit_service::get_kit_details(&state.store, &state.adapters, &body.id)).await
 }
 
 pub async fn create_kit(
     State(state): State<WebState>,
-    Json(req): Json<CreateKitRequest>,
+    Json(body): Json<ReqBody<CreateKitRequest>>,
 ) -> Result<KitSummary> {
-    blocking(move || kit_service::create_kit(&state.store, &state.adapters, req)).await
+    blocking(move || kit_service::create_kit(&state.store, &state.adapters, body.req)).await
 }
 
 pub async fn update_kit(
     State(state): State<WebState>,
-    Json(req): Json<UpdateKitRequest>,
+    Json(body): Json<ReqBody<UpdateKitRequest>>,
 ) -> Result<KitSummary> {
-    blocking(move || kit_service::update_kit(&state.store, &state.adapters, req)).await
+    blocking(move || kit_service::update_kit(&state.store, &state.adapters, body.req)).await
 }
 
 pub async fn delete_kit(
     State(state): State<WebState>,
-    Path(id): Path<String>,
-) -> std::result::Result<StatusCode, ApiError> {
-    blocking(move || kit_service::delete_kit(&state.store, &id))
-        .await
-        .map(|_| StatusCode::NO_CONTENT)
+    Json(body): Json<IdBody>,
+) -> Result<()> {
+    blocking(move || kit_service::delete_kit(&state.store, &body.id)).await
 }
 
 pub async fn preview_conflicts(
     State(state): State<WebState>,
-    Json(req): Json<PreviewKitConflictsRequest>,
+    Json(body): Json<ReqBody<PreviewKitConflictsRequest>>,
 ) -> Result<KitConflictPreview> {
     blocking(move || {
-        kit_service::preview_kit_project_conflicts(&state.store, &state.adapters, req)
+        kit_service::preview_kit_project_conflicts(&state.store, &state.adapters, body.req)
     })
     .await
 }
 
 pub async fn sync_kit(
     State(state): State<WebState>,
-    Json(req): Json<SyncKitRequest>,
+    Json(body): Json<ReqBody<SyncKitRequest>>,
 ) -> Result<KitSyncResult> {
-    blocking(move || kit_service::sync_kit_to_project(&state.store, &state.adapters, req)).await
+    blocking(move || kit_service::sync_kit_to_project(&state.store, &state.adapters, body.req)).await
 }
 
 pub async fn unsync_kit(
     State(state): State<WebState>,
-    Json(req): Json<UnsyncKitRequest>,
-) -> std::result::Result<StatusCode, ApiError> {
-    blocking(move || kit_service::unsync_kit_from_project(&state.store, &state.adapters, req))
-        .await
-        .map(|_| StatusCode::NO_CONTENT)
+    Json(body): Json<ReqBody<UnsyncKitRequest>>,
+) -> Result<()> {
+    blocking(move || {
+        kit_service::unsync_kit_from_project(&state.store, &state.adapters, body.req)
+    })
+    .await
 }
 
 #[derive(Deserialize)]
@@ -84,10 +97,8 @@ pub struct ExportBody {
 pub async fn export_kit(
     State(state): State<WebState>,
     Json(body): Json<ExportBody>,
-) -> std::result::Result<StatusCode, ApiError> {
-    blocking(move || kit_service::export_kit(&state.store, &body.id, &body.target_path))
-        .await
-        .map(|_| StatusCode::NO_CONTENT)
+) -> Result<()> {
+    blocking(move || kit_service::export_kit(&state.store, &body.id, &body.target_path)).await
 }
 
 #[derive(Deserialize)]

--- a/crates/hk-web/src/router.rs
+++ b/crates/hk-web/src/router.rs
@@ -2,7 +2,7 @@ use axum::{
     Router,
     body::Body,
     middleware,
-    routing::{delete, get, post},
+    routing::{get, post},
     response::{Html, IntoResponse},
     http::{Method, StatusCode, Uri, header},
     Json,
@@ -130,19 +130,20 @@ pub fn build_router(state: WebState) -> Router {
         .route("/api/get_cached_update_statuses", post(handlers::install::get_cached_update_statuses))
         .route("/api/get_cli_with_children", post(handlers::install::get_cli_with_children))
         .route("/api/get_skill_locations", post(handlers::install::get_skill_locations))
-        // Kits
-        .route("/api/kits", get(handlers::kits::list_kits))
-        .route("/api/kits", post(handlers::kits::create_kit))
-        .route("/api/kits/candidates", get(handlers::kits::list_candidates))
-        .route("/api/kits/{id}", get(handlers::kits::get_details))
-        .route("/api/kits/{id}", delete(handlers::kits::delete_kit))
-        .route("/api/kits/update", post(handlers::kits::update_kit))
-        .route("/api/kits/preview-conflicts", post(handlers::kits::preview_conflicts))
-        .route("/api/kits/sync", post(handlers::kits::sync_kit))
-        .route("/api/kits/unsync", post(handlers::kits::unsync_kit))
-        .route("/api/kits/export", post(handlers::kits::export_kit))
-        .route("/api/kits/import", post(handlers::kits::import_kit))
-        .route("/api/kits/install-records", get(handlers::kits::list_install_records));
+        // Kits — flat `POST /api/{command}` to match the frontend transport
+        // contract (src/lib/transport.ts) and the desktop Tauri command names.
+        .route("/api/list_kits", post(handlers::kits::list_kits))
+        .route("/api/get_kit_details", post(handlers::kits::get_details))
+        .route("/api/list_kit_asset_candidates", post(handlers::kits::list_candidates))
+        .route("/api/create_kit", post(handlers::kits::create_kit))
+        .route("/api/update_kit", post(handlers::kits::update_kit))
+        .route("/api/delete_kit", post(handlers::kits::delete_kit))
+        .route("/api/preview_kit_project_conflicts", post(handlers::kits::preview_conflicts))
+        .route("/api/sync_kit_to_project", post(handlers::kits::sync_kit))
+        .route("/api/unsync_kit_from_project", post(handlers::kits::unsync_kit))
+        .route("/api/export_kit", post(handlers::kits::export_kit))
+        .route("/api/import_kit", post(handlers::kits::import_kit))
+        .route("/api/list_project_install_records", post(handlers::kits::list_install_records));
 
     let cors = CorsLayer::new()
         .allow_origin(Any)

--- a/crates/hk-web/tests/api_test.rs
+++ b/crates/hk-web/tests/api_test.rs
@@ -107,3 +107,66 @@ async fn dashboard_stats_returns_valid_json() {
     let stats: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(stats["total_extensions"].is_number());
 }
+
+/// Regression guard for the web-mode Kits outage: the frontend transport posts
+/// to `/api/{command}` (e.g. `/api/list_kit_asset_candidates`), but the kit
+/// routes were once registered REST-style (`GET /api/kits/candidates`). The
+/// mismatch fell through to the SPA fallback, returning `200 text/html`, which
+/// the frontend then failed to parse as JSON — so kits/candidates silently
+/// showed empty in the browser while desktop worked. Assert every kit command
+/// the frontend calls reaches a real JSON handler.
+#[tokio::test]
+async fn kit_command_routes_return_json_not_spa_html() {
+    let (state, _tmp) = test_state();
+    let app = hk_web::router::build_router(state);
+
+    // Read-only commands the frontend posts with an empty body. Each must hit a
+    // handler (200 + application/json), not the HTML SPA fallback. `list_kits`
+    // and `list_project_install_records` return JSON arrays; the candidates
+    // command returns a `{ extensions, config_files }` object — so we only
+    // require valid JSON of the right shape, the point being it isn't HTML.
+    for command in [
+        "list_kits",
+        "list_kit_asset_candidates",
+        "list_project_install_records",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post(format!("/api/{command}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "POST /api/{command} should reach a handler"
+        );
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        assert!(
+            content_type.starts_with("application/json"),
+            "POST /api/{command} returned {content_type}, not JSON (SPA fallback?)"
+        );
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        // The decisive guard against the SPA-fallback regression: the body must
+        // parse as JSON at all (HTML would fail here) and be a real array/object
+        // rather than a bare string like an HTML document slurped as text.
+        let value: serde_json::Value = serde_json::from_slice(&body)
+            .unwrap_or_else(|e| panic!("POST /api/{command} returned non-JSON body: {e}"));
+        assert!(
+            value.is_array() || value.is_object(),
+            "POST /api/{command} should return a JSON array or object, got: {value}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

In **web mode** (`hk serve` → browser), the Kits page showed empty kit lists and the new-kit dialog couldn't discover any existing skills/MCPs — while the **desktop** app worked fine on the same machine / same database.

## Root cause

The frontend transport posts every command as `POST /api/{snake_case_command}` (`src/lib/transport.ts`), and all other features' routes follow that contract. The **Kits** block alone was registered REST-style:

| Frontend sends | Old web route | Match |
|---|---|---|
| `POST /api/list_kit_asset_candidates` | `GET /api/kits/candidates` | ❌ |
| `POST /api/list_kits` | `GET /api/kits` | ❌ |
| `POST /api/create_kit` | `POST /api/kits` | ❌ |
| …all 12 kit endpoints | REST-style paths | ❌ |

None matched, so every kit request fell through to the SPA `fallback(serve_frontend)` and returned **200 + `text/html`** (index.html). The frontend then called `response.json()` on HTML → threw → `.catch(console.error)` swallowed it → lists stayed empty, **with no visible error**. Desktop was unaffected because Tauri `invoke` dispatches by command name directly.

Verified empirically (oneshot against the real router): `POST /api/list_kit_asset_candidates` → `200 text/html`; `GET /api/kits/candidates` → `200 application/json`.

It went unnoticed because: zero router-level test coverage for kits, the failure was silent (200 + swallowed parse error), and the embedded `dist/` was stale.

## Fix

- Align all 12 kit routes to `POST /api/{command}`, matching the frontend transport and the desktop Tauri command names.
- Fix handler body/response shapes to match what the frontend actually sends:
  - unwrap `{ req }` payloads (`create/update/preview/sync/unsync`),
  - read `{ id }` from the JSON body instead of path params (`get_details`, `delete_kit`),
  - return JSON `()` instead of empty `204` bodies (which break the frontend's unconditional `response.json()`).
- Add a regression test (`kit_command_routes_return_json_not_spa_html`) asserting kit commands reach a JSON handler, not the SPA HTML fallback.

## Testing

- `cargo test --workspace` — all green (hk-core 519, hk-web 8, …), including the new regression test.
- `npm run test` — 231 passed.
- `biome check` clean; no new clippy warnings from the change.
- Manually verified in dev mode (`npm run dev` @ 1420): existing kits appear and skills are discoverable in the new-kit dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)