### PR TITLE
feat: add linux-arm64 (aarch64) CLI build and install support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,47 @@ jobs:
           cp target/x86_64-unknown-linux-musl/release/hk hk-linux-x64
           gh release upload "${{ github.ref_name }}" hk-linux-x64 --clobber
 
+  release-cli-linux-arm64:
+    needs: create-release
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-musl
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          key: aarch64-unknown-linux-musl
+
+      - name: Install musl toolchain
+        run: sudo apt-get update && sudo apt-get install -y musl-tools perl make
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build CLI (with embedded web frontend)
+        run: |
+          npm run build
+          cargo build --release -p hk-cli --target aarch64-unknown-linux-musl
+
+      - name: Upload CLI to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp target/aarch64-unknown-linux-musl/release/hk hk-linux-arm64
+          gh release upload "${{ github.ref_name }}" hk-linux-arm64 --clobber
+
   release-cli-windows:
     needs: create-release
     runs-on: windows-latest

--- a/install.sh
+++ b/install.sh
@@ -24,8 +24,9 @@ case "$OS" in
     ;;
   Linux)
     case "$ARCH" in
-      x86_64) BINARY="hk-linux-x64" ;;
-      *)      echo "Error: unsupported architecture: $ARCH"; exit 1 ;;
+      x86_64)        BINARY="hk-linux-x64" ;;
+      aarch64|arm64) BINARY="hk-linux-arm64" ;;
+      *)             echo "Error: unsupported architecture: $ARCH"; exit 1 ;;
     esac
     ;;
   *)


### PR DESCRIPTION
## Summary

Linux ARM64 servers cannot install HarnessKit today. The release ships `hk-linux-x64`,
`hk-macos-arm64`, `hk-macos-x64` and Windows, but no aarch64 Linux CLI, so `install.sh` exits with
`Error: unsupported architecture: aarch64` on ARM boxes (for example an Oracle Cloud Ampere A1
instance).

This adds the missing target:

- A new `release-cli-linux-arm64` job that builds the `hk` CLI for `aarch64-unknown-linux-musl` and
  uploads it as `hk-linux-arm64`. It is a near line-for-line mirror of the existing
  `release-cli-linux` job, and runs natively on GitHub's free `ubuntu-24.04-arm` public runner, so
  there is no cross-compilation and no self-hosted runner.
- An `install.sh` case mapping `aarch64`/`arm64` on Linux to `hk-linux-arm64`, instead of erroring.

No Rust source changes. The CLI is platform-agnostic; this is purely the build target plus the
installer mapping.

## Linked issue

No existing issue (I searched open and closed issues and PRs for arm64/aarch64 first). This is a
small, self-contained platform addition, but I am happy to open an issue first if you prefer that
flow.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Refactor or cleanup (no behaviour change)
- [ ] Documentation
- [x] CI, tooling, or config

## How to test

On a native aarch64 Linux box:

1. `npm ci && npm run build`
2. `cargo build --release -p hk-cli --target aarch64-unknown-linux-musl`
3. `./target/aarch64-unknown-linux-musl/release/hk status` (and `list`, `audit --no-scan`)

For the installer mapping: on aarch64 Linux, `install.sh` now resolves to `hk-linux-arm64` (the
full curl install works once a release carries that asset; before this change the script errored).

## Checklist

- [x] One concern only, scope limited to the summary above
- [x] I ran it and verified end to end, with one honest caveat below

Built and verified on a native aarch64 Ubuntu 24.04 box: the resulting static binary
(`statically linked, ARM aarch64`) runs and correctly detects agents (claude, cursor, opencode,
hermes) and 159 extensions. `npm test` (234 passing) and `cargo test` for `hk-core`, `hk-cli`,
`hk-web` pass locally. I did not run the full `cargo test --workspace` locally because the
`hk-desktop` (Tauri) crate needs a desktop build environment that is not present on a headless ARM
Linux server; the repo's PR CI runs the full workspace on `macos-latest`, which covers it.

## Model used

Claude Code (Claude Opus 4.8), used to write the CI job and installer change, and to build and
verify the binary on a native aarch64 box.

---

🤖 Generated with Claude Code (Claude Opus 4.8)
🧑‍💻 Ideated, directed and reviewed by a human, @Omee11
