### PR TITLE
feat: add Oh My Pi (omp) agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ HarnessKit manages **all five extension types** from a unified interface — **S
 | **OpenCode** | ✓ | ✓ | ✓ | — | ✓ |
 | **Hermes** | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **Kiro** | ✓ | ✓ | — | ✓ | ✓ |
+| **Oh My Pi** | ✓ | ✓ | ✓ | — | ✓ |
 
 <small><i>* "—" indicates the agent currently does not support this extension type.</i></small>
 
@@ -87,7 +88,7 @@ HarnessKit manages **all five extension types** from a unified interface — **S
 
 ### 🤖 Agent Configs, Memory & Rules
 
-HarnessKit manages every agent's **Configs**, **Memory**, **Rules**, **Subagents**, and **Ignore** files from one place. Currently supporting **10 agents**: **Claude Code**, **Codex**, **Gemini CLI**, **Cursor**, **Antigravity**, **Copilot**, **Windsurf**, **OpenCode**, **Hermes**, and **Kiro**.
+HarnessKit manages every agent's **Configs**, **Memory**, **Rules**, **Subagents**, and **Ignore** files from one place. Currently supporting **11 agents**: **Claude Code**, **Codex**, **Gemini CLI**, **Cursor**, **Antigravity**, **Copilot**, **Windsurf**, **OpenCode**, **Hermes**, **Kiro**, and **Oh My Pi**.
 
 - **Config file tracking** — Automatically discovers every agent's config files — both global and per-project. Add your project directories or custom paths and HarnessKit picks them up alongside the global ones.
 - **Per-agent dashboard** — Each agent gets its own page with all files organized by category, showing scope, path, file size, and a summary of installed extensions. Expand any file to preview its content right in the app.
@@ -175,7 +176,7 @@ HarnessKit ships a standalone command-line interface (`hk`) for terminal-first w
 
 ```shell
 $ hk status
-  Agents        10 detected (claude · codex · gemini · cursor · antigravity · copilot · windsurf · opencode · hermes · kiro)
+  Agents        11 detected (claude · codex · gemini · cursor · antigravity · copilot · windsurf · opencode · hermes · kiro · omp)
   Extensions    136 total (124 skills · 2 mcp · 8 plugins · 1 hooks · 1 clis)
 
 $ hk list --kind skill --agent claude    # filter by type and agent

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,6 +68,7 @@ HarnessKit 通过统一界面管理 **全部五种扩展类型** —— **Skill*
 | **OpenCode** | ✓ | ✓ | ✓ | — | ✓ |
 | **Hermes** | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **Kiro** | ✓ | ✓ | — | ✓ | ✓ |
+| **Oh My Pi** | ✓ | ✓ | ✓ | — | ✓ |
 
 <small><i>* "—" 表示该 Agent 目前不支持此扩展类型。</i></small>
 
@@ -87,7 +88,7 @@ HarnessKit 通过统一界面管理 **全部五种扩展类型** —— **Skill*
 
 ### 🤖 Agent 配置、记忆与规则
 
-HarnessKit 统一管理每个 Agent 的 **配置**、**记忆**、**规则**、**子 Agent** 与 **忽略**（Ignore）文件。目前支持 **10 个 Agent**：**Claude Code**、**Codex**、**Gemini CLI**、**Cursor**、**Antigravity**、**Copilot**、**Windsurf**、**OpenCode**、**Hermes** 与 **Kiro**。
+HarnessKit 统一管理每个 Agent 的 **配置**、**记忆**、**规则**、**子 Agent** 与 **忽略**（Ignore）文件。目前支持 **11 个 Agent**：**Claude Code**、**Codex**、**Gemini CLI**、**Cursor**、**Antigravity**、**Copilot**、**Windsurf**、**OpenCode**、**Hermes**、**Kiro** 与 **Oh My Pi**。
 
 - **配置文件跟踪** —— 自动发现每个 Agent 的全局与项目级配置文件。添加项目目录或自定义路径后，HarnessKit 会将它们与全局配置一同纳入管理。
 - **Agent 专属面板** —— 每个 Agent 拥有独立页面，文件按类别组织，列出范围、路径、文件大小以及已安装扩展的概览。展开任意文件即可在应用内预览。
@@ -175,7 +176,7 @@ HarnessKit 提供独立命令行工具（`hk`），面向偏好终端的工作�
 
 ```shell
 $ hk status
-  Agents        10 detected (claude · codex · gemini · cursor · antigravity · copilot · windsurf · opencode · hermes · kiro)
+  Agents        11 detected (claude · codex · gemini · cursor · antigravity · copilot · windsurf · opencode · hermes · kiro · omp)
   Extensions    136 total (124 skills · 2 mcp · 8 plugins · 1 hooks · 1 clis)
 
 $ hk list --kind skill --agent claude    # 按类型与 Agent 筛选

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -537,7 +537,7 @@ mod tests {
     fn test_supports_native_mcp_toggle_only_native_agents() {
         let adapters = all_adapters();
         for a in &adapters {
-            let expected = a.name() == "hermes" || a.name() == "kiro";
+            let expected = matches!(a.name(), "hermes" | "kiro" | "omp");
             assert_eq!(
                 a.supports_native_mcp_toggle(),
                 expected,

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -8,6 +8,7 @@ pub mod hermes;
 pub mod hook_events;
 pub mod kiro;
 pub mod opencode;
+pub mod omp;
 pub mod windsurf;
 
 use crate::models::ConfigScope;
@@ -479,6 +480,7 @@ pub fn all_adapters() -> Vec<Box<dyn AgentAdapter>> {
         Box::new(opencode::OpencodeAdapter::new()),
         Box::new(hermes::HermesAdapter::new()),
         Box::new(kiro::KiroAdapter::new()),
+        Box::new(omp::OmpAdapter::new()),
     ]
 }
 
@@ -487,9 +489,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_all_adapters_returns_ten() {
+    fn test_all_adapters_returns_eleven() {
         let adapters = all_adapters();
-        assert_eq!(adapters.len(), 10);
+        assert_eq!(adapters.len(), 11);
         let names: Vec<&str> = adapters.iter().map(|a| a.name()).collect();
         assert!(names.contains(&"claude"));
         assert!(names.contains(&"cursor"));
@@ -501,6 +503,7 @@ mod tests {
         assert!(names.contains(&"opencode"));
         assert!(names.contains(&"hermes"));
         assert!(names.contains(&"kiro"));
+        assert!(names.contains(&"omp"));
     }
 
     #[test]
@@ -521,7 +524,7 @@ mod tests {
         // unnecessarily rewrite users' mcp_config.json with absolute paths,
         // hurting cross-machine portability.
         for name in [
-            "claude", "codex", "gemini", "cursor", "copilot", "opencode", "hermes", "kiro",
+            "claude", "codex", "gemini", "cursor", "copilot", "opencode", "hermes", "kiro", "omp",
         ] {
             assert!(
                 !by_name[name].needs_path_injection(),
@@ -582,6 +585,7 @@ mod tests {
             ("antigravity", true, false, false, false, true), // no MCP/project, no hooks
             ("opencode", true, true, false, false, true), // hooks are JS plugins
             ("kiro", true, true, true, true, false),     // kirodotdev/Kiro#5440
+            ("omp", true, true, false, false, true),     // hooks are JS/TS modules
             ("hermes", false, false, false, true, true), // global-only (hermes-agent#4667)
         ];
 
@@ -713,6 +717,7 @@ mod tests {
             ("copilot", ".github/skills"),
             ("opencode", ".opencode/skills"),
             ("kiro", ".kiro/skills"),
+            ("omp", ".omp/skills"),
             // hermes is global-only — no project skill dir (hermes-agent#4667).
         ]
         .into_iter()

--- a/crates/hk-core/src/adapter/omp.rs
+++ b/crates/hk-core/src/adapter/omp.rs
@@ -66,10 +66,14 @@ impl OmpAdapter {
             .unwrap_or_else(|| base.to_string())
     }
 
-    /// omp extensions are .ts/.js modules exporting a default factory. A
-    /// `.disabled` extension suffix is HK's own in-place disable rename — omp
-    /// itself has no native per-file enable flag, so disable is a file rename
-    /// (same model as opencode plugins).
+    /// omp extensions are .ts/.js modules exporting a default factory. The
+    /// loader globs only `*.{ts,js}` (discovery/helpers.ts, extension-loading.md)
+    /// — no .mjs/.cjs — so matching more here would list files omp never loads.
+    ///
+    /// A `.disabled` suffix is HK's own in-place disable rename (same model as
+    /// opencode plugins). omp's native disable mechanism is the
+    /// `disabledExtensions` id list in config.yml, which HK doesn't write; the
+    /// rename works because the loader's glob won't match a `.disabled` file.
     fn is_extension_file(path: &Path) -> bool {
         let file_name = path
             .file_name()
@@ -78,7 +82,7 @@ impl OmpAdapter {
         let base = file_name.strip_suffix(".disabled").unwrap_or(&file_name);
         matches!(
             Path::new(base).extension().and_then(|ext| ext.to_str()),
-            Some("ts" | "js" | "mjs" | "cjs")
+            Some("ts" | "js")
         )
     }
 }
@@ -353,8 +357,10 @@ mod tests {
         std::fs::create_dir_all(&ext_dir).unwrap();
         std::fs::write(ext_dir.join("orca-status.ts"), "// ext\n").unwrap();
         std::fs::write(ext_dir.join("orca-spin.ts.disabled"), "// ext\n").unwrap();
-        // Non-extension file is ignored.
+        // Non-extension files are ignored — including .mjs/.cjs, which omp's
+        // loader glob (*.{ts,js}) never picks up.
         std::fs::write(ext_dir.join("README.md"), "# readme\n").unwrap();
+        std::fs::write(ext_dir.join("not-loaded.mjs"), "// ext\n").unwrap();
 
         let plugins = adapter.read_plugins();
         assert_eq!(plugins.len(), 2);

--- a/crates/hk-core/src/adapter/omp.rs
+++ b/crates/hk-core/src/adapter/omp.rs
@@ -1,0 +1,390 @@
+// omp (Oh My Pi) config references — read from the in-tree harness docs:
+// - Skills:   https://github.com/can1357/oh-my-pi  → docs/skills.md
+// - MCP:      docs/mcp-config.md
+// - Config:   docs/config-usage.md
+// - Context:  docs/context-files.md
+// - Hooks:    docs/hooks.md
+// - Extensions: docs/extensions.md, docs/extension-loading.md
+//
+// omp's base dir is ~/.omp; the agent subtree lives under ~/.omp/agent/.
+// A named profile (`omp --profile <name>`) relocates the agent dir to
+// ~/.omp/profiles/<name>/agent/ — HK scans the default profile only.
+//
+// Hooks are JS/TS modules (.omp/hooks/pre/*.ts), not shell commands, so this
+// adapter reports HookFormat::None — same model as opencode ("hooks are JS
+// plugins"). omp's shell-command HookEntry model has no equivalent.
+
+use super::{AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry, ProjectMarker};
+use std::path::{Path, PathBuf};
+
+pub struct OmpAdapter {
+    home: PathBuf,
+}
+
+impl Default for OmpAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OmpAdapter {
+    pub fn new() -> Self {
+        Self {
+            home: dirs::home_dir().unwrap_or_default(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_home(home: PathBuf) -> Self {
+        Self { home }
+    }
+
+    /// The agent subtree: ~/.omp/agent. All omp-native config (skills, mcp.json,
+    /// config.yml, extensions/, commands/, AGENTS.md, RULES.md) lives here.
+    fn agent_dir(&self) -> PathBuf {
+        self.base_dir().join("agent")
+    }
+
+    fn parse_json(path: &Path) -> Option<serde_json::Value> {
+        let content = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&content).ok()
+    }
+
+    fn plugin_name(path: &Path) -> String {
+        // Strip `.disabled` first so a toggled-off `orca-spin.ts.disabled`
+        // shares the name of its enabled sibling `orca-spin.ts` — the name
+        // must be stable across enable/disable or HK's toggle model breaks.
+        // Same approach as the opencode adapter.
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let base = file_name.strip_suffix(".disabled").unwrap_or(&file_name);
+        Path::new(base)
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().to_string())
+            .unwrap_or_else(|| base.to_string())
+    }
+
+    /// omp extensions are .ts/.js modules exporting a default factory. A
+    /// `.disabled` extension suffix is HK's own in-place disable rename — omp
+    /// itself has no native per-file enable flag, so disable is a file rename
+    /// (same model as opencode plugins).
+    fn is_extension_file(path: &Path) -> bool {
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let base = file_name.strip_suffix(".disabled").unwrap_or(&file_name);
+        matches!(
+            Path::new(base).extension().and_then(|ext| ext.to_str()),
+            Some("ts" | "js" | "mjs" | "cjs")
+        )
+    }
+}
+
+impl AgentAdapter for OmpAdapter {
+    fn name(&self) -> &str {
+        "omp"
+    }
+
+    fn base_dir(&self) -> PathBuf {
+        self.home.join(".omp")
+    }
+
+    fn detect(&self) -> bool {
+        // omp creates ~/.omp on first run (install-id, agent/, natives/).
+        // Presence of the base dir is a reliable signal — matches how every
+        // other adapter detects (base_dir().exists()).
+        self.base_dir().exists()
+    }
+
+    fn skill_dirs(&self) -> Vec<PathBuf> {
+        // Native omp skills live one level under ~/.omp/agent/skills/.
+        // (omp also reads .agents/skills and .claude/skills via its own
+        // discovery providers, but those are owned by the agents/codex/claude
+        // adapters — don't double-claim them here.)
+        vec![self.agent_dir().join("skills")]
+    }
+
+    fn mcp_config_path(&self) -> PathBuf {
+        // ~/.omp/agent/mcp.json is the canonical user-level file. omp also
+        // reads ~/.omp/agent/.mcp.json for compat, but writes to mcp.json.
+        self.agent_dir().join("mcp.json")
+    }
+
+    fn hook_config_path(&self) -> PathBuf {
+        // omp has no shell-command hooks file. Reuse the MCP path so the
+        // default plugin_config_path() lands on a real file (mirrors opencode).
+        self.mcp_config_path()
+    }
+
+    fn plugin_dirs(&self) -> Vec<PathBuf> {
+        // TypeScript extension modules: ~/.omp/agent/extensions/*.ts
+        vec![self.agent_dir().join("extensions")]
+    }
+
+    fn hook_format(&self) -> HookFormat {
+        HookFormat::None
+    }
+
+    fn mcp_format(&self) -> McpFormat {
+        McpFormat::McpServers
+    }
+
+    fn read_mcp_servers(&self) -> Vec<McpServerEntry> {
+        self.read_mcp_servers_from(&self.mcp_config_path())
+    }
+
+    fn read_mcp_servers_from(&self, path: &Path) -> Vec<McpServerEntry> {
+        let Some(config) = Self::parse_json(path) else {
+            return vec![];
+        };
+        let Some(servers) = config.get("mcpServers").and_then(|v| v.as_object()) else {
+            return vec![];
+        };
+        servers
+            .iter()
+            .map(|(name, val)| McpServerEntry {
+                name: name.clone(),
+                // stdio servers use `command`; http/sse servers use `url`.
+                // Store the url in the command field so remote servers
+                // round-trip (same approach Hermes uses for url-based entries).
+                command: val
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| val.get("url").and_then(|v| v.as_str()))
+                    .unwrap_or("")
+                    .into(),
+                args: val
+                    .get("args")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                env: val
+                    .get("env")
+                    .and_then(|v| v.as_object())
+                    .map(|obj| {
+                        obj.iter()
+                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                // omp carries a native per-server `enabled` flag (default true).
+                // Reported here so the scanner reflects on-disk state; HK's
+                // default toggle (remove+snapshot) is used since omp's writer
+                // path isn't wired into supports_native_mcp_toggle().
+                enabled: val
+                    .get("enabled")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true),
+            })
+            .collect()
+    }
+
+    fn read_hooks(&self) -> Vec<HookEntry> {
+        // omp hooks are JS/TS event-handler modules, not shell commands —
+        // there is no shell HookEntry representation. Returns empty, matching
+        // opencode.
+        vec![]
+    }
+
+    fn read_plugins(&self) -> Vec<PluginEntry> {
+        let mut entries = Vec::new();
+        for plugin_dir in self.plugin_dirs() {
+            let Ok(files) = std::fs::read_dir(plugin_dir) else {
+                continue;
+            };
+            for file in files.flatten() {
+                let path = file.path();
+                if !path.is_file() || !Self::is_extension_file(&path) {
+                    continue;
+                }
+                let enabled = path.extension().is_none_or(|ext| ext != "disabled");
+                entries.push(PluginEntry {
+                    name: Self::plugin_name(&path),
+                    source: "local".into(),
+                    enabled,
+                    path: Some(path),
+                    source_url: None,
+                    uri: None,
+                    installed_at: None,
+                    updated_at: None,
+                });
+            }
+        }
+        entries
+    }
+
+    fn global_rules_files(&self) -> Vec<PathBuf> {
+        // AGENTS.md is the native context file (advisory background loaded into
+        // the opening prompt). RULES.md is the sticky-rule sibling (loaded as
+        // an always-apply rule). Both are omp-native and read only from
+        // ~/.omp/agent/ at user scope.
+        vec![
+            self.agent_dir().join("AGENTS.md"),
+            self.agent_dir().join("RULES.md"),
+        ]
+    }
+
+    fn global_settings_files(&self) -> Vec<PathBuf> {
+        // config.yml is the primary (post-YAML-migration) global settings file.
+        // settings.json is the legacy form, kept until migration runs.
+        let agent = self.agent_dir();
+        vec![agent.join("config.yml"), agent.join("settings.json")]
+    }
+
+    fn global_workflow_files(&self) -> Vec<PathBuf> {
+        // Slash commands: ~/.omp/agent/commands/*.md
+        super::files_with_ext(&self.agent_dir().join("commands"), "md").collect()
+    }
+
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        vec![
+            ProjectMarker::Dir(".omp"),
+            ProjectMarker::File(".omp/mcp.json"),
+        ]
+    }
+
+    fn project_rules_patterns(&self) -> Vec<String> {
+        // Native project context: <ancestor>/.omp/AGENTS.md (nearest walk-up to
+        // repo root) + the sticky <ancestor>/.omp/RULES.md. Both are omp-native
+        // and only read from the .omp config directory.
+        vec![".omp/AGENTS.md".into(), ".omp/RULES.md".into()]
+    }
+
+    fn project_settings_patterns(&self) -> Vec<String> {
+        vec![".omp/config.yml".into(), ".omp/settings.json".into()]
+    }
+
+    fn project_workflow_patterns(&self) -> Vec<String> {
+        vec![".omp/commands/*.md".into()]
+    }
+
+    fn project_skill_dirs(&self) -> Vec<String> {
+        vec![".omp/skills".into()]
+    }
+
+    fn project_mcp_config_relpath(&self) -> Option<String> {
+        // omp reads .omp/mcp.json (and the compat .omp/.mcp.json); writes go to
+        // .omp/mcp.json. See docs/mcp-config.md "Preferred config locations".
+        Some(".omp/mcp.json".into())
+    }
+
+    fn project_plugin_dirs(&self) -> Vec<String> {
+        // Project-level extension modules: <repo>/.omp/extensions/*.ts
+        vec![".omp/extensions".into()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::AgentAdapter;
+    use super::*;
+
+    #[test]
+    fn detect_requires_omp_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = OmpAdapter::with_home(tmp.path().to_path_buf());
+        assert!(!adapter.detect());
+
+        std::fs::create_dir_all(tmp.path().join(".omp")).unwrap();
+        assert!(adapter.detect());
+    }
+
+    #[test]
+    fn read_mcp_servers_handles_stdio_and_remote() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = OmpAdapter::with_home(tmp.path().to_path_buf());
+        let cfg = tmp.path().join(".omp/agent/mcp.json");
+        std::fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        std::fs::write(
+            &cfg,
+            r#"{
+              "mcpServers": {
+                "filesystem": {
+                  "command": "npx",
+                  "args": ["-y", "@modelcontextprotocol/server-filesystem"]
+                },
+                "github": {
+                  "type": "http",
+                  "url": "https://api.githubcopilot.com/mcp/"
+                },
+                "disabled-one": {
+                  "command": "echo",
+                  "enabled": false
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let servers = adapter.read_mcp_servers();
+        assert_eq!(servers.len(), 3);
+
+        let by_name: std::collections::HashMap<&str, &McpServerEntry> =
+            servers.iter().map(|s| (s.name.as_str(), s)).collect();
+
+        let fs = by_name["filesystem"];
+        assert_eq!(fs.command, "npx");
+        assert_eq!(fs.args, vec!["-y", "@modelcontextprotocol/server-filesystem"]);
+        assert!(fs.enabled);
+
+        // Remote server: url stored in the command field (mirrors Hermes).
+        let gh = by_name["github"];
+        assert_eq!(gh.command, "https://api.githubcopilot.com/mcp/");
+        assert!(gh.args.is_empty());
+
+        // Native per-server enabled flag is read back.
+        let off = by_name["disabled-one"];
+        assert_eq!(off.command, "echo");
+        assert!(!off.enabled);
+    }
+
+    #[test]
+    fn read_plugins_lists_ts_extensions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = OmpAdapter::with_home(tmp.path().to_path_buf());
+        let ext_dir = tmp.path().join(".omp/agent/extensions");
+        std::fs::create_dir_all(&ext_dir).unwrap();
+        std::fs::write(ext_dir.join("orca-status.ts"), "// ext\n").unwrap();
+        std::fs::write(ext_dir.join("orca-spin.ts.disabled"), "// ext\n").unwrap();
+        // Non-extension file is ignored.
+        std::fs::write(ext_dir.join("README.md"), "# readme\n").unwrap();
+
+        let plugins = adapter.read_plugins();
+        assert_eq!(plugins.len(), 2);
+        let by_name: std::collections::HashMap<&str, &PluginEntry> =
+            plugins.iter().map(|p| (p.name.as_str(), p)).collect();
+        assert!(by_name.contains_key("orca-status"));
+        assert!(by_name["orca-status"].enabled);
+        assert!(by_name.contains_key("orca-spin"));
+        assert!(!by_name["orca-spin"].enabled);
+    }
+
+    #[test]
+    fn paths_match_omp_native_conventions() {
+        let adapter = OmpAdapter::with_home(PathBuf::from("/h"));
+        assert_eq!(adapter.base_dir(), PathBuf::from("/h/.omp"));
+        assert_eq!(adapter.skill_dirs(), vec![PathBuf::from("/h/.omp/agent/skills")]);
+        assert_eq!(
+            adapter.mcp_config_path(),
+            PathBuf::from("/h/.omp/agent/mcp.json")
+        );
+        assert_eq!(adapter.plugin_dirs(), vec![PathBuf::from("/h/.omp/agent/extensions")]);
+        assert_eq!(
+            adapter.project_skill_dirs(),
+            vec![".omp/skills".to_string()]
+        );
+        assert_eq!(
+            adapter.project_mcp_config_relpath(),
+            Some(".omp/mcp.json".into())
+        );
+        assert_eq!(adapter.hook_format(), HookFormat::None);
+        assert_eq!(adapter.mcp_format(), McpFormat::McpServers);
+    }
+}

--- a/crates/hk-core/src/adapter/omp.rs
+++ b/crates/hk-core/src/adapter/omp.rs
@@ -229,20 +229,57 @@ impl AgentAdapter for OmpAdapter {
             };
             for file in files.flatten() {
                 let path = file.path();
-                if !path.is_file() || !Self::is_extension_file(&path) {
-                    continue;
+                if path.is_file() {
+                    if !Self::is_extension_file(&path) {
+                        continue;
+                    }
+                    let enabled = path.extension().is_none_or(|ext| ext != "disabled");
+                    entries.push(PluginEntry {
+                        name: Self::plugin_name(&path),
+                        source: "local".into(),
+                        enabled,
+                        path: Some(path),
+                        source_url: None,
+                        uri: None,
+                        installed_at: None,
+                        updated_at: None,
+                    });
+                } else if path.is_dir() {
+                    // Directory-form extension: <name>/index.{ts,js}, TypeScript
+                    // preferred (extension-loading.md resolution order). Active
+                    // entry files first so a `index.ts.disabled` next to a live
+                    // `index.js` reports what omp actually loads. The entry's
+                    // path is the index file — HK's toggle renames that file,
+                    // keeping the directory (and thus the plugin name) stable.
+                    // package.json-manifest extensions (`omp.extensions`) are
+                    // not modeled.
+                    let Some(dir_name) = path.file_name().map(|n| n.to_string_lossy().to_string())
+                    else {
+                        continue;
+                    };
+                    let candidates = [
+                        ("index.ts", true),
+                        ("index.js", true),
+                        ("index.ts.disabled", false),
+                        ("index.js.disabled", false),
+                    ];
+                    if let Some((entry_file, enabled)) = candidates
+                        .iter()
+                        .map(|(f, e)| (path.join(f), *e))
+                        .find(|(p, _)| p.is_file())
+                    {
+                        entries.push(PluginEntry {
+                            name: dir_name,
+                            source: "local".into(),
+                            enabled,
+                            path: Some(entry_file),
+                            source_url: None,
+                            uri: None,
+                            installed_at: None,
+                            updated_at: None,
+                        });
+                    }
                 }
-                let enabled = path.extension().is_none_or(|ext| ext != "disabled");
-                entries.push(PluginEntry {
-                    name: Self::plugin_name(&path),
-                    source: "local".into(),
-                    enabled,
-                    path: Some(path),
-                    source_url: None,
-                    uri: None,
-                    installed_at: None,
-                    updated_at: None,
-                });
             }
         }
         entries
@@ -251,12 +288,14 @@ impl AgentAdapter for OmpAdapter {
     fn global_rules_files(&self) -> Vec<PathBuf> {
         // AGENTS.md is the native context file (advisory background loaded into
         // the opening prompt). RULES.md is the sticky-rule sibling (loaded as
-        // an always-apply rule). Both are omp-native and read only from
-        // ~/.omp/agent/ at user scope.
-        vec![
-            self.agent_dir().join("AGENTS.md"),
-            self.agent_dir().join("RULES.md"),
-        ]
+        // an always-apply rule). rules/*.{md,mdc} are per-file rules loaded by
+        // the same provider (builtin.ts loadRules), separate from the sticky
+        // RULES.md. All omp-native, read from ~/.omp/agent/ at user scope.
+        let agent = self.agent_dir();
+        let mut files = vec![agent.join("AGENTS.md"), agent.join("RULES.md")];
+        files.extend(super::files_with_ext(&agent.join("rules"), "md"));
+        files.extend(super::files_with_ext(&agent.join("rules"), "mdc"));
+        files
     }
 
     fn global_settings_files(&self) -> Vec<PathBuf> {
@@ -280,9 +319,15 @@ impl AgentAdapter for OmpAdapter {
 
     fn project_rules_patterns(&self) -> Vec<String> {
         // Native project context: <ancestor>/.omp/AGENTS.md (nearest walk-up to
-        // repo root) + the sticky <ancestor>/.omp/RULES.md. Both are omp-native
+        // repo root), the sticky <ancestor>/.omp/RULES.md, and per-file rules
+        // under .omp/rules/ (md + mdc, builtin.ts loadRules). All omp-native
         // and only read from the .omp config directory.
-        vec![".omp/AGENTS.md".into(), ".omp/RULES.md".into()]
+        vec![
+            ".omp/AGENTS.md".into(),
+            ".omp/RULES.md".into(),
+            ".omp/rules/*.md".into(),
+            ".omp/rules/*.mdc".into(),
+        ]
     }
 
     fn project_settings_patterns(&self) -> Vec<String> {
@@ -430,14 +475,31 @@ mod tests {
         std::fs::write(ext_dir.join("README.md"), "# readme\n").unwrap();
         std::fs::write(ext_dir.join("not-loaded.mjs"), "// ext\n").unwrap();
 
+        // Directory-form extension: <name>/index.ts.
+        let dir_ext = ext_dir.join("orca-panel");
+        std::fs::create_dir_all(&dir_ext).unwrap();
+        std::fs::write(dir_ext.join("index.ts"), "// ext\n").unwrap();
+
+        // Disabled directory-form extension: only index.ts.disabled inside.
+        let dir_off = ext_dir.join("orca-dock");
+        std::fs::create_dir_all(&dir_off).unwrap();
+        std::fs::write(dir_off.join("index.ts.disabled"), "// ext\n").unwrap();
+
         let plugins = adapter.read_plugins();
-        assert_eq!(plugins.len(), 2);
+        assert_eq!(plugins.len(), 4);
         let by_name: std::collections::HashMap<&str, &PluginEntry> =
             plugins.iter().map(|p| (p.name.as_str(), p)).collect();
         assert!(by_name.contains_key("orca-status"));
         assert!(by_name["orca-status"].enabled);
         assert!(by_name.contains_key("orca-spin"));
         assert!(!by_name["orca-spin"].enabled);
+
+        // Directory-form entries are named after the directory; the path points
+        // at the index file so HK's rename toggle keeps the name stable.
+        let panel = by_name["orca-panel"];
+        assert!(panel.enabled);
+        assert_eq!(panel.path, Some(dir_ext.join("index.ts")));
+        assert!(!by_name["orca-dock"].enabled);
     }
 
     #[test]

--- a/crates/hk-core/src/adapter/omp.rs
+++ b/crates/hk-core/src/adapter/omp.rs
@@ -300,9 +300,15 @@ impl AgentAdapter for OmpAdapter {
 
     fn global_settings_files(&self) -> Vec<PathBuf> {
         // config.yml is the primary (post-YAML-migration) global settings file.
-        // settings.json is the legacy form, kept until migration runs.
+        // settings.json is the legacy form, kept until migration runs. mcp.json
+        // is listed so the servers file is browsable from the agent page
+        // (matches the kiro adapter).
         let agent = self.agent_dir();
-        vec![agent.join("config.yml"), agent.join("settings.json")]
+        vec![
+            agent.join("config.yml"),
+            agent.join("settings.json"),
+            self.mcp_config_path(),
+        ]
     }
 
     fn global_workflow_files(&self) -> Vec<PathBuf> {
@@ -311,10 +317,9 @@ impl AgentAdapter for OmpAdapter {
     }
 
     fn project_markers(&self) -> Vec<ProjectMarker> {
-        vec![
-            ProjectMarker::Dir(".omp"),
-            ProjectMarker::File(".omp/mcp.json"),
-        ]
+        // Dir(".omp") alone suffices: every project-level omp file lives inside
+        // .omp/, so any narrower marker would be redundant.
+        vec![ProjectMarker::Dir(".omp")]
     }
 
     fn project_rules_patterns(&self) -> Vec<String> {

--- a/crates/hk-core/src/adapter/omp.rs
+++ b/crates/hk-core/src/adapter/omp.rs
@@ -85,6 +85,22 @@ impl OmpAdapter {
             Some("ts" | "js")
         )
     }
+
+    /// Read a string-array field (e.g. `disabledServers`) from the *user*
+    /// mcp.json. Both the denylist and the force-enable allowlist live only in
+    /// the user file but apply to servers from every source, including project
+    /// configs (mcp/config.ts in the omp source).
+    fn user_mcp_name_list(&self, key: &str) -> std::collections::HashSet<String> {
+        Self::parse_json(&self.mcp_config_path())
+            .and_then(|cfg| {
+                cfg.get(key).and_then(|v| v.as_array()).map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+            })
+            .unwrap_or_default()
+    }
 }
 
 impl AgentAdapter for OmpAdapter {
@@ -147,6 +163,13 @@ impl AgentAdapter for OmpAdapter {
         let Some(servers) = config.get("mcpServers").and_then(|v| v.as_object()) else {
             return vec![];
         };
+        // omp's effective-enabled state is decided by three inputs
+        // (mcp/config.ts): the user-level `disabledServers` denylist always
+        // wins; the per-entry `enabled` flag (default true) is next; the
+        // user-level `enabledServers` allowlist can force a server back on
+        // over `enabled: false` — but never over the denylist.
+        let denylist = self.user_mcp_name_list("disabledServers");
+        let allowlist = self.user_mcp_name_list("enabledServers");
         servers
             .iter()
             .map(|(name, val)| McpServerEntry {
@@ -178,14 +201,15 @@ impl AgentAdapter for OmpAdapter {
                             .collect()
                     })
                     .unwrap_or_default(),
-                // omp carries a native per-server `enabled` flag (default true).
-                // Reported here so the scanner reflects on-disk state; HK's
-                // default toggle (remove+snapshot) is used since omp's writer
-                // path isn't wired into supports_native_mcp_toggle().
-                enabled: val
-                    .get("enabled")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(true),
+                // Reported so the scanner reflects effective on-disk state.
+                // HK's default toggle (remove+snapshot) is used since omp's
+                // denylist writer isn't wired into supports_native_mcp_toggle().
+                enabled: !denylist.contains(name)
+                    && (val
+                        .get("enabled")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true)
+                        || allowlist.contains(name)),
             })
             .collect()
     }
@@ -321,14 +345,23 @@ mod tests {
                 "disabled-one": {
                   "command": "echo",
                   "enabled": false
+                },
+                "denylisted": {
+                  "command": "echo"
+                },
+                "force-enabled": {
+                  "command": "echo",
+                  "enabled": false
                 }
-              }
+              },
+              "disabledServers": ["denylisted"],
+              "enabledServers": ["force-enabled"]
             }"#,
         )
         .unwrap();
 
         let servers = adapter.read_mcp_servers();
-        assert_eq!(servers.len(), 3);
+        assert_eq!(servers.len(), 5);
 
         let by_name: std::collections::HashMap<&str, &McpServerEntry> =
             servers.iter().map(|s| (s.name.as_str(), s)).collect();
@@ -347,6 +380,41 @@ mod tests {
         let off = by_name["disabled-one"];
         assert_eq!(off.command, "echo");
         assert!(!off.enabled);
+
+        // The user-level `disabledServers` denylist always wins, even over an
+        // entry with no `enabled: false` of its own.
+        assert!(!by_name["denylisted"].enabled);
+
+        // The `enabledServers` allowlist forces a server back on over its own
+        // `enabled: false` (but never over the denylist).
+        assert!(by_name["force-enabled"].enabled);
+    }
+
+    #[test]
+    fn user_denylist_applies_to_project_servers() {
+        // Both name lists live in the *user* mcp.json but gate servers from
+        // every source, including project configs (mcp/config.ts).
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = OmpAdapter::with_home(tmp.path().to_path_buf());
+        let user_cfg = tmp.path().join(".omp/agent/mcp.json");
+        std::fs::create_dir_all(user_cfg.parent().unwrap()).unwrap();
+        std::fs::write(
+            &user_cfg,
+            r#"{ "mcpServers": {}, "disabledServers": ["project-server"] }"#,
+        )
+        .unwrap();
+
+        let project_cfg = tmp.path().join("repo/.omp/mcp.json");
+        std::fs::create_dir_all(project_cfg.parent().unwrap()).unwrap();
+        std::fs::write(
+            &project_cfg,
+            r#"{ "mcpServers": { "project-server": { "command": "echo" } } }"#,
+        )
+        .unwrap();
+
+        let servers = adapter.read_mcp_servers_from(&project_cfg);
+        assert_eq!(servers.len(), 1);
+        assert!(!servers[0].enabled);
     }
 
     #[test]

--- a/crates/hk-core/src/adapter/omp.rs
+++ b/crates/hk-core/src/adapter/omp.rs
@@ -152,6 +152,15 @@ impl AgentAdapter for OmpAdapter {
         McpFormat::McpServers
     }
 
+    fn supports_native_mcp_toggle(&self) -> bool {
+        // Toggle flips the entry's own `enabled` flag in place (see
+        // deployer::set_omp_mcp_enabled) — no remove+snapshot, so secrets and
+        // extra keys (`type`, `url`, `headers`) are never touched. The
+        // user-level disabledServers/enabledServers lists are scrubbed so the
+        // flag actually takes effect.
+        true
+    }
+
     fn read_mcp_servers(&self) -> Vec<McpServerEntry> {
         self.read_mcp_servers_from(&self.mcp_config_path())
     }
@@ -201,9 +210,9 @@ impl AgentAdapter for OmpAdapter {
                             .collect()
                     })
                     .unwrap_or_default(),
-                // Reported so the scanner reflects effective on-disk state.
-                // HK's default toggle (remove+snapshot) is used since omp's
-                // denylist writer isn't wired into supports_native_mcp_toggle().
+                // Reported so the scanner reflects effective on-disk state;
+                // the toggle writes the same inputs back in place
+                // (deployer::set_omp_mcp_enabled).
                 enabled: !denylist.contains(name)
                     && (val
                         .get("enabled")

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -453,6 +453,55 @@ pub fn set_kiro_mcp_enabled(
     })
 }
 
+/// Flip an omp MCP server's native per-entry `enabled` flag in place, then
+/// scrub the user-level name list that would override the flag: on disable
+/// the name is removed from `enabledServers` (the force-enable allowlist
+/// overrides `enabled: false`), on enable from `disabledServers` (the
+/// denylist overrides everything). Both lists live only in the *user*
+/// mcp.json but gate servers from every source (omp mcp/config.ts), so
+/// `user_config_path` differs from `entry_config_path` for project-scoped
+/// servers.
+///
+/// The entry flag — not the denylist — carries the toggle so it stays scoped
+/// to this one entry: `disabledServers` matches by NAME across all sources
+/// and would knock out same-named servers in other projects.
+pub fn set_omp_mcp_enabled(
+    entry_config_path: &Path,
+    user_config_path: &Path,
+    server_name: &str,
+    enabled: bool,
+) -> Result<(), HkError> {
+    locked_modify_json(entry_config_path, |config| {
+        let servers = config
+            .get_mut("mcpServers")
+            .and_then(|v| v.as_object_mut())
+            .ok_or_else(|| HkError::NotFound("No mcpServers block found".into()))?;
+        let server = servers
+            .get_mut(server_name)
+            .and_then(|v| v.as_object_mut())
+            .ok_or_else(|| HkError::NotFound(format!("MCP server '{server_name}' not found")))?;
+        if enabled {
+            // Absent means enabled (mcp-config.md: "skip when false").
+            server.remove("enabled");
+        } else {
+            server.insert("enabled".into(), serde_json::Value::Bool(false));
+        }
+        Ok(())
+    })?;
+    // A missing user file can't contain the name — don't create one just to
+    // scrub it.
+    if !user_config_path.exists() {
+        return Ok(());
+    }
+    let list_key = if enabled { "disabledServers" } else { "enabledServers" };
+    locked_modify_json(user_config_path, |config| {
+        if let Some(list) = config.get_mut(list_key).and_then(|v| v.as_array_mut()) {
+            list.retain(|v| v.as_str() != Some(server_name));
+        }
+        Ok(())
+    })
+}
+
 /// Flip a Kiro IDE hook's native `enabled` flag in place, keeping the entry
 /// in the file — mirrors Kiro's own panel toggle ("skip without deleting").
 pub fn set_kiro_hook_enabled(
@@ -2905,6 +2954,79 @@ mod tests {
         let enabled: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
         assert!(enabled["mcpServers"]["github"].get("disabled").is_none());
+    }
+
+    #[test]
+    fn test_set_omp_mcp_enabled_flips_flag_and_scrubs_lists() {
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("mcp.json");
+        // Entry currently force-enabled via the allowlist; a stale denylist
+        // entry for another server must survive untouched.
+        std::fs::write(
+            &config,
+            r#"{
+              "mcpServers": {"github": {"type": "http", "url": "https://example.com/mcp", "enabled": false}},
+              "enabledServers": ["github"],
+              "disabledServers": ["other"]
+            }"#,
+        )
+        .unwrap();
+
+        // Disable: entry flag set, name scrubbed from the allowlist (which
+        // would otherwise override enabled:false), entry keys preserved.
+        set_omp_mcp_enabled(&config, &config, "github", false).unwrap();
+        let disabled: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+        assert_eq!(disabled["mcpServers"]["github"]["enabled"], false);
+        assert_eq!(disabled["mcpServers"]["github"]["type"], "http");
+        assert_eq!(disabled["mcpServers"]["github"]["url"], "https://example.com/mcp");
+        assert!(disabled["enabledServers"].as_array().unwrap().is_empty());
+        assert_eq!(disabled["disabledServers"][0], "other");
+
+        // Enable: flag removed (absent means enabled).
+        set_omp_mcp_enabled(&config, &config, "github", true).unwrap();
+        let enabled: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+        assert!(enabled["mcpServers"]["github"].get("enabled").is_none());
+        assert_eq!(enabled["mcpServers"]["github"]["url"], "https://example.com/mcp");
+    }
+
+    #[test]
+    fn test_set_omp_mcp_enabled_project_entry_scrubs_user_denylist() {
+        let dir = TempDir::new().unwrap();
+        // Project entry file and user file are distinct for project scope.
+        let project = dir.path().join("project-mcp.json");
+        let user = dir.path().join("user-mcp.json");
+        std::fs::write(
+            &project,
+            r#"{"mcpServers": {"srv": {"command": "echo", "enabled": false}}}"#,
+        )
+        .unwrap();
+        std::fs::write(&user, r#"{"mcpServers": {}, "disabledServers": ["srv"]}"#).unwrap();
+
+        set_omp_mcp_enabled(&project, &user, "srv", true).unwrap();
+        let p: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&project).unwrap()).unwrap();
+        let u: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&user).unwrap()).unwrap();
+        assert!(p["mcpServers"]["srv"].get("enabled").is_none());
+        // Denylist would override the entry flag — must be scrubbed.
+        assert!(u["disabledServers"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_set_omp_mcp_enabled_missing_user_file_ok() {
+        let dir = TempDir::new().unwrap();
+        let project = dir.path().join("project-mcp.json");
+        std::fs::write(&project, r#"{"mcpServers": {"srv": {"command": "echo"}}}"#).unwrap();
+        let user = dir.path().join("does-not-exist.json");
+
+        set_omp_mcp_enabled(&project, &user, "srv", false).unwrap();
+        let p: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&project).unwrap()).unwrap();
+        assert_eq!(p["mcpServers"]["srv"]["enabled"], false);
+        // No user file must not be created just to scrub a list.
+        assert!(!user.exists());
     }
 
     #[test]

--- a/crates/hk-core/src/manager.rs
+++ b/crates/hk-core/src/manager.rs
@@ -190,6 +190,16 @@ fn toggle_mcp(
         if a.supports_native_mcp_toggle() {
             if a.name() == "kiro" {
                 deployer::set_kiro_mcp_enabled(&config_path, &ext.name, enabled)?;
+            } else if a.name() == "omp" {
+                // Entry flag flips in the scope's own file; the user-level
+                // disabledServers/enabledServers lists that would override it
+                // are scrubbed in the user mcp.json.
+                deployer::set_omp_mcp_enabled(
+                    &config_path,
+                    &a.mcp_config_path(),
+                    &ext.name,
+                    enabled,
+                )?;
             } else {
                 deployer::set_hermes_mcp_enabled(&config_path, &ext.name, enabled)?;
             }

--- a/crates/hk-core/src/manager.rs
+++ b/crates/hk-core/src/manager.rs
@@ -580,7 +580,10 @@ fn find_disabled_plugin_path(adapter: &dyn adapter::AgentAdapter, ext_id: &str) 
                     if !file_name.ends_with(".disabled") {
                         continue;
                     }
-                    let source = if adapter.name() == "opencode" {
+                    // opencode and omp report single-file plugins with
+                    // source "local" (see their read_plugins), so the ID must
+                    // be rebuilt with that label, not the directory name.
+                    let source = if matches!(adapter.name(), "opencode" | "omp") {
                         "local".to_string()
                     } else {
                         plugin_dir
@@ -593,6 +596,22 @@ fn find_disabled_plugin_path(adapter: &dyn adapter::AgentAdapter, ext_id: &str) 
                         return Some(path);
                     }
                     continue;
+                }
+                // Directory-form single-entry plugins (omp: <name>/index.{ts,js})
+                // — the disabled marker is the renamed index file inside the
+                // directory, and the plugin is named after the directory.
+                if adapter.name() == "omp" {
+                    for index_name in ["index.ts.disabled", "index.js.disabled"] {
+                        let disabled = entry.path().join(index_name);
+                        if !disabled.exists() {
+                            continue;
+                        }
+                        let dir_name = entry.file_name().to_string_lossy().to_string();
+                        let id_name = format!("{dir_name}:local");
+                        if scanner::stable_id_for(&id_name, "plugin", adapter.name()) == ext_id {
+                            return Some(disabled);
+                        }
+                    }
                 }
                 // Check known manifest locations with .disabled suffix
                 for manifest_name in &[
@@ -2576,6 +2595,58 @@ mod tests {
         assert!(r.is_ok(), "re-enable failed: {:?}", r.err());
         assert!(plugin_path.exists());
         assert!(!plugins_dir.join("lint.ts.disabled").exists());
+    }
+
+    /// Regression: re-enabling an EXTERNALLY-disabled omp extension (renamed on
+    /// disk, no DB snapshot) must go through the find_disabled_plugin_path
+    /// fallback, which rebuilds the ID with source "local" — not the plugin
+    /// directory name.
+    #[test]
+    fn test_omp_file_plugin_reenable_via_fallback() {
+        let dir = TempDir::new().unwrap();
+        let store = crate::store::Store::open(&dir.path().join("test.db")).unwrap();
+        let ext_dir = dir.path().join(".omp/agent/extensions");
+        std::fs::create_dir_all(&ext_dir).unwrap();
+        // Externally disabled: .disabled file on disk, no disabled_config saved.
+        std::fs::write(ext_dir.join("orca-spin.ts.disabled"), "export default {};").unwrap();
+
+        let adapter = crate::adapter::omp::OmpAdapter::with_home(dir.path().to_path_buf());
+        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![Box::new(adapter)];
+
+        let scanned = scanner::scan_plugins(&*adapters[0]);
+        assert_eq!(scanned.len(), 1);
+        assert!(!scanned[0].enabled);
+        store.sync_extensions(&scanned).unwrap();
+
+        let r = toggle_extension_with_adapters(&store, &adapters, &scanned[0].id, true);
+        assert!(r.is_ok(), "re-enable failed: {:?}", r.err());
+        assert!(ext_dir.join("orca-spin.ts").exists());
+        assert!(!ext_dir.join("orca-spin.ts.disabled").exists());
+    }
+
+    /// Same fallback path for a directory-form omp extension: the disabled
+    /// marker is <name>/index.ts.disabled inside the directory and the plugin
+    /// is named after the directory.
+    #[test]
+    fn test_omp_dir_plugin_reenable_via_fallback() {
+        let dir = TempDir::new().unwrap();
+        let store = crate::store::Store::open(&dir.path().join("test.db")).unwrap();
+        let ext_dir = dir.path().join(".omp/agent/extensions/orca-panel");
+        std::fs::create_dir_all(&ext_dir).unwrap();
+        std::fs::write(ext_dir.join("index.ts.disabled"), "export default {};").unwrap();
+
+        let adapter = crate::adapter::omp::OmpAdapter::with_home(dir.path().to_path_buf());
+        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![Box::new(adapter)];
+
+        let scanned = scanner::scan_plugins(&*adapters[0]);
+        assert_eq!(scanned.len(), 1);
+        assert!(!scanned[0].enabled);
+        store.sync_extensions(&scanned).unwrap();
+
+        let r = toggle_extension_with_adapters(&store, &adapters, &scanned[0].id, true);
+        assert!(r.is_ok(), "re-enable failed: {:?}", r.err());
+        assert!(ext_dir.join("index.ts").exists());
+        assert!(!ext_dir.join("index.ts.disabled").exists());
     }
 
     /// Regression: a global skill and a project skill that happen to share a

--- a/src/components/extensions/extension-filters.tsx
+++ b/src/components/extensions/extension-filters.tsx
@@ -44,6 +44,7 @@ const AGENT_FILTER_COLORS: Record<string, string> = {
   opencode: "bg-agent-opencode/10 text-agent-opencode border-agent-opencode/30",
   hermes: "bg-agent-hermes/10 text-agent-hermes border-agent-hermes/30",
   kiro: "bg-agent-kiro/10 text-agent-kiro border-agent-kiro/30",
+  omp: "bg-agent-omp/10 text-agent-omp border-agent-omp/30",
 };
 
 export function ExtensionFilters() {

--- a/src/components/onboarding/onboarding.tsx
+++ b/src/components/onboarding/onboarding.tsx
@@ -265,6 +265,7 @@ const FLOAT_DELAYS: Record<(typeof AGENT_ORDER)[number], number> = {
   opencode: 0.8,
   hermes: 1.9,
   kiro: 1.4,
+  omp: 1.0,
 };
 const SCATTER_POSITIONS: Record<
   (typeof AGENT_ORDER)[number],
@@ -280,6 +281,7 @@ const SCATTER_POSITIONS: Record<
   opencode: { x: 210, y: -10, r: 8 },
   hermes: { x: -60, y: -115, r: 18 },
   kiro: { x: 40, y: -126, r: -10 },
+  omp: { x: -200, y: 60, r: 22 },
 };
 
 function HandAnnotation({

--- a/src/components/shared/agent-card.tsx
+++ b/src/components/shared/agent-card.tsx
@@ -12,6 +12,7 @@ const CLICK_DURATIONS: Partial<Record<AgentInfo["name"], number>> = {
   opencode: 4000,
   antigravity: 800,
   kiro: 1100,
+  omp: 900,
 };
 
 export function AgentCard({ agent }: AgentCardProps) {

--- a/src/components/shared/agent-mascot/agent-mascot.tsx
+++ b/src/components/shared/agent-mascot/agent-mascot.tsx
@@ -8,6 +8,7 @@ import { FallbackMascot } from "./fallback-mascot";
 import { GeminiMascot } from "./gemini-mascot";
 import { HermesMascot } from "./hermes-mascot";
 import { KiroMascot } from "./kiro-mascot";
+import { OmpMascot } from "./omp-mascot";
 import { OpencodeMascot } from "./opencode-mascot";
 import { WindsurfMascot } from "./windsurf-mascot";
 
@@ -69,6 +70,11 @@ const MASCOT_MAP: Record<
     className: "mascot-kiro",
     scale: 1.12,
     offsetY: 1,
+  },
+  omp: {
+    component: OmpMascot,
+    className: "mascot-omp",
+    scale: 0.95,
   },
 };
 

--- a/src/components/shared/agent-mascot/mascot.css
+++ b/src/components/shared/agent-mascot/mascot.css
@@ -1611,6 +1611,7 @@
   .mascot-opencode.is-animated *,
   .mascot-hermes.is-animated *,
   .mascot-kiro.is-animated *,
+  .mascot-omp.is-animated,
   .mascot-omp.is-animated *,
   .mascot-fallback.is-animated *,
   .mascot-claude.is-clicked,

--- a/src/components/shared/agent-mascot/mascot.css
+++ b/src/components/shared/agent-mascot/mascot.css
@@ -1283,6 +1283,51 @@
   100% { opacity: 0; transform: translate(0,    0)    rotate(0deg);   }
 }
 
+/* === omp (Oh My Pi) ===
+   The icon is the π symbol on a dark tile with a pink→purple→cyan gradient
+   (omp.sh/favicon.svg). Hover: gentle float + gradient hue cycle. Click:
+   glow burst from the tile + scale pulse on the π. */
+
+/* Hover: float the whole tile + cycle the gradient's hue */
+.mascot-omp.is-animated {
+  animation: omp-float 2.2s ease-in-out infinite;
+}
+.mascot-omp.is-animated .omp-pi {
+  animation: omp-hue 3s linear infinite;
+}
+
+/* Click: glow burst from the tile, π scales briefly */
+.mascot-omp.is-clicked .omp-bg {
+  animation: omp-glow 0.9s ease-out;
+}
+.mascot-omp.is-clicked .omp-pi {
+  animation: omp-pulse 0.9s cubic-bezier(0.25, 0.75, 0.25, 1);
+  transform-origin: 32px 32px;
+}
+
+@keyframes omp-float {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-4px); }
+}
+
+@keyframes omp-hue {
+  0%   { filter: hue-rotate(0deg); }
+  100% { filter: hue-rotate(360deg); }
+}
+
+@keyframes omp-glow {
+  0%   { filter: drop-shadow(0 0 0 transparent); }
+  30%  { filter: drop-shadow(0 0 12px rgba(155, 77, 255, 0.8)); }
+  100% { filter: drop-shadow(0 0 0 transparent); }
+}
+
+@keyframes omp-pulse {
+  0%   { transform: scale(1);    opacity: 1; }
+  30%  { transform: scale(1.15); opacity: 1; }
+  60%  { transform: scale(0.95); opacity: 0.9; }
+  100% { transform: scale(1);    opacity: 1; }
+}
+
 /* === Hermes ===
    The icon is a classical left-facing profile — a coin/cameo head. So the
    motion leans into that: hover catches a glint of light across the profile
@@ -1566,6 +1611,7 @@
   .mascot-opencode.is-animated *,
   .mascot-hermes.is-animated *,
   .mascot-kiro.is-animated *,
+  .mascot-omp.is-animated *,
   .mascot-fallback.is-animated *,
   .mascot-claude.is-clicked,
   .mascot-claude.is-clicked *,
@@ -1585,6 +1631,8 @@
   .mascot-hermes.is-clicked *,
   .mascot-kiro.is-clicked,
   .mascot-kiro.is-clicked *,
+  .mascot-omp.is-clicked,
+  .mascot-omp.is-clicked *,
   .mascot-fallback.is-clicked * {
     animation: none;
     transition: none;

--- a/src/components/shared/agent-mascot/omp-mascot.tsx
+++ b/src/components/shared/agent-mascot/omp-mascot.tsx
@@ -1,0 +1,37 @@
+// omp (Oh My Pi) mascot — the π symbol from omp.sh/favicon.svg, with a
+// pink→purple→cyan gradient on a dark rounded tile.
+// Hover: gentle float + hue cycle on the gradient.
+// Click: glow burst + scale pulse.
+// Source path: https://omp.sh/favicon.svg (viewBox 0 0 64 64)
+
+interface MascotSvgProps {
+  size: number;
+}
+
+export function OmpMascot({ size }: MascotSvgProps) {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      style={{ overflow: "visible" }}
+    >
+      <defs>
+        <linearGradient id="omp-grad" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="#ed4abf" />
+          <stop offset=".5" stopColor="#9b4dff" />
+          <stop offset="1" stopColor="#5ad8e6" />
+        </linearGradient>
+      </defs>
+      {/* Dark rounded background tile */}
+      <rect className="omp-bg" width="64" height="64" rx="12" fill="#0f0a14" />
+      {/* π symbol */}
+      <path
+        className="omp-pi"
+        fill="url(#omp-grad)"
+        d="M14 16h36v8H40v32h-8V24h-6v22h-8V24h-4z"
+      />
+    </svg>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -98,6 +98,7 @@
   --agent-opencode: oklch(0.52 0.07 250);
   --agent-hermes: oklch(0.64 0.13 90);
   --agent-kiro: oklch(0.58 0.15 305);
+  --agent-omp: oklch(0.58 0.13 160);
   --toast-success-bg: oklch(0.94 0.06 155);
   --toast-success-border: oklch(0.72 0.16 155);
   --toast-success-text: oklch(0.4 0.1 155);
@@ -202,6 +203,7 @@
   --agent-opencode: oklch(0.76 0.06 250);
   --agent-hermes: oklch(0.83 0.15 90);
   --agent-kiro: oklch(0.78 0.13 305);
+  --agent-omp: oklch(0.78 0.11 160);
   --toast-success-bg: oklch(0.23 0.04 155);
   --toast-success-border: oklch(0.55 0.14 155);
   --toast-success-text: oklch(0.78 0.12 155);
@@ -300,6 +302,7 @@
   --agent-opencode: oklch(0.52 0.07 250);
   --agent-hermes: oklch(0.64 0.13 90);
   --agent-kiro: oklch(0.58 0.15 305);
+  --agent-omp: oklch(0.58 0.13 160);
   --toast-success-bg: oklch(0.94 0.06 155);
   --toast-success-border: oklch(0.65 0.15 155);
   --toast-success-text: oklch(0.4 0.1 155);
@@ -392,6 +395,7 @@
   --agent-opencode: oklch(0.76 0.06 250);
   --agent-hermes: oklch(0.83 0.15 90);
   --agent-kiro: oklch(0.78 0.13 305);
+  --agent-omp: oklch(0.78 0.11 160);
   --toast-success-bg: oklch(0.26 0.04 155);
   --toast-success-border: oklch(0.55 0.14 155);
   --toast-success-text: oklch(0.78 0.12 155);
@@ -496,6 +500,7 @@
   --agent-opencode: oklch(0.52 0.07 250);
   --agent-hermes: oklch(0.64 0.13 90);
   --agent-kiro: oklch(0.58 0.15 305);
+  --agent-omp: oklch(0.58 0.13 160);
   --toast-success-bg: oklch(0.94 0.06 155);
   --toast-success-border: oklch(0.72 0.16 155);
   --toast-success-text: oklch(0.4 0.1 155);
@@ -594,6 +599,7 @@
   --agent-opencode: oklch(0.76 0.06 250);
   --agent-hermes: oklch(0.83 0.15 90);
   --agent-kiro: oklch(0.78 0.13 305);
+  --agent-omp: oklch(0.78 0.11 160);
   --toast-success-bg: oklch(0.23 0.04 155);
   --toast-success-border: oklch(0.55 0.14 155);
   --toast-success-text: oklch(0.78 0.12 155);
@@ -670,6 +676,7 @@ html.dark[data-theme="tiesen"][data-web="true"] {
   --color-agent-opencode: var(--agent-opencode);
   --color-agent-hermes: var(--agent-hermes);
   --color-agent-kiro: var(--agent-kiro);
+  --color-agent-omp: var(--agent-omp);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -340,6 +340,7 @@ describe("agentDisplayName", () => {
     expect(agentDisplayName("windsurf")).toBe("Windsurf");
     expect(agentDisplayName("opencode")).toBe("OpenCode");
     expect(agentDisplayName("kiro")).toBe("Kiro");
+    expect(agentDisplayName("omp")).toBe("Oh My Pi");
   });
 
   it("capitalizes first letter for unknown agents", () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -408,6 +408,7 @@ export const AGENT_ORDER = [
   "opencode",
   "hermes",
   "kiro",
+  "omp",
 ] as const;
 
 /** Sort an array of agents (or agent-like objects with a `name` field) by a given order. */
@@ -433,6 +434,7 @@ const AGENT_DISPLAY_NAMES: Record<string, string> = {
   opencode: "OpenCode",
   hermes: "Hermes",
   kiro: "Kiro",
+  omp: "Oh My Pi",
 };
 
 /** Get the display name for an agent (e.g. "claude" → "Claude Code"). */


### PR DESCRIPTION
## Summary

Adds Oh My Pi (`omp`) as the 11th supported agent in HarnessKit.

### Backend
- New `OmpAdapter` for `~/.omp` / `~/.omp/agent` layout.
- Discovers user/project skills:
  - `~/.omp/agent/skills/<name>/SKILL.md`
  - `.omp/skills/<name>/SKILL.md`
- Discovers MCP config:
  - `~/.omp/agent/mcp.json`
  - `.omp/mcp.json`
  - JSON `mcpServers` format, including stdio `command`, remote `url`, `args`, `env`, and native `enabled` flag.
- Discovers TypeScript/JavaScript extension modules as plugins:
  - `~/.omp/agent/extensions/*.{ts,js,mjs,cjs}`
  - `.omp/extensions/`
- Discovers native config/rules:
  - `AGENTS.md`, `RULES.md`, `config.yml`, `settings.json`.
- Declares `HookFormat::None` because omp hooks are JS/TS event modules, not shell-command hook configs (same model as OpenCode).

### Frontend
- Adds `omp` to `AGENT_ORDER` and display names.
- Adds theme color variables and extension filter colors.
- Adds an Oh My Pi mascot using the official `omp.sh/favicon.svg` π logo (pink→purple→cyan gradient).
- Updates onboarding layout for the new agent.

### Docs
- Updates English and Chinese README agent count and capability matrix.

## Verification

- `cargo check -p hk-core` ✅
- `cargo test -p hk-core` ✅ — 557 tests passed
- `npx tsc --noEmit` ✅
- `npx vitest run src/lib/__tests__/types.test.ts src/stores/__tests__/extension-helpers.test.ts` ✅ — 76 tests passed
- Manual smoke test against a real `~/.omp` install ✅
  - detected `omp`
  - read `~/.omp/agent/config.yml`
  - discovered 3 real extension modules: `orca-agent-status`, `orca-prefill`, `orca-titlebar-spinner`

## Screenshots

### Overview — Oh My Pi detected
![Overview with Oh My Pi](https://raw.githubusercontent.com/FelipeMayerDev/HarnessKit/pr-assets/omp-support-screenshots/pr-assets/omp-support/overview-omp.png)

### Agent details — Oh My Pi
![Oh My Pi agent details](https://raw.githubusercontent.com/FelipeMayerDev/HarnessKit/pr-assets/omp-support-screenshots/pr-assets/omp-support/omp-agent-detail.png)

### Extensions filtered by Oh My Pi
![Extensions filtered by Oh My Pi](https://raw.githubusercontent.com/FelipeMayerDev/HarnessKit/pr-assets/omp-support-screenshots/pr-assets/omp-support/omp-extensions-filtered.png)

### Oh My Pi mascot card crop
![Oh My Pi mascot card](https://raw.githubusercontent.com/FelipeMayerDev/HarnessKit/pr-assets/omp-support-screenshots/pr-assets/omp-support/omp-card.png)
