### PR TITLE
docs(readme): list hk-linux-arm64 download asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,8 @@ Download the binary for your platform from the [latest release](https://github.c
 |----------|------|
 | macOS (Apple Silicon) | `hk-macos-arm64` |
 | macOS (Intel) | `hk-macos-x64` |
-| Linux | `hk-linux-x64` |
+| Linux (x64) | `hk-linux-x64` |
+| Linux (ARM64) | `hk-linux-arm64` |
 | Windows | `hk-windows-x64.exe` |
 
 **Local machine:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -297,7 +297,8 @@ HarnessKit Web UI running at http://127.0.0.1:7070
 |----------|------|
 | macOS（Apple Silicon） | `hk-macos-arm64` |
 | macOS（Intel） | `hk-macos-x64` |
-| Linux | `hk-linux-x64` |
+| Linux（x64） | `hk-linux-x64` |
+| Linux（ARM64） | `hk-linux-arm64` |
 | Windows | `hk-windows-x64.exe` |
 
 **本机：**


### PR DESCRIPTION
## Summary

Docs-only follow-up to #93, which added the Linux ARM64 (aarch64) CLI build and `install.sh` mapping. The manual-download asset table only listed `hk-linux-x64`, so split the single **Linux** row into **x64 / ARM64** to document the new `hk-linux-arm64` release asset.

- Mirrored across **README.md** and **README.zh-CN.md**.
- Asset name `hk-linux-arm64` cross-checked against the `release-cli-linux-arm64` job upload step in `release.yml`, and against the other four rows (`hk-macos-arm64` / `hk-macos-x64` / `hk-linux-x64` / `hk-windows-x64.exe`).

## Test plan

- [x] No code changes — documentation only.
- [x] Asset names verified to match `release.yml` upload steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)