### PR TITLE
fix: macOS Tahoe window regression (pin CI runners, rebalance traffic lights)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   analyze:
-    runs-on: macos-latest
+    # Only javascript-typescript is analyzed here, which needs no macOS toolchain.
+    # ubuntu is faster/cheaper and sidesteps the macos-latest -> macos-26 migration.
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    # Pinned to macos-15 to match the release build env (release.yml) and avoid
+    # the macos-latest -> macos-26 toolchain jump breaking PR builds mid-rollout.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,10 @@ jobs:
             arch: arm64
           - target: x86_64-apple-darwin
             arch: x64
-    runs-on: macos-latest
+    # Pinned to macos-15: macos-latest migrated to macos-26 (Tahoe) in June 2026,
+    # whose SDK makes desktop builds adopt Tahoe's new window chrome (misplaced
+    # traffic lights + white frame). Pin keeps a reproducible, pre-26 SDK build.
+    runs-on: macos-15
     permissions:
       contents: write
 
@@ -241,7 +244,10 @@ jobs:
 
   release-cli-windows:
     needs: create-release
-    runs-on: windows-latest
+    # Pinned to windows-2025 so a future windows-latest OS-major migration can't
+    # silently change the build env (same control-your-upgrade-timing rationale
+    # as the macos-15 pin). Keeps the current, working Server 2025 + VS2026 image.
+    runs-on: windows-2025
     permissions:
       contents: write
     steps:

--- a/crates/hk-desktop/tauri.conf.json
+++ b/crates/hk-desktop/tauri.conf.json
@@ -15,7 +15,7 @@
         "title": "HarnessKit",
         "hiddenTitle": true,
         "titleBarStyle": "Overlay",
-        "trafficLightPosition": { "x": 16, "y": 12 },
+        "trafficLightPosition": { "x": 16, "y": 18 },
         "decorations": true,
         "width": 1280,
         "height": 800,


### PR DESCRIPTION
## Why

After v1.6.3, the macOS desktop app showed misplaced traffic-light buttons and a white frame around the window — but only on **macOS 26 (Tahoe)**, and only for the *released* binary (`cargo tauri dev` and earlier releases looked fine).

Root cause is **not** a source change (the window config/layout/Tauri stack are byte-identical since v1.5.0). It's the runner:

- `runs-on: macos-latest` is a floating label, and GitHub migrated it from `macos-15` to **`macos-26`** in June 2026 (staged rollout).
- v1.6.3's arm64 desktop leg landed on `macos-26`, making it the **first build linked against the macOS 26 SDK** (`codesign -dvvv` on the installed app reports `Runtime Version=26.5.0`).
- macOS 26 Tahoe gates window chrome on the linked SDK: a binary built with SDK ≥ 26 opts into the new Tahoe window appearance → white frame + raised traffic lights. Binaries built with an older SDK (`macos-15`, or local CLT SDK 13.3 in dev) render in the legacy appearance and look correct.

Verified by patching a copy of the release binary's `LC_BUILD_VERSION` SDK from `26.5` → `15.0` and re-signing: the appearance returned to normal, confirming the SDK field is the gate.

## What changed

**CI runner pins** (stop the toolchain drifting between releases):
- `release.yml`: desktop `macos-latest` → `macos-15`; Windows CLI `windows-latest` → `windows-2025`
- `pr-checks.yml`: `macos-latest` → `macos-15` (match the release build env)
- `codeql.yml`: `macos-latest` → `ubuntu-latest` (only JS/TS is analyzed — no macOS toolchain needed)

**Traffic light position:**
- `tauri.conf.json`: `trafficLightPosition` `{16,12}` → `{16,18}`, tuned for the macos-15 (legacy) chrome that now ships. Since dev (CLT SDK 13.3) and the pinned `macos-15` release both render legacy, the dev preview is now a faithful proxy.

## Follow-up (not in this PR)

When `macos-15` nears deprecation, or we decide to adopt the Tahoe design: switch the desktop runner back to `macos-26`, re-tune `trafficLightPosition` (the same `y` renders higher under SDK 26), and fix `transparent`/vibrancy so the new chrome shows frosted glass instead of a white frame.