### PR TITLE
fix: release experience polish (badge reliability + updater heading)

### DIFF
--- a/.github/badges/release.json
+++ b/.github/badges/release.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "release",
+  "message": "v1.6.1",
+  "color": "brightgreen"
+}

--- a/.github/workflows/update-release-badge.yml
+++ b/.github/workflows/update-release-badge.yml
@@ -1,0 +1,58 @@
+name: Update Release Badge
+
+# Keeps .github/badges/release.json in sync with the latest published release.
+# The README renders the release badge via shields.io's `endpoint` type, which
+# reads this committed JSON instead of calling the GitHub API live — avoiding
+# shields.io's intermittent "Unable to select next GitHub token from pool"
+# failures on the dynamic github/v/release badge.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-badge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Resolve latest release tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          else
+            VERSION="$(gh release view --json tagName -q .tagName)"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Write badge JSON
+        run: |
+          mkdir -p .github/badges
+          cat > .github/badges/release.json <<EOF
+          {
+            "schemaVersion": 1,
+            "label": "release",
+            "message": "${{ steps.tag.outputs.version }}",
+            "color": "brightgreen"
+          }
+          EOF
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- .github/badges/release.json; then
+            echo "Badge already up to date for ${{ steps.tag.outputs.version }}."
+          else
+            git add .github/badges/release.json
+            git commit -m "chore: update release badge to ${{ steps.tag.outputs.version }}"
+            git push origin HEAD:main
+          fi

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/RealZST/HarnessKit/releases/latest"><img src="https://img.shields.io/github/v/release/RealZST/HarnessKit?style=flat-square&color=brightgreen" alt="Latest Release" /></a>
-  <a href="https://github.com/RealZST/HarnessKit/releases"><img src="https://img.shields.io/github/downloads/RealZST/HarnessKit/total?style=flat-square&color=blueviolet" alt="Total Downloads" /></a>
+  <a href="https://github.com/RealZST/HarnessKit/releases/latest"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/RealZST/HarnessKit/main/.github/badges/release.json&style=flat-square" alt="Latest Release" /></a>
+  <a href="https://github.com/RealZST/HarnessKit/releases"><img src="https://img.shields.io/github/downloads/RealZST/HarnessKit/total?style=flat-square&color=blueviolet&cacheSeconds=86400" alt="Total Downloads" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square" alt="License" /></a>
   <a href="#getting-started"><img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square" alt="Platform" /></a>
 </p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,8 +14,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/RealZST/HarnessKit/releases/latest"><img src="https://img.shields.io/github/v/release/RealZST/HarnessKit?style=flat-square&color=brightgreen" alt="Latest Release" /></a>
-  <a href="https://github.com/RealZST/HarnessKit/releases"><img src="https://img.shields.io/github/downloads/RealZST/HarnessKit/total?style=flat-square&color=blueviolet" alt="Total Downloads" /></a>
+  <a href="https://github.com/RealZST/HarnessKit/releases/latest"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/RealZST/HarnessKit/main/.github/badges/release.json&style=flat-square" alt="Latest Release" /></a>
+  <a href="https://github.com/RealZST/HarnessKit/releases"><img src="https://img.shields.io/github/downloads/RealZST/HarnessKit/total?style=flat-square&color=blueviolet&cacheSeconds=86400" alt="Total Downloads" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square" alt="License" /></a>
   <a href="#快速开始"><img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square" alt="Platform" /></a>
 </p>

--- a/src/components/layout/changelog-markdown.tsx
+++ b/src/components/layout/changelog-markdown.tsx
@@ -11,10 +11,18 @@ const components = {
       {children}
     </a>
   ),
+  // Restore visual hierarchy: release notes use `## Section` (top level) and
+  // `### Subsection`. Without an h3 override, h2 rendered small/gray while h3
+  // fell through to the browser default (large/bold), inverting the hierarchy.
   h2: ({ children }: { children?: React.ReactNode }) => (
-    <h4 className="mb-2 text-xs font-medium text-muted-foreground">
+    <h4 className="mb-2 mt-3 text-sm font-semibold text-foreground">
       {children}
     </h4>
+  ),
+  h3: ({ children }: { children?: React.ReactNode }) => (
+    <h5 className="mb-1 mt-2 text-xs font-medium text-muted-foreground">
+      {children}
+    </h5>
   ),
   ul: ({ children }: { children?: React.ReactNode }) => (
     <ul className="list-disc pl-4 space-y-1 text-sm text-foreground">


### PR DESCRIPTION
Two small, independent release-experience fixes (one commit each).

## 1. `fix(badges)` — stop the README release/downloads badges from breaking

The `github/v/release` and `github/downloads` badges use shields.io's **dynamic GitHub-API** endpoints, which intermittently render as `Unable to select next GitHub token from pool` whenever shields' shared GitHub token pool is rate-limited. (The static `/badge/...` license & platform badges on the same line never fail — proof it's a shields-side issue, not ours.)

- **Release badge → shields `endpoint` type**, backed by a committed `.github/badges/release.json`. A new workflow (`update-release-badge.yml`) rewrites that JSON on `release: published`, so the badge **never calls the GitHub API at render time**.
- **Downloads badge → `cacheSeconds=86400`**, kept dynamic but far less exposed to the same failure.

> Note: the endpoint badge only renders once `release.json` exists on `main`, i.e. **after this PR merges**.

## 2. `fix(updater)` — correct release-notes heading hierarchy

`ChangelogMarkdown` only overrode `h2` (rendered small/gray) and let `h3` fall through to the browser default (large/bold), **inverting** the hierarchy in the in-app updater dialog — top-level `## Highlights` / `## What's Changed` looked smaller than their `### Features` / `### Fixes` children. Now `h2` is the prominent heading and `h3` the subdued subheading.

## Testing

- `npm run test` — 231 passed; `tsc --noEmit` clean; `biome check` clean.
- README/workflow/JSON validated (YAML + JSON parse OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)