### PR TITLE
fix(mcp): support remote MCP transports (Streamable HTTP / SSE) end to end

### DIFF
--- a/crates/hk-core/src/adapter/antigravity.rs
+++ b/crates/hk-core/src/adapter/antigravity.rs
@@ -10,7 +10,9 @@
 //                               brain/, knowledge/, conversations/) — the path Google's
 //                               docs and codelabs actually reference. Used as base_dir.
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker};
+use super::{
+    AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker, RemoteMcpSchema,
+};
 use std::path::{Path, PathBuf};
 
 pub struct AntigravityAdapter {
@@ -152,35 +154,32 @@ impl AgentAdapter for AntigravityAdapter {
         };
         servers
             .iter()
-            .map(|(name, val)| McpServerEntry {
-                name: name.clone(),
-                command: val
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .into(),
-                args: val
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                env: val
-                    .get("env")
-                    .and_then(|v| v.as_object())
-                    .map(|obj| {
-                        obj.iter()
-                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                // Antigravity's MCP schema has no agent-native disable concept.
-                enabled: true,
+            .map(|(name, val)| {
+                // Remote entries: {serverUrl, headers}. Official docs only
+                // show Streamable HTTP examples; SSE support is unverified
+                // upstream, so treat serverUrl as HTTP.
+                let (transport, url) = super::parse_plain_url(val, "serverUrl");
+                McpServerEntry {
+                    name: name.clone(),
+                    command: val
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .into(),
+                    args: super::json_string_vec(val, "args"),
+                    env: super::json_string_map(val, "env"),
+                    transport,
+                    url,
+                    headers: super::json_string_map(val, "headers"),
+                    // Antigravity's MCP schema has no agent-native disable concept.
+                    enabled: true,
+                }
             })
             .collect()
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::ServerUrl
     }
 
     fn read_hooks(&self) -> Vec<HookEntry> {
@@ -190,8 +189,31 @@ impl AgentAdapter for AntigravityAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::super::AgentAdapter;
+    use super::super::{AgentAdapter, McpTransport};
     use super::*;
+
+    #[test]
+    fn read_mcp_servers_parses_server_url_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("mcp_config.json");
+        std::fs::write(
+            &config,
+            r#"{"mcpServers":{
+                "remote":{"serverUrl":"https://example.com/mcp","headers":{"Authorization":"Bearer t"}},
+                "fs":{"command":"npx","args":["-y","srv"]}
+            }}"#,
+        )
+        .unwrap();
+        let adapter = AntigravityAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers_from(&config);
+        let remote = servers.iter().find(|s| s.name == "remote").unwrap();
+        assert_eq!(remote.transport, McpTransport::Http);
+        assert_eq!(remote.url.as_deref(), Some("https://example.com/mcp"));
+        assert_eq!(remote.command, "");
+        assert_eq!(remote.headers["Authorization"], "Bearer t");
+        let fs = servers.iter().find(|s| s.name == "fs").unwrap();
+        assert_eq!(fs.transport, McpTransport::Stdio);
+    }
 
     #[test]
     fn read_hooks_returns_empty() {

--- a/crates/hk-core/src/adapter/claude.rs
+++ b/crates/hk-core/src/adapter/claude.rs
@@ -7,7 +7,7 @@
 //   https://code.claude.com/docs/en/plugins
 // Plugins: ~/.claude/plugins/, registry at installed_plugins.json, manifest at .claude-plugin/plugin.json
 
-use super::{AgentAdapter, HookEntry, McpServerEntry, PluginEntry, ProjectMarker};
+use super::{AgentAdapter, HookEntry, McpServerEntry, PluginEntry, ProjectMarker, RemoteMcpSchema};
 use std::path::{Path, PathBuf};
 
 pub struct ClaudeAdapter {
@@ -115,35 +115,30 @@ impl AgentAdapter for ClaudeAdapter {
 
         servers
             .iter()
-            .map(|(name, val)| McpServerEntry {
-                name: name.clone(),
-                command: val
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .into(),
-                args: val
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                env: val
-                    .get("env")
-                    .and_then(|v| v.as_object())
-                    .map(|obj| {
-                        obj.iter()
-                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                // Claude's MCP schema has no agent-native disable concept.
-                enabled: true,
+            .map(|(name, val)| {
+                // Remote entries: {type: "http"|"sse", url, headers} — no command key.
+                let (transport, url) = super::parse_type_url(val);
+                McpServerEntry {
+                    name: name.clone(),
+                    command: val
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .into(),
+                    args: super::json_string_vec(val, "args"),
+                    env: super::json_string_map(val, "env"),
+                    transport,
+                    url,
+                    headers: super::json_string_map(val, "headers"),
+                    // Claude's MCP schema has no agent-native disable concept.
+                    enabled: true,
+                }
             })
             .collect()
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::TypeAndUrl
     }
 
     fn translate_hook_event(&self, event: &str) -> Option<String> {
@@ -416,6 +411,50 @@ mod tests {
     fn test_claude_adapter_name() {
         let adapter = ClaudeAdapter::new();
         assert_eq!(adapter.name(), "claude");
+    }
+
+    #[test]
+    fn read_mcp_servers_parses_remote_transports() {
+        // Shapes written by `claude mcp add --transport http|sse` (issue #105).
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join(".claude.json");
+        std::fs::write(
+            &config,
+            r#"{"mcpServers":{
+                "linear":{"type":"http","url":"https://mcp.linear.app/mcp",
+                          "headers":{"Authorization":"Bearer tok"}},
+                "events":{"type":"sse","url":"https://example.com/sse"},
+                "spec-alias":{"type":"streamable-http","url":"https://example.com/mcp"},
+                "bare-url":{"url":"https://example.com/mcp"},
+                "fs":{"command":"npx","args":["-y","server-fs"]}
+            }}"#,
+        )
+        .unwrap();
+        let adapter = ClaudeAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers_from(&config);
+        let by_name: std::collections::HashMap<_, _> =
+            servers.iter().map(|s| (s.name.as_str(), s)).collect();
+
+        let linear = by_name["linear"];
+        assert_eq!(linear.transport, super::super::McpTransport::Http);
+        assert_eq!(linear.url.as_deref(), Some("https://mcp.linear.app/mcp"));
+        assert_eq!(linear.command, "", "remote entries must not fill command");
+        assert_eq!(linear.headers["Authorization"], "Bearer tok");
+
+        assert_eq!(by_name["events"].transport, super::super::McpTransport::Sse);
+        // `streamable-http` is the MCP spec's accepted alias for `http`.
+        assert_eq!(
+            by_name["spec-alias"].transport,
+            super::super::McpTransport::Http
+        );
+        // url without type tolerated as Streamable HTTP (laxer than Claude
+        // itself, which refuses to load such an entry — see parse_type_url).
+        assert_eq!(by_name["bare-url"].transport, super::super::McpTransport::Http);
+
+        let fs = by_name["fs"];
+        assert_eq!(fs.transport, super::super::McpTransport::Stdio);
+        assert_eq!(fs.command, "npx");
+        assert_eq!(fs.url, None);
     }
 
     #[test]

--- a/crates/hk-core/src/adapter/codex.rs
+++ b/crates/hk-core/src/adapter/codex.rs
@@ -5,7 +5,10 @@
 // Plugin reference: https://developers.openai.com/codex/plugins
 // Plugins: ~/.codex/plugins/cache/{marketplace}/{plugin}/{version}/, manifest at .codex-plugin/plugin.json
 
-use super::{AgentAdapter, HookEntry, McpFormat, McpServerEntry, PluginEntry, ProjectMarker};
+use super::{
+    AgentAdapter, HookEntry, McpFormat, McpServerEntry, McpTransport, PluginEntry, ProjectMarker,
+    RemoteMcpSchema,
+};
 use std::path::{Path, PathBuf};
 
 /// Codex's built-in fallback order for project doc files. Matches Codex's
@@ -18,6 +21,23 @@ const DEFAULT_DOC_FALLBACK_FILENAMES: &[&str] = &[
     "TEAM_GUIDE.md",
     ".agents.md",
 ];
+
+/// Parse a `key = { "A" = "B", ... }` TOML sub-table into a string map,
+/// dropping non-string values. Used for `env` and `http_headers` blocks.
+fn toml_string_map(
+    table: Option<&toml::Table>,
+    key: &str,
+) -> std::collections::HashMap<String, String> {
+    table
+        .and_then(|t| t.get(key))
+        .and_then(|v| v.as_table())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
 
 pub struct CodexAdapter {
     home: PathBuf,
@@ -229,6 +249,17 @@ impl AgentAdapter for CodexAdapter {
                     .and_then(|v| v.as_str())
                     .map(String::from)
                     .unwrap_or_else(|| name.clone());
+                // Remote entries: url = "..." (+ http_headers = {...}) —
+                // Codex speaks Streamable HTTP only, no SSE.
+                let url = table
+                    .and_then(|t| t.get("url"))
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                let transport = if url.is_some() {
+                    McpTransport::Http
+                } else {
+                    McpTransport::Stdio
+                };
                 McpServerEntry {
                     name: canonical_name,
                     command: table
@@ -245,20 +276,19 @@ impl AgentAdapter for CodexAdapter {
                                 .collect()
                         })
                         .unwrap_or_default(),
-                    env: table
-                        .and_then(|t| t.get("env"))
-                        .and_then(|v| v.as_table())
-                        .map(|obj| {
-                            obj.iter()
-                                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                                .collect()
-                        })
-                        .unwrap_or_default(),
+                    env: toml_string_map(table, "env"),
+                    transport,
+                    url,
+                    headers: toml_string_map(table, "http_headers"),
                     // Codex's TOML schema has no agent-native disable concept.
                     enabled: true,
                 }
             })
             .collect()
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::Toml
     }
 
     fn translate_hook_event(&self, event: &str) -> Option<String> {
@@ -419,6 +449,36 @@ mod tests {
     use super::super::AgentAdapter;
     use super::*;
     use std::fs;
+
+    #[test]
+    fn read_mcp_servers_parses_url_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("config.toml");
+        fs::write(
+            &config,
+            r#"
+[mcp_servers.figma]
+url = "https://mcp.figma.com/mcp"
+
+[mcp_servers.figma.http_headers]
+"X-Figma-Region" = "us-east-1"
+
+[mcp_servers.fs]
+command = "npx"
+args = ["-y", "srv"]
+"#,
+        )
+        .unwrap();
+        let adapter = CodexAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers_from(&config);
+        let figma = servers.iter().find(|s| s.name == "figma").unwrap();
+        assert_eq!(figma.transport, McpTransport::Http);
+        assert_eq!(figma.url.as_deref(), Some("https://mcp.figma.com/mcp"));
+        assert_eq!(figma.command, "");
+        assert_eq!(figma.headers["X-Figma-Region"], "us-east-1");
+        let fs_entry = servers.iter().find(|s| s.name == "fs").unwrap();
+        assert_eq!(fs_entry.transport, McpTransport::Stdio);
+    }
 
     /// Helper: create a plugin version directory with a manifest
     fn create_plugin_version(

--- a/crates/hk-core/src/adapter/copilot.rs
+++ b/crates/hk-core/src/adapter/copilot.rs
@@ -18,7 +18,10 @@
 // Format: {"hooks": {"PreToolUse": [{"type": "command", "command": "...", "timeout": 30}]}}
 // Events: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PreCompact, SubagentStart, SubagentStop, Stop
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry, ProjectMarker};
+use super::{
+    AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry, ProjectMarker,
+    RemoteMcpSchema,
+};
 use std::path::{Path, PathBuf};
 
 /// Read VS Code agent plugin enablement from state.vscdb.
@@ -320,35 +323,31 @@ impl AgentAdapter for CopilotAdapter {
         };
         servers
             .iter()
-            .map(|(name, val)| McpServerEntry {
-                name: name.clone(),
-                command: val
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .into(),
-                args: val
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                env: val
-                    .get("env")
-                    .and_then(|v| v.as_object())
-                    .map(|obj| {
-                        obj.iter()
-                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                // Copilot's MCP schema has no agent-native disable concept.
-                enabled: true,
+            .map(|(name, val)| {
+                // Remote entries: {type: "http"|"sse", url, headers} — VS Code
+                // mcp.json uses the same type/url shape as Claude.
+                let (transport, url) = super::parse_type_url(val);
+                McpServerEntry {
+                    name: name.clone(),
+                    command: val
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .into(),
+                    args: super::json_string_vec(val, "args"),
+                    env: super::json_string_map(val, "env"),
+                    transport,
+                    url,
+                    headers: super::json_string_map(val, "headers"),
+                    // Copilot's MCP schema has no agent-native disable concept.
+                    enabled: true,
+                }
             })
             .collect()
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::TypeAndUrl
     }
 
     fn translate_hook_event(&self, event: &str) -> Option<String> {
@@ -422,8 +421,32 @@ impl AgentAdapter for CopilotAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::super::AgentAdapter;
+    use super::super::{AgentAdapter, McpTransport};
     use super::*;
+
+    #[test]
+    fn read_mcp_servers_parses_type_url_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("mcp.json");
+        std::fs::write(
+            &config,
+            r#"{"servers":{
+                "remote":{"type":"http","url":"https://example.com/mcp","headers":{"A":"b"}},
+                "local":{"type":"stdio","command":"npx","args":["-y","srv"]}
+            }}"#,
+        )
+        .unwrap();
+        let adapter = CopilotAdapter::with_home(std::path::PathBuf::from("/nonexistent"));
+        let servers = adapter.read_mcp_servers_from(&config);
+        let remote = servers.iter().find(|s| s.name == "remote").unwrap();
+        assert_eq!(remote.transport, McpTransport::Http);
+        assert_eq!(remote.url.as_deref(), Some("https://example.com/mcp"));
+        assert_eq!(remote.command, "");
+        assert_eq!(remote.headers["A"], "b");
+        let local = servers.iter().find(|s| s.name == "local").unwrap();
+        assert_eq!(local.transport, McpTransport::Stdio);
+        assert_eq!(local.command, "npx");
+    }
 
     #[test]
     fn read_hooks_copilot_format() {

--- a/crates/hk-core/src/adapter/cursor.rs
+++ b/crates/hk-core/src/adapter/cursor.rs
@@ -5,7 +5,10 @@
 // Plugin reference: https://cursor.com/docs/plugins
 // Plugins: ~/.cursor/plugins/, manifest at .cursor-plugin/plugin.json
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, PluginEntry, ProjectMarker};
+use super::{
+    AgentAdapter, HookEntry, HookFormat, McpServerEntry, PluginEntry, ProjectMarker,
+    RemoteMcpSchema,
+};
 use std::path::{Path, PathBuf};
 
 pub struct CursorAdapter {
@@ -90,35 +93,30 @@ impl AgentAdapter for CursorAdapter {
         };
         servers
             .iter()
-            .map(|(name, val)| McpServerEntry {
-                name: name.clone(),
-                command: val
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .into(),
-                args: val
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                env: val
-                    .get("env")
-                    .and_then(|v| v.as_object())
-                    .map(|obj| {
-                        obj.iter()
-                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                // Cursor's MCP schema has no agent-native disable concept.
-                enabled: true,
+            .map(|(name, val)| {
+                // Remote entries: {url, headers} — protocol auto-detected by Cursor.
+                let (transport, url) = super::parse_plain_url(val, "url");
+                McpServerEntry {
+                    name: name.clone(),
+                    command: val
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .into(),
+                    args: super::json_string_vec(val, "args"),
+                    env: super::json_string_map(val, "env"),
+                    transport,
+                    url,
+                    headers: super::json_string_map(val, "headers"),
+                    // Cursor's MCP schema has no agent-native disable concept.
+                    enabled: true,
+                }
             })
             .collect()
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::PlainUrl
     }
 
     fn translate_hook_event(&self, event: &str) -> Option<String> {
@@ -290,8 +288,31 @@ impl AgentAdapter for CursorAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::super::AgentAdapter;
+    use super::super::{AgentAdapter, McpTransport};
     use super::*;
+
+    #[test]
+    fn read_mcp_servers_parses_url_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("mcp.json");
+        std::fs::write(
+            &config,
+            r#"{"mcpServers":{
+                "linear":{"url":"https://mcp.linear.app/mcp","headers":{"X-K":"v"}},
+                "fs":{"command":"npx","args":["-y","server-fs"]}
+            }}"#,
+        )
+        .unwrap();
+        let adapter = CursorAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers_from(&config);
+        let linear = servers.iter().find(|s| s.name == "linear").unwrap();
+        assert_eq!(linear.transport, McpTransport::Http);
+        assert_eq!(linear.url.as_deref(), Some("https://mcp.linear.app/mcp"));
+        assert_eq!(linear.command, "");
+        assert_eq!(linear.headers["X-K"], "v");
+        let fs = servers.iter().find(|s| s.name == "fs").unwrap();
+        assert_eq!(fs.transport, McpTransport::Stdio);
+    }
 
     #[test]
     fn test_cursor_subagent_methods() {

--- a/crates/hk-core/src/adapter/gemini.rs
+++ b/crates/hk-core/src/adapter/gemini.rs
@@ -7,7 +7,10 @@
 // Extension (plugin) reference: https://geminicli.com/docs/extensions/
 // Extensions: ~/.gemini/extensions/{name}/, manifest at gemini-extension.json
 
-use super::{AgentAdapter, HookEntry, McpServerEntry, PluginEntry, ProjectMarker};
+use super::{
+    AgentAdapter, HookEntry, McpServerEntry, McpTransport, PluginEntry, ProjectMarker,
+    RemoteMcpSchema,
+};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -178,35 +181,39 @@ impl AgentAdapter for GeminiAdapter {
         };
         servers
             .iter()
-            .map(|(name, val)| McpServerEntry {
-                name: name.clone(),
-                command: val
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .into(),
-                args: val
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                env: val
-                    .get("env")
-                    .and_then(|v| v.as_object())
-                    .map(|obj| {
-                        obj.iter()
-                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                // Gemini's MCP schema has no agent-native disable concept.
-                enabled: true,
+            .map(|(name, val)| {
+                // Remote entries: `httpUrl` = Streamable HTTP, `url` = SSE
+                // (per gemini-cli's mcp-server.md). `httpUrl` wins if both
+                // are present, matching gemini-cli's own precedence.
+                let (transport, url) = match (
+                    val.get("httpUrl").and_then(|v| v.as_str()),
+                    val.get("url").and_then(|v| v.as_str()),
+                ) {
+                    (Some(http), _) => (McpTransport::Http, Some(http.to_string())),
+                    (None, Some(sse)) => (McpTransport::Sse, Some(sse.to_string())),
+                    (None, None) => (McpTransport::Stdio, None),
+                };
+                McpServerEntry {
+                    name: name.clone(),
+                    command: val
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .into(),
+                    args: super::json_string_vec(val, "args"),
+                    env: super::json_string_map(val, "env"),
+                    transport,
+                    url,
+                    headers: super::json_string_map(val, "headers"),
+                    // Gemini's MCP schema has no agent-native disable concept.
+                    enabled: true,
+                }
             })
             .collect()
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::GeminiSplit
     }
 
     fn read_plugins(&self) -> Vec<PluginEntry> {
@@ -306,6 +313,33 @@ impl AgentAdapter for GeminiAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn read_mcp_servers_splits_http_url_and_sse_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("settings.json");
+        std::fs::write(
+            &config,
+            r#"{"mcpServers":{
+                "streaming":{"httpUrl":"https://example.com/mcp","headers":{"Authorization":"Bearer t"}},
+                "legacy":{"url":"http://localhost:8080/sse"},
+                "fs":{"command":"npx","args":["-y","server-fs"]}
+            }}"#,
+        )
+        .unwrap();
+        let adapter = GeminiAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers_from(&config);
+        let by_name: std::collections::HashMap<_, _> =
+            servers.iter().map(|s| (s.name.as_str(), s)).collect();
+        assert_eq!(by_name["streaming"].transport, McpTransport::Http);
+        assert_eq!(
+            by_name["streaming"].url.as_deref(),
+            Some("https://example.com/mcp")
+        );
+        assert_eq!(by_name["streaming"].headers["Authorization"], "Bearer t");
+        assert_eq!(by_name["legacy"].transport, McpTransport::Sse);
+        assert_eq!(by_name["fs"].transport, McpTransport::Stdio);
+    }
 
     fn setup_extension(tmp: &std::path::Path, name: &str) {
         let ext_dir = tmp.join(".gemini").join("extensions").join(name);

--- a/crates/hk-core/src/adapter/hermes.rs
+++ b/crates/hk-core/src/adapter/hermes.rs
@@ -9,9 +9,26 @@
 //          (one nesting level). Enable-state in config.yaml `plugins.enabled` (disabled by default).
 
 use super::{
-    AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry, ProjectMarker,
+    AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, McpTransport, PluginEntry,
+    ProjectMarker, RemoteMcpSchema,
 };
 use std::path::{Path, PathBuf};
+
+/// Parse a YAML `key: {A: B, ...}` sub-mapping into a string map, dropping
+/// non-string values. Used for `env` and `headers` blocks.
+fn yaml_string_map(
+    val: &serde_yaml::Value,
+    key: &str,
+) -> std::collections::HashMap<String, String> {
+    val.get(key)
+        .and_then(|v| v.as_mapping())
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| Some((k.as_str()?.to_string(), v.as_str()?.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
 
 pub struct HermesAdapter {
     home: PathBuf,
@@ -214,12 +231,22 @@ impl AgentAdapter for HermesAdapter {
             .iter()
             .filter_map(|(key, val)| {
                 let name = key.as_str()?.to_string();
-                // HTTP MCP: {url: "http://..."} — store URL in command field
+                // Remote MCP: {url, headers?, transport: sse?} — Streamable
+                // HTTP unless `transport: sse` is set.
                 // stdio MCP: {command: "...", args: [...], env: {...}}
-                let command = if let Some(url) = val.get("url").and_then(|v| v.as_str()) {
-                    url.to_string()
-                } else {
-                    val.get("command").and_then(|v| v.as_str())?.to_string()
+                let url = val.get("url").and_then(|v| v.as_str()).map(String::from);
+                let (transport, command) = match &url {
+                    Some(_) => {
+                        let sse = val.get("transport").and_then(|v| v.as_str()) == Some("sse");
+                        (
+                            if sse { McpTransport::Sse } else { McpTransport::Http },
+                            String::new(),
+                        )
+                    }
+                    None => (
+                        McpTransport::Stdio,
+                        val.get("command").and_then(|v| v.as_str())?.to_string(),
+                    ),
                 };
 
                 let args: Vec<String> = val
@@ -228,18 +255,6 @@ impl AgentAdapter for HermesAdapter {
                     .map(|seq| {
                         seq.iter()
                             .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-
-                let env: std::collections::HashMap<String, String> = val
-                    .get("env")
-                    .and_then(|v| v.as_mapping())
-                    .map(|m| {
-                        m.iter()
-                            .filter_map(|(k, v)| {
-                                Some((k.as_str()?.to_string(), v.as_str()?.to_string()))
-                            })
                             .collect()
                     })
                     .unwrap_or_default();
@@ -253,11 +268,18 @@ impl AgentAdapter for HermesAdapter {
                     name,
                     command,
                     args,
-                    env,
+                    env: yaml_string_map(val, "env"),
+                    transport,
+                    url,
+                    headers: yaml_string_map(val, "headers"),
                     enabled,
                 })
             })
             .collect()
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::HermesUrl
     }
 
     fn supports_native_mcp_toggle(&self) -> bool {
@@ -428,6 +450,28 @@ mod tests {
     use std::fs;
 
     #[test]
+    fn read_mcp_servers_parses_url_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("config.yaml");
+        fs::write(
+            &config,
+            "mcp_servers:\n  stripe:\n    url: https://mcp.stripe.com\n    headers:\n      Authorization: Bearer tok\n  events:\n    url: https://example.com/sse\n    transport: sse\n  local:\n    command: npx\n    args: [-y, srv]\n",
+        )
+        .unwrap();
+        let adapter = HermesAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers_from(&config);
+        let by_name: std::collections::HashMap<_, _> =
+            servers.iter().map(|s| (s.name.as_str(), s)).collect();
+        let stripe = by_name["stripe"];
+        assert_eq!(stripe.transport, McpTransport::Http);
+        assert_eq!(stripe.url.as_deref(), Some("https://mcp.stripe.com"));
+        assert_eq!(stripe.command, "", "url must not leak into command");
+        assert_eq!(stripe.headers["Authorization"], "Bearer tok");
+        assert_eq!(by_name["events"].transport, McpTransport::Sse);
+        assert_eq!(by_name["local"].transport, McpTransport::Stdio);
+    }
+
+    #[test]
     fn test_name() {
         let adapter = HermesAdapter::new();
         assert_eq!(adapter.name(), "hermes");
@@ -529,7 +573,9 @@ mod tests {
         let servers = adapter.read_mcp_servers();
         assert_eq!(servers.len(), 1);
         assert_eq!(servers[0].name, "proxy");
-        assert_eq!(servers[0].command, "http://localhost:8080/mcp");
+        assert_eq!(servers[0].transport, McpTransport::Http);
+        assert_eq!(servers[0].url.as_deref(), Some("http://localhost:8080/mcp"));
+        assert_eq!(servers[0].command, "");
         assert!(!servers[0].enabled);
     }
 

--- a/crates/hk-core/src/adapter/kiro.rs
+++ b/crates/hk-core/src/adapter/kiro.rs
@@ -7,7 +7,9 @@
 // Hooks are IDE Agent Hooks in `.kiro/hooks/*.json`, not CLI custom-agent
 // hooks embedded in `.kiro/agents/*.json`.
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker};
+use super::{
+    AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker, RemoteMcpSchema,
+};
 use crate::models::ConfigScope;
 use std::path::{Path, PathBuf};
 
@@ -136,38 +138,32 @@ impl AgentAdapter for KiroAdapter {
         };
         servers
             .iter()
-            .map(|(name, val)| McpServerEntry {
-                name: name.clone(),
-                command: val
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .or_else(|| val.get("url").and_then(|v| v.as_str()))
-                    .unwrap_or("")
-                    .into(),
-                args: val
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                env: val
-                    .get("env")
-                    .and_then(|v| v.as_object())
-                    .map(|obj| {
-                        obj.iter()
-                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                enabled: !val
-                    .get("disabled")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false),
+            .map(|(name, val)| {
+                // Remote entries: {url, headers} — protocol auto-detected by Kiro.
+                let (transport, url) = super::parse_plain_url(val, "url");
+                McpServerEntry {
+                    name: name.clone(),
+                    command: val
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .into(),
+                    args: super::json_string_vec(val, "args"),
+                    env: super::json_string_map(val, "env"),
+                    transport,
+                    url,
+                    headers: super::json_string_map(val, "headers"),
+                    enabled: !val
+                        .get("disabled")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false),
+                }
             })
             .collect()
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::PlainUrl
     }
 
     fn read_hooks(&self) -> Vec<HookEntry> {
@@ -245,8 +241,31 @@ impl AgentAdapter for KiroAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::super::AgentAdapter;
+    use super::super::{AgentAdapter, McpTransport};
     use super::*;
+
+    #[test]
+    fn read_mcp_servers_parses_url_entries() {
+        // Remote schema per kiro.dev/docs/mcp/configuration — the url no
+        // longer round-trips through the command field.
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("mcp.json");
+        std::fs::write(
+            &config,
+            r#"{"mcpServers":{
+                "gh":{"url":"https://api.github.com/mcp","headers":{"X-K":"v"}},
+                "fs":{"command":"npx","args":["-y","srv"]}
+            }}"#,
+        )
+        .unwrap();
+        let adapter = KiroAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers_from(&config);
+        let gh = servers.iter().find(|s| s.name == "gh").unwrap();
+        assert_eq!(gh.transport, McpTransport::Http);
+        assert_eq!(gh.url.as_deref(), Some("https://api.github.com/mcp"));
+        assert_eq!(gh.command, "", "url must not leak into command");
+        assert_eq!(gh.headers["X-K"], "v");
+    }
 
     #[test]
     fn detect_requires_kiro_dir() {

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -58,6 +58,27 @@ impl McpTransport {
     fn is_stdio(&self) -> bool {
         *self == McpTransport::Stdio
     }
+
+    /// Plain-text form used for the extensions DB column.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            McpTransport::Stdio => "stdio",
+            McpTransport::Http => "http",
+            McpTransport::Sse => "sse",
+        }
+    }
+}
+
+impl std::str::FromStr for McpTransport {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "stdio" => Ok(McpTransport::Stdio),
+            "http" => Ok(McpTransport::Http),
+            "sse" => Ok(McpTransport::Sse),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Represents an MCP server entry parsed from an agent's config.
@@ -589,6 +610,7 @@ impl crate::models::AgentCapabilities {
     /// cannot drift.
     pub fn from_adapter(a: &dyn AgentAdapter) -> Self {
         let skill = !a.project_skill_dirs().is_empty();
+        let remote_schema = a.remote_mcp_schema();
         Self {
             project_install: crate::models::KindFlags {
                 skill,
@@ -600,6 +622,15 @@ impl crate::models::AgentCapabilities {
             },
             hooks_supported: a.hook_format() != HookFormat::None,
             global_hook_install: a.supports_global_hook_install(),
+            // Codex's TOML schema (the only `Toml` agent) speaks Streamable
+            // HTTP but not SSE; every other non-Unsupported schema takes both.
+            mcp_remote: crate::models::RemoteTransportFlags {
+                http: remote_schema != RemoteMcpSchema::Unsupported,
+                sse: !matches!(
+                    remote_schema,
+                    RemoteMcpSchema::Unsupported | RemoteMcpSchema::Toml
+                ),
+            },
         }
     }
 }
@@ -666,6 +697,26 @@ mod tests {
         assert_eq!(back.transport, McpTransport::Sse);
         assert_eq!(back.url.as_deref(), Some("https://example.com/sse"));
         assert_eq!(back.headers["Authorization"], "Bearer t");
+    }
+
+    #[test]
+    fn mcp_remote_capability_derivation() {
+        // Codex (TOML) is the only HTTP-only agent; every other adapter's
+        // remote schema supports both transports. Pinned so a future agent
+        // with partial support must consciously extend the derivation.
+        for a in all_adapters() {
+            let caps = crate::models::AgentCapabilities::from_adapter(a.as_ref());
+            match a.name() {
+                "codex" => {
+                    assert!(caps.mcp_remote.http);
+                    assert!(!caps.mcp_remote.sse);
+                }
+                _ => {
+                    assert!(caps.mcp_remote.http, "{} should accept http", a.name());
+                    assert!(caps.mcp_remote.sse, "{} should accept sse", a.name());
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -36,9 +36,36 @@ pub(crate) fn files_with_ext<'a>(
         .filter(move |path| path.extension().is_some_and(|e| e == ext))
 }
 
+/// Transport an MCP server entry uses. `Stdio` entries carry `command/args/env`;
+/// `Http` (Streamable HTTP) and `Sse` entries carry `url` (+ optional `headers`)
+/// and an empty `command`.
+///
+/// Agents whose config has a single auto-detecting URL key (Cursor, Kiro,
+/// Windsurf, Antigravity, Codex, OpenCode) are read as `Http` — the modern
+/// default — since the file doesn't record which protocol the server speaks.
+/// Only agents with an explicit discriminator (Claude/Copilot/omp `type`,
+/// Gemini `url` vs `httpUrl`, Hermes `transport`) can yield `Sse`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum McpTransport {
+    #[default]
+    Stdio,
+    Http,
+    Sse,
+}
+
+impl McpTransport {
+    fn is_stdio(&self) -> bool {
+        *self == McpTransport::Stdio
+    }
+}
+
 /// Represents an MCP server entry parsed from an agent's config.
 ///
-/// Serde representation is the canonical Kit blob: `{command, args, env}`.
+/// Serde representation is the canonical Kit blob: `{command, args, env}` for
+/// stdio entries plus `{transport, url, headers}` for remote ones. The remote
+/// fields are skipped when empty so stdio blobs stay byte-identical to the
+/// pre-transport format, and `#[serde(default)]` keeps old blobs parseable.
 /// `name` is carried by the caller's context (asset name in the manifest);
 /// `enabled` is HarnessKit-internal and defaults to `true` on the install
 /// side (only OpenCode's source schema has a per-entry agent-native
@@ -52,12 +79,100 @@ pub struct McpServerEntry {
     pub args: Vec<String>,
     #[serde(default)]
     pub env: std::collections::HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "McpTransport::is_stdio")]
+    pub transport: McpTransport,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// HTTP headers sent to remote servers (typically `Authorization`).
+    /// Secret-bearing: must be redacted alongside `env` wherever entries
+    /// are snapshotted to the DB (see `manager::redact_mcp_env`).
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub headers: std::collections::HashMap<String, String>,
     #[serde(skip, default = "default_enabled")]
     pub enabled: bool,
 }
 
 fn default_enabled() -> bool {
     true
+}
+
+impl Default for McpServerEntry {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            command: String::new(),
+            args: vec![],
+            env: Default::default(),
+            transport: McpTransport::Stdio,
+            url: None,
+            headers: Default::default(),
+            enabled: true,
+        }
+    }
+}
+
+/// Parse a `{"key": "value", ...}` JSON object field into a string map,
+/// dropping non-string values. Shared by adapter readers for `env` and
+/// `headers` blocks.
+pub(crate) fn json_string_map(
+    val: &serde_json::Value,
+    key: &str,
+) -> std::collections::HashMap<String, String> {
+    val.get(key)
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Transport + url for `{type: "http"|"sse", url}`-style entries (Claude,
+/// Copilot, omp — the `RemoteMcpSchema::TypeAndUrl` agents).
+/// `streamable-http` is the MCP spec's name for the HTTP transport and an
+/// accepted alias in these agents' configs (Claude docs: "configurations
+/// copied from server documentation work without modification").
+///
+/// An entry with a `url` but no `type` also counts as Streamable HTTP.
+/// That is deliberately laxer than Claude itself, which refuses to load
+/// such an entry — HK is a scanner, and showing the URL beats showing an
+/// empty command for a config the user needs to fix.
+pub(crate) fn parse_type_url(val: &serde_json::Value) -> (McpTransport, Option<String>) {
+    let url = val.get("url").and_then(|v| v.as_str()).map(String::from);
+    let transport = match (val.get("type").and_then(|v| v.as_str()), &url) {
+        (Some("sse"), _) => McpTransport::Sse,
+        (Some("http" | "streamable-http"), _) | (None, Some(_)) => McpTransport::Http,
+        _ => McpTransport::Stdio,
+    };
+    (transport, url)
+}
+
+/// Transport + url for single-URL-key entries (`url` — Cursor/Kiro,
+/// `serverUrl` — Windsurf/Antigravity). These configs don't record the
+/// protocol, so presence of the key reads as Streamable HTTP (see
+/// `McpTransport` docs).
+pub(crate) fn parse_plain_url(
+    val: &serde_json::Value,
+    key: &str,
+) -> (McpTransport, Option<String>) {
+    match val.get(key).and_then(|v| v.as_str()) {
+        Some(url) => (McpTransport::Http, Some(url.to_string())),
+        None => (McpTransport::Stdio, None),
+    }
+}
+
+/// Parse a `["a", "b", ...]` JSON array field into a string vec, dropping
+/// non-string items. Shared by adapter readers for `args` lists.
+pub(crate) fn json_string_vec(val: &serde_json::Value, key: &str) -> Vec<String> {
+    val.get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Represents a hook entry parsed from an agent's config
@@ -145,9 +260,36 @@ pub enum McpFormat {
     /// See https://opencode.ai/config.json (McpLocalConfig).
     Opencode,
     /// YAML config.yaml with "mcp_servers" top-level key (Hermes).
-    /// Each entry may be URL-based ({url: "..."}) or command-based ({command: "..."}).
-    /// URL-based entries are stored with the URL in the `command` field and empty args.
+    /// Each entry is URL-based ({url, headers?, transport: sse?}) or
+    /// command-based ({command, args?, env?}).
     HermesYaml,
+}
+
+/// How an agent's config spells a remote (HTTP/SSE) MCP entry.
+///
+/// This is the single source of truth for "which transports can this agent
+/// receive": the deployer's JSON writer dispatches on the four JSON-family
+/// variants, and `AgentCapabilities::from_adapter` derives UI install-gating
+/// from it (`Toml` is the only HTTP-only variant — Codex has no SSE support;
+/// `Unsupported` receives no remote entries at all).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RemoteMcpSchema {
+    /// `{type: "http"|"sse", url, headers}` — Claude, Copilot, omp.
+    TypeAndUrl,
+    /// `{url, headers}`, protocol auto-detected by the agent — Cursor, Kiro.
+    PlainUrl,
+    /// `{httpUrl}` for Streamable HTTP, `{url}` for SSE, `headers` for both — Gemini.
+    GeminiSplit,
+    /// `{serverUrl, headers}`, protocol auto-detected — Windsurf, Antigravity.
+    ServerUrl,
+    /// TOML `url = "..."` + `http_headers` — Codex. Streamable HTTP only.
+    Toml,
+    /// `{type: "remote", url, headers, enabled}` — OpenCode.
+    OpencodeRemote,
+    /// YAML `url:` + `headers:` + optional `transport: sse` — Hermes.
+    HermesUrl,
+    /// Agent has no remote MCP concept; deploying a remote entry is an error.
+    Unsupported,
 }
 
 pub trait AgentAdapter: Send + Sync {
@@ -188,6 +330,13 @@ pub trait AgentAdapter: Send + Sync {
     }
     fn mcp_format(&self) -> McpFormat {
         McpFormat::McpServers
+    }
+
+    /// How this agent's config spells a remote MCP entry. `Unsupported`
+    /// (the default) means the agent only handles stdio servers; the
+    /// deployer refuses remote entries for such targets.
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::Unsupported
     }
 
     /// True if HarnessKit should resolve bare commands to absolute paths and
@@ -487,6 +636,37 @@ pub fn all_adapters() -> Vec<Box<dyn AgentAdapter>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mcp_entry_kit_blob_compat() {
+        // Old Kit blobs ({command, args, env}) must keep parsing, defaulting
+        // to stdio transport.
+        let old: McpServerEntry =
+            serde_json::from_str(r#"{"command":"npx","args":["-y","srv"],"env":{}}"#).unwrap();
+        assert_eq!(old.transport, McpTransport::Stdio);
+        assert_eq!(old.url, None);
+        assert!(old.headers.is_empty());
+
+        // Stdio entries serialize with exactly the pre-transport key set
+        // (remote fields are skipped when empty).
+        let json = serde_json::to_value(&old).unwrap();
+        let mut keys: Vec<_> = json.as_object().unwrap().keys().collect();
+        keys.sort();
+        assert_eq!(keys, vec!["args", "command", "env"]);
+
+        // Remote entries round-trip transport/url/headers.
+        let remote = McpServerEntry {
+            transport: McpTransport::Sse,
+            url: Some("https://example.com/sse".into()),
+            headers: [("Authorization".to_string(), "Bearer t".to_string())].into(),
+            ..Default::default()
+        };
+        let back: McpServerEntry =
+            serde_json::from_str(&serde_json::to_string(&remote).unwrap()).unwrap();
+        assert_eq!(back.transport, McpTransport::Sse);
+        assert_eq!(back.url.as_deref(), Some("https://example.com/sse"));
+        assert_eq!(back.headers["Authorization"], "Bearer t");
+    }
 
     #[test]
     fn test_all_adapters_returns_eleven() {

--- a/crates/hk-core/src/adapter/omp.rs
+++ b/crates/hk-core/src/adapter/omp.rs
@@ -14,7 +14,10 @@
 // adapter reports HookFormat::None — same model as opencode ("hooks are JS
 // plugins"). omp's shell-command HookEntry model has no equivalent.
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry, ProjectMarker};
+use super::{
+    AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry, ProjectMarker,
+    RemoteMcpSchema,
+};
 use std::path::{Path, PathBuf};
 
 pub struct OmpAdapter {
@@ -181,46 +184,37 @@ impl AgentAdapter for OmpAdapter {
         let allowlist = self.user_mcp_name_list("enabledServers");
         servers
             .iter()
-            .map(|(name, val)| McpServerEntry {
-                name: name.clone(),
-                // stdio servers use `command`; http/sse servers use `url`.
-                // Store the url in the command field so remote servers
-                // round-trip (same approach Hermes uses for url-based entries).
-                command: val
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .or_else(|| val.get("url").and_then(|v| v.as_str()))
-                    .unwrap_or("")
-                    .into(),
-                args: val
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                env: val
-                    .get("env")
-                    .and_then(|v| v.as_object())
-                    .map(|obj| {
-                        obj.iter()
-                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                // Reported so the scanner reflects effective on-disk state;
-                // the toggle writes the same inputs back in place
-                // (deployer::set_omp_mcp_enabled).
-                enabled: !denylist.contains(name)
-                    && (val
-                        .get("enabled")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(true)
-                        || allowlist.contains(name)),
+            .map(|(name, val)| {
+                // Remote entries: {type: "http"|"sse", url, headers}.
+                let (transport, url) = super::parse_type_url(val);
+                McpServerEntry {
+                    name: name.clone(),
+                    command: val
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .into(),
+                    args: super::json_string_vec(val, "args"),
+                    env: super::json_string_map(val, "env"),
+                    transport,
+                    url,
+                    headers: super::json_string_map(val, "headers"),
+                    // Reported so the scanner reflects effective on-disk state;
+                    // the toggle writes the same inputs back in place
+                    // (deployer::set_omp_mcp_enabled).
+                    enabled: !denylist.contains(name)
+                        && (val
+                            .get("enabled")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(true)
+                            || allowlist.contains(name)),
+                }
             })
             .collect()
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::TypeAndUrl
     }
 
     fn read_hooks(&self) -> Vec<HookEntry> {
@@ -430,9 +424,11 @@ mod tests {
         assert_eq!(fs.args, vec!["-y", "@modelcontextprotocol/server-filesystem"]);
         assert!(fs.enabled);
 
-        // Remote server: url stored in the command field (mirrors Hermes).
+        // Remote server: transport + url fields, command stays empty.
         let gh = by_name["github"];
-        assert_eq!(gh.command, "https://api.githubcopilot.com/mcp/");
+        assert_eq!(gh.transport, super::super::McpTransport::Http);
+        assert_eq!(gh.url.as_deref(), Some("https://api.githubcopilot.com/mcp/"));
+        assert_eq!(gh.command, "");
         assert!(gh.args.is_empty());
 
         // Native per-server enabled flag is read back.

--- a/crates/hk-core/src/adapter/opencode.rs
+++ b/crates/hk-core/src/adapter/opencode.rs
@@ -3,7 +3,6 @@ use super::{
     ProjectMarker, RemoteMcpSchema,
 };
 use crate::models::ConfigScope;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 pub struct OpencodeAdapter {

--- a/crates/hk-core/src/adapter/opencode.rs
+++ b/crates/hk-core/src/adapter/opencode.rs
@@ -1,4 +1,7 @@
-use super::{AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, PluginEntry, ProjectMarker};
+use super::{
+    AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, McpTransport, PluginEntry,
+    ProjectMarker, RemoteMcpSchema,
+};
 use crate::models::ConfigScope;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -76,10 +79,10 @@ impl OpencodeAdapter {
         }
     }
 
-    fn parse_local_mcp_entry(name: &str, value: &serde_json::Value) -> Option<McpServerEntry> {
-        if value.get("type").and_then(|v| v.as_str()) != Some("local") {
-            return None;
-        }
+    /// Parse one `mcp` entry — a tagged union: `{type: "local", command:
+    /// [bin, ...args], environment}` or `{type: "remote", url, headers}`.
+    /// Entries with any other/missing `type` are skipped.
+    fn parse_mcp_entry(name: &str, value: &serde_json::Value) -> Option<McpServerEntry> {
         // Honor OpenCode's `enabled` field by surfacing its value through the
         // McpServerEntry — entries with `enabled: false` are NOT filtered out,
         // matching how HarnessKit displays user-disabled MCPs from every other
@@ -92,33 +95,40 @@ impl OpencodeAdapter {
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
 
-        let (command, args) = match value.get("command") {
-            Some(serde_json::Value::Array(parts)) => {
-                let mut parts = parts
-                    .iter()
-                    .filter_map(|part| part.as_str().map(String::from));
-                let command = parts.next()?;
-                (command, parts.collect())
+        let (command, args, transport, url) = match value.get("type").and_then(|v| v.as_str()) {
+            Some("local") => {
+                let (command, args) = match value.get("command") {
+                    Some(serde_json::Value::Array(parts)) => {
+                        let mut parts = parts
+                            .iter()
+                            .filter_map(|part| part.as_str().map(String::from));
+                        let command = parts.next()?;
+                        (command, parts.collect())
+                    }
+                    Some(serde_json::Value::String(command)) => (command.clone(), vec![]),
+                    _ => return None,
+                };
+                (command, args, McpTransport::Stdio, None)
             }
-            Some(serde_json::Value::String(command)) => (command.clone(), vec![]),
+            Some("remote") => {
+                let url = value.get("url").and_then(|v| v.as_str())?.to_string();
+                // OpenCode's remote config carries no transport marker; at
+                // runtime it tries Streamable HTTP first and falls back to
+                // SSE (mcp/index.ts connectRemote), so Http is the closest
+                // reading.
+                (String::new(), vec![], McpTransport::Http, Some(url))
+            }
             _ => return None,
         };
-
-        let env = value
-            .get("environment")
-            .and_then(|v| v.as_object())
-            .map(|obj| {
-                obj.iter()
-                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                    .collect::<HashMap<_, _>>()
-            })
-            .unwrap_or_default();
 
         Some(McpServerEntry {
             name: name.to_string(),
             command,
             args,
-            env,
+            env: super::json_string_map(value, "environment"),
+            transport,
+            url,
+            headers: super::json_string_map(value, "headers"),
             enabled,
         })
     }
@@ -131,6 +141,10 @@ impl AgentAdapter for OpencodeAdapter {
 
     fn mcp_format(&self) -> McpFormat {
         McpFormat::Opencode
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::OpencodeRemote
     }
 
     fn name(&self) -> &str {
@@ -189,7 +203,7 @@ impl AgentAdapter for OpencodeAdapter {
         };
         servers
             .iter()
-            .filter_map(|(name, value)| Self::parse_local_mcp_entry(name, value))
+            .filter_map(|(name, value)| Self::parse_mcp_entry(name, value))
             .collect()
     }
 
@@ -330,7 +344,7 @@ impl AgentAdapter for OpencodeAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::super::AgentAdapter;
+    use super::super::{AgentAdapter, McpTransport};
     use super::*;
 
     #[test]
@@ -348,7 +362,8 @@ mod tests {
     }
 
     #[test]
-    fn read_mcp_servers_keeps_only_local_entries() {
+    fn read_mcp_servers_parses_local_and_remote_entries() {
+        // `type: "remote"` entries were previously skipped entirely.
         let tmp = tempfile::tempdir().unwrap();
         let config_dir = tmp.path().join(".config/opencode");
         std::fs::create_dir_all(&config_dir).unwrap();
@@ -363,7 +378,8 @@ mod tests {
                     },
                     "remote-server": {
                         "type": "remote",
-                        "url": "https://example.com/mcp"
+                        "url": "https://example.com/mcp",
+                        "headers": {"Authorization": "Bearer k"}
                     }
                 }
             }"#,
@@ -372,11 +388,19 @@ mod tests {
 
         let adapter = OpencodeAdapter::with_home(tmp.path().to_path_buf());
         let servers = adapter.read_mcp_servers();
-        assert_eq!(servers.len(), 1);
-        assert_eq!(servers[0].name, "local-server");
-        assert_eq!(servers[0].command, "bun");
-        assert_eq!(servers[0].args, vec!["x", "tool"]);
-        assert_eq!(servers[0].env.get("TOKEN"), Some(&"abc".to_string()));
+        assert_eq!(servers.len(), 2, "remote entries must be visible");
+
+        let local = servers.iter().find(|s| s.name == "local-server").unwrap();
+        assert_eq!(local.transport, McpTransport::Stdio);
+        assert_eq!(local.command, "bun");
+        assert_eq!(local.args, vec!["x", "tool"]);
+        assert_eq!(local.env.get("TOKEN"), Some(&"abc".to_string()));
+
+        let remote = servers.iter().find(|s| s.name == "remote-server").unwrap();
+        assert_eq!(remote.transport, McpTransport::Http);
+        assert_eq!(remote.url.as_deref(), Some("https://example.com/mcp"));
+        assert_eq!(remote.command, "");
+        assert_eq!(remote.headers["Authorization"], "Bearer k");
     }
 
     #[test]

--- a/crates/hk-core/src/adapter/windsurf.rs
+++ b/crates/hk-core/src/adapter/windsurf.rs
@@ -9,7 +9,9 @@
 // Ignore reference:   https://docs.windsurf.com/context-awareness/windsurf-ignore
 // File:               .codeiumignore (project root)
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker};
+use super::{
+    AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker, RemoteMcpSchema,
+};
 use std::path::{Path, PathBuf};
 
 pub struct WindsurfAdapter {
@@ -100,35 +102,30 @@ impl AgentAdapter for WindsurfAdapter {
 
         servers
             .iter()
-            .map(|(name, val)| McpServerEntry {
-                name: name.clone(),
-                command: val
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .into(),
-                args: val
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                env: val
-                    .get("env")
-                    .and_then(|v| v.as_object())
-                    .map(|obj| {
-                        obj.iter()
-                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                // Windsurf's MCP schema has no agent-native disable concept.
-                enabled: true,
+            .map(|(name, val)| {
+                // Remote entries: {serverUrl, headers} — protocol auto-detected.
+                let (transport, url) = super::parse_plain_url(val, "serverUrl");
+                McpServerEntry {
+                    name: name.clone(),
+                    command: val
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .into(),
+                    args: super::json_string_vec(val, "args"),
+                    env: super::json_string_map(val, "env"),
+                    transport,
+                    url,
+                    headers: super::json_string_map(val, "headers"),
+                    // Windsurf's MCP schema has no agent-native disable concept.
+                    enabled: true,
+                }
             })
             .collect()
+    }
+
+    fn remote_mcp_schema(&self) -> RemoteMcpSchema {
+        RemoteMcpSchema::ServerUrl
     }
 
     fn translate_hook_event(&self, event: &str) -> Option<String> {
@@ -251,8 +248,31 @@ impl AgentAdapter for WindsurfAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::super::AgentAdapter;
+    use super::super::{AgentAdapter, McpTransport};
     use super::*;
+
+    #[test]
+    fn read_mcp_servers_parses_server_url_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("mcp_config.json");
+        std::fs::write(
+            &config,
+            r#"{"mcpServers":{
+                "remote":{"serverUrl":"https://example.com/mcp","headers":{"Authorization":"Bearer t"}},
+                "fs":{"command":"npx","args":["-y","srv"]}
+            }}"#,
+        )
+        .unwrap();
+        let adapter = WindsurfAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers_from(&config);
+        let remote = servers.iter().find(|s| s.name == "remote").unwrap();
+        assert_eq!(remote.transport, McpTransport::Http);
+        assert_eq!(remote.url.as_deref(), Some("https://example.com/mcp"));
+        assert_eq!(remote.command, "");
+        assert_eq!(remote.headers["Authorization"], "Bearer t");
+        let fs = servers.iter().find(|s| s.name == "fs").unwrap();
+        assert_eq!(fs.transport, McpTransport::Stdio);
+    }
 
     #[test]
     fn detect_requires_base_dir() {

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -1088,6 +1088,7 @@ pub fn restore_mcp_server(
                 // entry; the value is preserved as-is. Codex (TOML) has no
                 // agent-native disable concept, so always true.
                 enabled: true,
+                ..Default::default()
             };
             deploy_mcp_server_toml(config_path, &mcp_entry)
         }
@@ -2019,6 +2020,7 @@ mod tests {
             args: vec!["-y".into(), "@mcp/fs".into()],
             env: std::collections::HashMap::new(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
 
@@ -2104,6 +2106,7 @@ mod tests {
             args: vec!["-y".into(), "@modelcontextprotocol/server-github".into()],
             env: [("GITHUB_TOKEN".into(), "ghp_test".into())].into(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::McpServers).unwrap();
 
@@ -2131,6 +2134,7 @@ mod tests {
             args: vec!["server.py".into()],
             env: Default::default(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::McpServers).unwrap();
 
@@ -2151,6 +2155,7 @@ mod tests {
             args: vec!["-y".into(), "@modelcontextprotocol/server-memory".into()],
             env: Default::default(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Servers).unwrap();
 
@@ -2177,6 +2182,7 @@ mod tests {
             args: vec!["-y".into(), "@upstash/context7-mcp".into()],
             env: [("MY_KEY".into(), "val".into())].into(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
@@ -2208,6 +2214,7 @@ mod tests {
             args: vec!["-y".into(), "@modelcontextprotocol/server-github".into()],
             env: [("GITHUB_TOKEN".into(), "ghp_test".into())].into(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
 
@@ -2248,6 +2255,7 @@ mod tests {
             args: vec!["-y".into(), "@modelcontextprotocol/server-memory".into()],
             env: Default::default(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
 
@@ -2281,6 +2289,7 @@ mod tests {
             args: vec!["server.py".into()],
             env: Default::default(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
 
@@ -2354,6 +2363,7 @@ mod tests {
             args: vec!["-y".into(), "@upstash/context7-mcp".into()],
             env: [("API_KEY".into(), "k1".into())].into(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &original, McpFormat::Opencode).unwrap();
 
@@ -2390,6 +2400,7 @@ mod tests {
             args: vec!["markitdown-mcp@0.0.1a4".into()],
             env: Default::default(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
@@ -2413,6 +2424,7 @@ mod tests {
             args: vec![],
             env: Default::default(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
@@ -2506,6 +2518,7 @@ mod tests {
             args: vec!["markitdown-mcp@0.0.1a4".into()],
             env: Default::default(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
@@ -2528,6 +2541,7 @@ mod tests {
             args: vec!["markitdown-mcp@0.0.1a4".into()],
             env: Default::default(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 
@@ -2554,6 +2568,7 @@ mod tests {
             args: vec!["markitdown-mcp@0.0.1a4".into()],
             env: Default::default(),
             enabled: true,
+            ..Default::default()
         };
         deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
 

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -1,5 +1,5 @@
 use crate::HkError;
-use crate::adapter::{HookEntry, HookFormat, McpFormat, McpServerEntry};
+use crate::adapter::{HookEntry, HookFormat, McpFormat, McpServerEntry, McpTransport, RemoteMcpSchema};
 use fs2::FileExt;
 use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::path::Path;
@@ -126,6 +126,10 @@ pub fn build_path_for_command(resolved_command: &str) -> Option<String> {
 /// so a user's manual override is never overwritten. To re-compute PATH (e.g. when
 /// repairing dirty data), remove the existing key first then call this function.
 pub fn ensure_path_injection(entry: &mut crate::adapter::McpServerEntry) {
+    // Remote entries launch no subprocess — nothing to resolve or inject.
+    if entry.transport != McpTransport::Stdio {
+        return;
+    }
     entry.command = resolve_command_path(&entry.command);
     if let Some(path_val) = build_path_for_command(&entry.command) {
         entry.env.entry("PATH".to_string()).or_insert(path_val);
@@ -157,27 +161,131 @@ fn json_top_key(format: McpFormat) -> &'static str {
 }
 
 /// Deploy an MCP server config entry into the target agent's config file.
-/// Format varies by agent — see `McpFormat`.
+/// Format varies by agent — see `McpFormat`. Remote (HTTP/SSE) entries are
+/// validated against the target's `RemoteMcpSchema` first: a target that
+/// can't express the entry's transport gets a hard error instead of a
+/// broken config (issue #105's failure mode was writing `command = ""`).
+/// The UI prevents these combinations up front via `AgentCapabilities`;
+/// this guard covers direct API callers.
 pub fn deploy_mcp_server(
     config_path: &Path,
     entry: &McpServerEntry,
-    format: McpFormat,
+    adapter: &dyn crate::adapter::AgentAdapter,
 ) -> Result<(), HkError> {
-    match format {
-        McpFormat::McpServers => deploy_mcp_server_json(config_path, entry, "mcpServers"),
-        McpFormat::Servers => deploy_mcp_server_json(config_path, entry, "servers"),
+    let remote_schema = adapter.remote_mcp_schema();
+    if entry.transport != McpTransport::Stdio {
+        validate_remote_mcp_target(entry, adapter.name(), remote_schema)?;
+    }
+    match adapter.mcp_format() {
+        McpFormat::McpServers => {
+            deploy_mcp_server_json(config_path, entry, "mcpServers", remote_schema)
+        }
+        McpFormat::Servers => deploy_mcp_server_json(config_path, entry, "servers", remote_schema),
         McpFormat::Toml => deploy_mcp_server_toml(config_path, entry),
         McpFormat::Opencode => deploy_mcp_server_opencode(config_path, entry),
         McpFormat::HermesYaml => deploy_mcp_server_hermes_yaml(config_path, entry),
     }
 }
 
-/// JSON-based MCP deploy (Claude, Gemini, Cursor, Antigravity, Copilot).
-/// `top_key` is "mcpServers" or "servers" depending on the agent.
+/// Refuse remote entries the target agent cannot load.
+fn validate_remote_mcp_target(
+    entry: &McpServerEntry,
+    agent_name: &str,
+    schema: RemoteMcpSchema,
+) -> Result<(), HkError> {
+    if entry.url.is_none() {
+        return Err(HkError::ConfigCorrupted(format!(
+            "Remote MCP server '{}' has no url",
+            entry.name
+        )));
+    }
+    match schema {
+        RemoteMcpSchema::Unsupported => Err(HkError::Validation(format!(
+            "{agent_name} does not support remote (HTTP/SSE) MCP servers"
+        ))),
+        RemoteMcpSchema::Toml if entry.transport == McpTransport::Sse => {
+            Err(HkError::Validation(format!(
+                "{agent_name} supports Streamable HTTP MCP servers only, not SSE"
+            )))
+        }
+        _ => Ok(()),
+    }
+}
+
+/// The JSON object for one server entry, in the target agent's spelling.
+fn build_mcp_json_value(
+    entry: &McpServerEntry,
+    remote: RemoteMcpSchema,
+) -> Result<serde_json::Value, HkError> {
+    if entry.transport == McpTransport::Stdio {
+        return Ok(serde_json::json!({
+            "command": entry.command,
+            "args": entry.args,
+            "env": entry.env,
+        }));
+    }
+    let url = entry.url.clone().unwrap_or_default();
+    let mut obj = serde_json::Map::new();
+    match remote {
+        RemoteMcpSchema::TypeAndUrl => {
+            let type_str = if entry.transport == McpTransport::Sse {
+                "sse"
+            } else {
+                "http"
+            };
+            obj.insert("type".into(), type_str.into());
+            obj.insert("url".into(), url.into());
+        }
+        RemoteMcpSchema::PlainUrl => {
+            obj.insert("url".into(), url.into());
+        }
+        RemoteMcpSchema::GeminiSplit => {
+            let key = if entry.transport == McpTransport::Sse {
+                "url"
+            } else {
+                "httpUrl"
+            };
+            obj.insert(key.into(), url.into());
+        }
+        RemoteMcpSchema::ServerUrl => {
+            obj.insert("serverUrl".into(), url.into());
+        }
+        // Non-JSON formats have their own writers; validation rejects
+        // Unsupported before this point. Reaching here means an adapter's
+        // mcp_format() and remote_mcp_schema() disagree — surface it as an
+        // error instead of a panic.
+        RemoteMcpSchema::Toml
+        | RemoteMcpSchema::OpencodeRemote
+        | RemoteMcpSchema::HermesUrl
+        | RemoteMcpSchema::Unsupported => {
+            return Err(HkError::Internal(format!(
+                "remote JSON value requested for non-JSON schema {remote:?}"
+            )));
+        }
+    }
+    if !entry.headers.is_empty() {
+        obj.insert(
+            "headers".into(),
+            serde_json::Value::Object(
+                entry
+                    .headers
+                    .iter()
+                    .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                    .collect(),
+            ),
+        );
+    }
+    Ok(serde_json::Value::Object(obj))
+}
+
+/// JSON-based MCP deploy (Claude, Gemini, Cursor, Antigravity, Copilot,
+/// Windsurf, Kiro, omp). `top_key` is "mcpServers" or "servers" depending
+/// on the agent; `remote` picks the agent's remote-entry spelling.
 fn deploy_mcp_server_json(
     config_path: &Path,
     entry: &McpServerEntry,
     top_key: &str,
+    remote: RemoteMcpSchema,
 ) -> Result<(), HkError> {
     locked_modify_json(config_path, |config| {
         let servers = config
@@ -185,21 +293,69 @@ fn deploy_mcp_server_json(
             .ok_or_else(|| HkError::ConfigCorrupted("Config is not an object".into()))?
             .entry(top_key)
             .or_insert_with(|| serde_json::json!({}));
-        let server_val = serde_json::json!({
-            "command": entry.command,
-            "args": entry.args,
-            "env": entry.env,
-        });
         servers
             .as_object_mut()
             .ok_or_else(|| HkError::ConfigCorrupted(format!("{} is not an object", top_key)))?
-            .insert(entry.name.clone(), server_val);
+            .insert(entry.name.clone(), build_mcp_json_value(entry, remote)?);
         Ok(())
     })
 }
 
 /// TOML-based MCP deploy (Codex: ~/.codex/config.toml with [mcp_servers.<name>]).
 fn deploy_mcp_server_toml(config_path: &Path, entry: &McpServerEntry) -> Result<(), HkError> {
+    // Build server entry table. Remote entries use url/http_headers
+    // (Codex's Streamable HTTP schema); stdio entries use command/args/env.
+    // Dispatch on transport (like the JSON writers); validation guarantees
+    // remote entries carry a url by the time a writer runs.
+    let mut server_table = toml::Table::new();
+    if entry.transport != McpTransport::Stdio {
+        let url = entry.url.clone().unwrap_or_default();
+        server_table.insert("url".into(), toml::Value::String(url));
+        if !entry.headers.is_empty() {
+            let mut headers_table = toml::Table::new();
+            for (k, v) in &entry.headers {
+                headers_table.insert(k.clone(), toml::Value::String(v.clone()));
+            }
+            server_table.insert("http_headers".into(), toml::Value::Table(headers_table));
+        }
+    } else {
+        server_table.insert("command".into(), toml::Value::String(entry.command.clone()));
+        if !entry.args.is_empty() {
+            server_table.insert(
+                "args".into(),
+                toml::Value::Array(
+                    entry
+                        .args
+                        .iter()
+                        .map(|a| toml::Value::String(a.clone()))
+                        .collect(),
+                ),
+            );
+        }
+        if !entry.env.is_empty() {
+            let mut env_table = toml::Table::new();
+            for (k, v) in &entry.env {
+                env_table.insert(k.clone(), toml::Value::String(v.clone()));
+            }
+            server_table.insert("env".into(), toml::Value::Table(env_table));
+        }
+    }
+
+    upsert_mcp_server_toml(config_path, &entry.name, toml::Value::Table(server_table))
+}
+
+/// Insert/replace `[mcp_servers.<name>]` in a TOML config, preserving the
+/// rest of the file. Shared by deploy (freshly built table) and restore
+/// (snapshot transcoded wholesale).
+///
+/// Codex requires names to match ^[a-zA-Z0-9_-]+$; sanitize before inserting.
+/// The original name is stored as `_hk_name` so the scanner can recover it
+/// for consistent grouping with other agents that use the unsanitized name.
+fn upsert_mcp_server_toml(
+    config_path: &Path,
+    name: &str,
+    mut server_val: toml::Value,
+) -> Result<(), HkError> {
     let parent = config_path
         .parent()
         .ok_or_else(|| HkError::Validation("Invalid config path".into()))?;
@@ -222,37 +378,14 @@ fn deploy_mcp_server_toml(config_path: &Path, entry: &McpServerEntry) -> Result<
         .as_table_mut()
         .ok_or_else(|| HkError::ConfigCorrupted("mcp_servers is not a table".into()))?;
 
-    // Build server entry table
-    let mut server_table = toml::Table::new();
-    server_table.insert("command".into(), toml::Value::String(entry.command.clone()));
-    if !entry.args.is_empty() {
-        server_table.insert(
-            "args".into(),
-            toml::Value::Array(
-                entry
-                    .args
-                    .iter()
-                    .map(|a| toml::Value::String(a.clone()))
-                    .collect(),
-            ),
-        );
+    let safe_name = sanitize_mcp_name(name);
+    if safe_name != name {
+        server_val
+            .as_table_mut()
+            .ok_or_else(|| HkError::ConfigCorrupted("MCP server entry is not a table".into()))?
+            .insert("_hk_name".into(), toml::Value::String(name.to_string()));
     }
-    if !entry.env.is_empty() {
-        let mut env_table = toml::Table::new();
-        for (k, v) in &entry.env {
-            env_table.insert(k.clone(), toml::Value::String(v.clone()));
-        }
-        server_table.insert("env".into(), toml::Value::Table(env_table));
-    }
-
-    // Codex requires names to match ^[a-zA-Z0-9_-]+$; sanitize before inserting.
-    // Store the original name as `_hk_name` so the scanner can recover it for
-    // consistent grouping with other agents that use the unsanitized name.
-    let safe_name = sanitize_mcp_name(&entry.name);
-    if safe_name != entry.name {
-        server_table.insert("_hk_name".into(), toml::Value::String(entry.name.clone()));
-    }
-    mcp_servers.insert(safe_name, toml::Value::Table(server_table));
+    mcp_servers.insert(safe_name, server_val);
 
     // Write back atomically
     atomic_write(
@@ -341,8 +474,21 @@ fn deploy_mcp_server_hermes_yaml(
             .as_mapping_mut()
             .ok_or_else(|| HkError::ConfigCorrupted("mcp_servers is not a mapping".into()))?;
         let mut server = serde_yaml::Mapping::new();
-        if entry.command.starts_with("http://") || entry.command.starts_with("https://") {
-            server.insert("url".into(), entry.command.clone().into());
+        if entry.transport != crate::adapter::McpTransport::Stdio {
+            // Remote: {url, headers?, transport: sse?} — Streamable HTTP
+            // is Hermes' default, so only SSE needs the transport key.
+            let url = entry.url.clone().unwrap_or_default();
+            server.insert("url".into(), url.into());
+            if entry.transport == crate::adapter::McpTransport::Sse {
+                server.insert("transport".into(), "sse".into());
+            }
+            if !entry.headers.is_empty() {
+                let mut headers = serde_yaml::Mapping::new();
+                for (k, v) in &entry.headers {
+                    headers.insert(k.clone().into(), v.clone().into());
+                }
+                server.insert("headers".into(), serde_yaml::Value::Mapping(headers));
+            }
         } else {
             server.insert("command".into(), entry.command.clone().into());
             if !entry.args.is_empty() {
@@ -692,23 +838,41 @@ fn read_hook_config_hermes_yaml(
 /// "regenerate from McpServerEntry" reference. Schema invariants are
 /// documented at the parent function — keep them in sync.
 fn build_opencode_mcp_value(entry: &McpServerEntry) -> serde_json::Value {
-    let mut command_array = vec![serde_json::Value::String(entry.command.clone())];
-    command_array.extend(entry.args.iter().cloned().map(serde_json::Value::String));
-
     let mut server_obj = serde_json::Map::new();
-    server_obj.insert("type".into(), serde_json::Value::String("local".into()));
-    server_obj.insert("command".into(), serde_json::Value::Array(command_array));
-    if !entry.env.is_empty() {
-        server_obj.insert(
-            "environment".into(),
-            serde_json::Value::Object(
-                entry
-                    .env
-                    .iter()
-                    .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-                    .collect(),
-            ),
-        );
+    if entry.transport != McpTransport::Stdio {
+        // McpRemoteConfig: {type: "remote", url, headers?}
+        let url = entry.url.clone().unwrap_or_default();
+        server_obj.insert("type".into(), serde_json::Value::String("remote".into()));
+        server_obj.insert("url".into(), serde_json::Value::String(url));
+        if !entry.headers.is_empty() {
+            server_obj.insert(
+                "headers".into(),
+                serde_json::Value::Object(
+                    entry
+                        .headers
+                        .iter()
+                        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                        .collect(),
+                ),
+            );
+        }
+    } else {
+        let mut command_array = vec![serde_json::Value::String(entry.command.clone())];
+        command_array.extend(entry.args.iter().cloned().map(serde_json::Value::String));
+        server_obj.insert("type".into(), serde_json::Value::String("local".into()));
+        server_obj.insert("command".into(), serde_json::Value::Array(command_array));
+        if !entry.env.is_empty() {
+            server_obj.insert(
+                "environment".into(),
+                serde_json::Value::Object(
+                    entry
+                        .env
+                        .iter()
+                        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                        .collect(),
+                ),
+            );
+        }
     }
     serde_json::Value::Object(server_obj)
 }
@@ -1058,39 +1222,14 @@ pub fn restore_mcp_server(
 ) -> Result<(), HkError> {
     match format {
         McpFormat::Toml => {
-            // Convert saved JSON entry back to TOML and write
-            let mcp_entry = McpServerEntry {
-                name: server_name.to_string(),
-                command: entry
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .into(),
-                args: entry
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                env: entry
-                    .get("env")
-                    .and_then(|v| v.as_object())
-                    .map(|obj| {
-                        obj.iter()
-                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                // restore happens for the same agent that originally read this
-                // entry; the value is preserved as-is. Codex (TOML) has no
-                // agent-native disable concept, so always true.
-                enabled: true,
-                ..Default::default()
-            };
-            deploy_mcp_server_toml(config_path, &mcp_entry)
+            // Transcode the saved JSON snapshot back to TOML wholesale. The
+            // snapshot is the raw on-disk table (read_mcp_server_config), so a
+            // generic conversion preserves every key — url, http_headers, and
+            // anything Codex adds later — where a field-by-field copy through
+            // McpServerEntry silently dropped unknown ones.
+            let toml_val: toml::Value = serde_json::from_value(entry.clone())
+                .map_err(|e| HkError::ConfigCorrupted(format!("saved MCP snapshot: {e}")))?;
+            upsert_mcp_server_toml(config_path, server_name, toml_val)
         }
         McpFormat::Opencode => restore_mcp_server_opencode(config_path, server_name, entry),
         McpFormat::HermesYaml => unreachable!(
@@ -1874,6 +2013,190 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// A representative adapter for each MCP format, so deploy tests can
+    /// exercise `deploy_mcp_server`'s real dispatch (format + remote schema).
+    fn test_adapter(format: McpFormat) -> Box<dyn crate::adapter::AgentAdapter> {
+        use crate::adapter::*;
+        let home = std::path::PathBuf::from("/nonexistent");
+        match format {
+            McpFormat::McpServers => Box::new(claude::ClaudeAdapter::with_home(home)),
+            McpFormat::Servers => Box::new(copilot::CopilotAdapter::with_home(home)),
+            McpFormat::Toml => Box::new(codex::CodexAdapter::with_home(home)),
+            McpFormat::Opencode => Box::new(opencode::OpencodeAdapter::with_home(home)),
+            McpFormat::HermesYaml => Box::new(hermes::HermesAdapter::with_home(home)),
+        }
+    }
+
+    fn remote_entry(transport: McpTransport) -> McpServerEntry {
+        McpServerEntry {
+            name: "linear".into(),
+            transport,
+            url: Some("https://mcp.linear.app/mcp".into()),
+            headers: [("Authorization".to_string(), "Bearer tok".to_string())].into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn build_mcp_json_value_spells_each_remote_schema() {
+        let http = remote_entry(McpTransport::Http);
+        let sse = remote_entry(McpTransport::Sse);
+
+        let v = build_mcp_json_value(&http, RemoteMcpSchema::TypeAndUrl).unwrap();
+        assert_eq!(v["type"], "http");
+        assert_eq!(v["url"], "https://mcp.linear.app/mcp");
+        assert_eq!(v["headers"]["Authorization"], "Bearer tok");
+        assert!(v.get("command").is_none());
+        assert_eq!(
+            build_mcp_json_value(&sse, RemoteMcpSchema::TypeAndUrl).unwrap()["type"],
+            "sse"
+        );
+
+        let v = build_mcp_json_value(&http, RemoteMcpSchema::PlainUrl).unwrap();
+        assert_eq!(v["url"], "https://mcp.linear.app/mcp");
+        assert!(v.get("type").is_none());
+
+        // Gemini spells the transport through the key itself.
+        let v = build_mcp_json_value(&http, RemoteMcpSchema::GeminiSplit).unwrap();
+        assert_eq!(v["httpUrl"], "https://mcp.linear.app/mcp");
+        assert!(v.get("url").is_none());
+        let v = build_mcp_json_value(&sse, RemoteMcpSchema::GeminiSplit).unwrap();
+        assert_eq!(v["url"], "https://mcp.linear.app/mcp");
+        assert!(v.get("httpUrl").is_none());
+
+        let v = build_mcp_json_value(&http, RemoteMcpSchema::ServerUrl).unwrap();
+        assert_eq!(v["serverUrl"], "https://mcp.linear.app/mcp");
+    }
+
+    #[test]
+    fn validate_remote_mcp_target_rejects_unsupported_combinations() {
+        let http = remote_entry(McpTransport::Http);
+        let sse = remote_entry(McpTransport::Sse);
+
+        let err = validate_remote_mcp_target(&http, "someagent", RemoteMcpSchema::Unsupported)
+            .unwrap_err();
+        assert!(matches!(&err, HkError::Validation(m) if m.contains("someagent")));
+
+        // Codex (TOML) is HTTP-only.
+        let err = validate_remote_mcp_target(&sse, "codex", RemoteMcpSchema::Toml).unwrap_err();
+        assert!(matches!(&err, HkError::Validation(m) if m.contains("not SSE")));
+        validate_remote_mcp_target(&http, "codex", RemoteMcpSchema::Toml).unwrap();
+
+        // Remote without url is corrupt regardless of target.
+        let mut broken = remote_entry(McpTransport::Http);
+        broken.url = None;
+        let err = validate_remote_mcp_target(&broken, "claude", RemoteMcpSchema::TypeAndUrl)
+            .unwrap_err();
+        assert!(matches!(err, HkError::ConfigCorrupted(_)));
+    }
+
+    #[test]
+    fn deploy_remote_mcp_json_end_to_end_per_agent_spelling() {
+        // Full deploy_mcp_server dispatch (validate + format + remote schema)
+        // for the JSON-family agents, not just the value builder.
+        let dir = TempDir::new().unwrap();
+
+        // Claude (TypeAndUrl): {type, url, headers} under mcpServers.
+        let config = dir.path().join("claude.json");
+        let entry = remote_entry(McpTransport::Http);
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::McpServers)).unwrap();
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+        let server = &doc["mcpServers"]["linear"];
+        assert_eq!(server["type"], "http");
+        assert_eq!(server["url"], "https://mcp.linear.app/mcp");
+        assert_eq!(server["headers"]["Authorization"], "Bearer tok");
+        assert!(server.get("command").is_none());
+
+        // Gemini (GeminiSplit): SSE entries land under `url`, not `httpUrl`.
+        let config = dir.path().join("gemini.json");
+        let sse = remote_entry(McpTransport::Sse);
+        let gemini = crate::adapter::gemini::GeminiAdapter::with_home("/nonexistent".into());
+        deploy_mcp_server(&config, &sse, &gemini).unwrap();
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+        let server = &doc["mcpServers"]["linear"];
+        assert_eq!(server["url"], "https://mcp.linear.app/mcp");
+        assert!(server.get("httpUrl").is_none());
+        assert!(server.get("type").is_none());
+
+        // Windsurf (ServerUrl): single serverUrl key regardless of protocol.
+        let config = dir.path().join("windsurf.json");
+        let windsurf = crate::adapter::windsurf::WindsurfAdapter::with_home("/nonexistent".into());
+        deploy_mcp_server(&config, &entry, &windsurf).unwrap();
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+        let server = &doc["mcpServers"]["linear"];
+        assert_eq!(server["serverUrl"], "https://mcp.linear.app/mcp");
+        assert!(server.get("url").is_none());
+    }
+
+    #[test]
+    fn deploy_remote_mcp_hermes_yaml_writes_url_headers_and_transport() {
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("config.yaml");
+        let mut entry = remote_entry(McpTransport::Sse);
+        entry.name = "stripe".into();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::HermesYaml)).unwrap();
+
+        let doc: serde_yaml::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+        let server = &doc["mcp_servers"]["stripe"];
+        assert_eq!(server["url"].as_str(), Some("https://mcp.linear.app/mcp"));
+        assert_eq!(server["transport"].as_str(), Some("sse"));
+        assert_eq!(
+            server["headers"]["Authorization"].as_str(),
+            Some("Bearer tok")
+        );
+        assert!(server.get("command").is_none());
+    }
+
+    #[test]
+    fn deploy_remote_mcp_opencode_writes_remote_type() {
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("opencode.json");
+        std::fs::write(&config, "{}").unwrap();
+        let entry = remote_entry(McpTransport::Http);
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Opencode)).unwrap();
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
+        let server = &doc["mcp"]["linear"];
+        assert_eq!(server["type"], "remote");
+        assert_eq!(server["url"], "https://mcp.linear.app/mcp");
+        assert_eq!(server["headers"]["Authorization"], "Bearer tok");
+        assert!(server.get("command").is_none());
+    }
+
+    #[test]
+    fn toml_disable_enable_roundtrip_preserves_remote_fields() {
+        // The old restore path narrowed snapshots to command/args/env,
+        // destroying url/http_headers on re-enable.
+        let dir = TempDir::new().unwrap();
+        let config = dir.path().join("config.toml");
+        let entry = remote_entry(McpTransport::Http);
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Toml)).unwrap();
+
+        let snapshot = read_mcp_server_config(&config, "linear", McpFormat::Toml)
+            .unwrap()
+            .unwrap();
+        remove_mcp_server(&config, "linear", McpFormat::Toml).unwrap();
+        restore_mcp_server(&config, "linear", &snapshot, McpFormat::Toml).unwrap();
+
+        let doc: toml::Table = std::fs::read_to_string(&config).unwrap().parse().unwrap();
+        let restored = doc["mcp_servers"]["linear"].as_table().unwrap();
+        assert_eq!(
+            restored["url"].as_str(),
+            Some("https://mcp.linear.app/mcp"),
+            "url must survive disable→enable"
+        );
+        assert_eq!(
+            restored["http_headers"]["Authorization"].as_str(),
+            Some("Bearer tok")
+        );
+        assert!(!restored.contains_key("command"));
+    }
+
     // ----- jsonc / OpenCode-specific tests -----
     // Helper tests pin `locked_modify_jsonc` round-trip and edge cases.
     // End-to-end tests pin the public MCP API (deploy/remove/restore)
@@ -2022,7 +2345,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Opencode)).unwrap();
 
         let written = std::fs::read_to_string(&config).unwrap();
         assert!(
@@ -2108,7 +2431,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::McpServers).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::McpServers)).unwrap();
 
         let content: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
@@ -2136,7 +2459,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::McpServers).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::McpServers)).unwrap();
 
         let content: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
@@ -2157,7 +2480,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Servers).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Servers)).unwrap();
 
         let content: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
@@ -2184,7 +2507,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Toml)).unwrap();
 
         let content = std::fs::read_to_string(&config).unwrap();
         let doc: toml::Table = content.parse().unwrap();
@@ -2216,7 +2539,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Opencode)).unwrap();
 
         let content: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
@@ -2257,7 +2580,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Opencode)).unwrap();
 
         let content: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
@@ -2291,7 +2614,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Opencode).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Opencode)).unwrap();
 
         let content: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&config).unwrap()).unwrap();
@@ -2365,7 +2688,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &original, McpFormat::Opencode).unwrap();
+        deploy_mcp_server(&config, &original, &*test_adapter(McpFormat::Opencode)).unwrap();
 
         let adapter = OpencodeAdapter::with_home(dir.path().to_path_buf());
         let entries = adapter.read_mcp_servers_from(&config);
@@ -2402,7 +2725,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Toml)).unwrap();
 
         let doc: toml::Table = std::fs::read_to_string(&config).unwrap().parse().unwrap();
         let servers = doc["mcp_servers"].as_table().unwrap();
@@ -2426,7 +2749,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Toml)).unwrap();
 
         let doc: toml::Table = std::fs::read_to_string(&config).unwrap().parse().unwrap();
         let server = doc["mcp_servers"]["context7"].as_table().unwrap();
@@ -2520,7 +2843,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Toml)).unwrap();
 
         // Read using the original (unsanitized) name
         let result =
@@ -2543,7 +2866,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Toml)).unwrap();
 
         // Remove using the original name
         remove_mcp_server(&config, "microsoft/markitdown", McpFormat::Toml).unwrap();
@@ -2570,7 +2893,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        deploy_mcp_server(&config, &entry, McpFormat::Toml).unwrap();
+        deploy_mcp_server(&config, &entry, &*test_adapter(McpFormat::Toml)).unwrap();
 
         // 2. Read (for saving before disable) — using original name
         let saved = read_mcp_server_config(&config, original_name, McpFormat::Toml)

--- a/crates/hk-core/src/kits/service.rs
+++ b/crates/hk-core/src/kits/service.rs
@@ -417,8 +417,9 @@ fn embed_extension(
         }
         ExtensionKind::Hook => Err(HkError::Validation(HOOK_V1_NOT_KITABLE.into())),
         ExtensionKind::Mcp => {
-            // Read via the source adapter's format-aware parser; normalize to the
-            // canonical `{command, args, env}` blob so install-side stays format-agnostic.
+            // Read via the source adapter's format-aware parser; normalize to
+            // the canonical blob ({command, args, env} plus {transport, url,
+            // headers} for remote entries) so install-side stays format-agnostic.
             let agent_name = loc.agent.as_deref().ok_or_else(|| {
                 HkError::Internal("MCP source location missing adapter binding".into())
             })?;
@@ -435,14 +436,18 @@ fn embed_extension(
                         loc.entry_path.display()
                     ))
                 })?;
-            // URL/SSE-based MCP servers leave `command` empty; only stdio is supported.
-            if entry.command.is_empty() {
+            // A valid entry is stdio (command) or remote (url); an entry with
+            // neither is a corrupt config we refuse to embed.
+            if entry.command.is_empty() && entry.url.is_none() {
                 return Err(HkError::Validation(format!(
-                    "MCP server '{ext_name}' has no 'command' (URL/SSE-based?). \
-                     Only stdio servers can be embedded in Kits."
+                    "MCP server '{ext_name}' has neither 'command' nor 'url'; \
+                     cannot be embedded in a Kit."
                 )));
             }
-            let stripped = strip_secrets_from_env(&mut entry.env);
+            // Headers carry the same class of secrets as env (Authorization
+            // bearer tokens) — strip both before the blob enters the zip.
+            let stripped = strip_secrets_from_env(&mut entry.env)
+                | strip_secrets_from_env(&mut entry.headers);
             let bytes = serde_json::to_vec_pretty(&entry)
                 .map_err(|e| HkError::Internal(format!("serialize mcp entry: {e}")))?;
             let asset_path = format!("{asset_prefix}mcp.json");
@@ -962,12 +967,10 @@ fn apply_extension_item(
             let mut entry_struct: McpServerEntry = serde_json::from_slice(&entry_bytes)
                 .map_err(|e| HkError::ConfigCorrupted(format!("mcp entry json: {e}")))?;
             entry_struct.name = asset_name.clone();
-            let mcp_format = adapter_for_agent(adapters, agent_name)
-                .ok_or_else(|| {
-                    HkError::NotFound(format!("Agent '{}' not found", agent_name))
-                })?
-                .mcp_format();
-            crate::deployer::deploy_mcp_server(&item.target_path, &entry_struct, mcp_format)?;
+            let adapter = adapter_for_agent(adapters, agent_name).ok_or_else(|| {
+                HkError::NotFound(format!("Agent '{}' not found", agent_name))
+            })?;
+            crate::deployer::deploy_mcp_server(&item.target_path, &entry_struct, adapter)?;
             // "mcp:<config_path>:<server_name>" lets unsync target only this entry.
             Ok(Some(format!(
                 "mcp:{}:{}",

--- a/crates/hk-core/src/kits/tests/migration_v5.rs
+++ b/crates/hk-core/src/kits/tests/migration_v5.rs
@@ -6,7 +6,7 @@ fn migrate_creates_kit_tables() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("hk.db");
     let store = Store::open(&db_path).unwrap();
-    assert_eq!(store.schema_version().unwrap(), 8);
+    assert_eq!(store.schema_version().unwrap(), 9);
 
     let conn = store.conn_for_test();
     let names: Vec<String> = conn
@@ -43,6 +43,6 @@ fn migrate_is_idempotent() {
     let _store = Store::open(&db_path).unwrap();
     // Re-open to re-run migration logic
     let store = Store::open(&db_path).unwrap();
-    assert_eq!(store.schema_version().unwrap(), 8);
+    assert_eq!(store.schema_version().unwrap(), 9);
 }
 

--- a/crates/hk-core/src/kits/tests/service.rs
+++ b/crates/hk-core/src/kits/tests/service.rs
@@ -1134,6 +1134,7 @@ fn make_skill_ext(
         cli_meta: None,
         install_meta: None,
         scope: ConfigScope::Global,
+        mcp_transport: None,
     }
 }
 
@@ -1316,6 +1317,7 @@ fn insert_kit_asset(
         cli_meta: None,
         install_meta: None,
         scope: ConfigScope::Global,
+        mcp_transport: None,
     };
     let g = store.lock();
     g.insert_extension(&ext).unwrap();

--- a/crates/hk-core/src/kits/tests/service.rs
+++ b/crates/hk-core/src/kits/tests/service.rs
@@ -1429,6 +1429,7 @@ fn mcp_server_entry_serde_round_trip() {
         args: vec!["server.js".to_string()],
         env,
         enabled: true,
+        ..Default::default()
     };
 
     // Canonical Kit blob omits name/enabled — install side supplies name from

--- a/crates/hk-core/src/manager.rs
+++ b/crates/hk-core/src/manager.rs
@@ -1272,6 +1272,7 @@ mod tests {
             cli_meta: None,
             install_meta: None,
             scope: ConfigScope::Global,
+            mcp_transport: None,
         };
         store.insert_extension(&ext).unwrap();
 
@@ -1319,6 +1320,7 @@ mod tests {
             cli_meta: None,
             install_meta: None,
             scope: ConfigScope::Global,
+            mcp_transport: None,
         };
         store.insert_extension(&ext).unwrap();
 
@@ -1381,6 +1383,7 @@ mod tests {
             cli_meta: None,
             install_meta: None,
             scope: ConfigScope::Global,
+            mcp_transport: None,
         };
         store.insert_extension(&ext).unwrap();
 
@@ -2051,6 +2054,7 @@ mod tests {
             cli_meta: None,
             install_meta: None,
             scope: ConfigScope::Global,
+            mcp_transport: None,
         }
     }
 
@@ -2813,6 +2817,7 @@ mod tests {
             cli_meta: None,
             install_meta: None,
             scope,
+            mcp_transport: None,
         };
         store
             .insert_extension(&make_ext(

--- a/crates/hk-core/src/manager.rs
+++ b/crates/hk-core/src/manager.rs
@@ -5,11 +5,12 @@ use crate::{adapter, deployer, sanitize, scanner};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Field names under which an MCP server entry stores its environment-variable
-/// block. Most agents use `"env"`; OpenCode's schema names the same block
-/// `"environment"`. Centralized so secret-handling code (redaction, restore
-/// warnings) stays format-agnostic.
-const MCP_ENV_KEYS: [&str; 2] = ["env", "environment"];
+/// Field names under which an MCP server entry stores a secret-bearing
+/// string map. Most agents use `"env"`; OpenCode's schema names the same
+/// block `"environment"`. Remote entries carry auth in `"headers"` (JSON/
+/// YAML agents) or `"http_headers"` (Codex TOML). Centralized so
+/// secret-handling code (redaction, restore warnings) stays format-agnostic.
+const MCP_SECRET_BLOCK_KEYS: [&str; 4] = ["env", "environment", "headers", "http_headers"];
 
 #[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct InstallResult {
@@ -218,7 +219,11 @@ fn toggle_mcp(
             // with secrets. For agents where HarnessKit injects PATH (see
             // AgentAdapter::needs_path_injection), recompute and overwrite PATH so
             // the restored config is actually usable.
+            // Remote entries (url-based) launch no subprocess, so there is
+            // no PATH to repair — gate explicitly rather than relying on
+            // them never carrying an env block.
             let needs_path_repair = a.needs_path_injection()
+                && entry.get("url").is_none()
                 && entry
                     .get("env")
                     .and_then(|env| env.get("PATH"))
@@ -237,28 +242,26 @@ fn toggle_mcp(
                     env_obj.insert("PATH".into(), serde_json::Value::String(path_val));
                 }
             }
-            // Warn about redacted env values — server will be restored but
-            // the user needs to manually set the real values in the config.
+            // Warn about redacted env/header values — server will be restored
+            // but the user needs to manually set the real values in the config.
             // PATH is excluded: it is auto-injected, not a secret, and is
             // self-healed above for antigravity.
-            for env_key in MCP_ENV_KEYS {
-                let Some(env_obj) = entry.get(env_key).and_then(|v| v.as_object()) else {
-                    continue;
-                };
-                let redacted_keys: Vec<&str> = env_obj
-                    .iter()
-                    .filter(|(k, v)| k.as_str() != "PATH" && v.as_str() == Some("<redacted>"))
-                    .map(|(k, _)| k.as_str())
-                    .collect();
-                if !redacted_keys.is_empty() {
-                    eprintln!(
-                        "[hk] warning: MCP server '{}' has redacted environment variables ({}) — \
-                         the server has been re-enabled but you must set the real values in the agent config",
-                        ext.name,
-                        redacted_keys.join(", ")
-                    );
-                }
-                break; // each entry has at most one env block — stop on first hit
+            let redacted_keys: Vec<String> = MCP_SECRET_BLOCK_KEYS
+                .iter()
+                .filter_map(|block| entry.get(block).and_then(|v| v.as_object()))
+                .flat_map(|obj| {
+                    obj.iter()
+                        .filter(|(k, v)| k.as_str() != "PATH" && v.as_str() == Some("<redacted>"))
+                        .map(|(k, _)| k.clone())
+                })
+                .collect();
+            if !redacted_keys.is_empty() {
+                eprintln!(
+                    "[hk] warning: MCP server '{}' has redacted environment variables or headers ({}) — \
+                     the server has been re-enabled but you must set the real values in the agent config",
+                    ext.name,
+                    redacted_keys.join(", ")
+                );
             }
             deployer::restore_mcp_server(&config_path, &ext.name, &entry, format)?;
             store.set_disabled_config(&ext.id, None)?;
@@ -277,15 +280,16 @@ fn toggle_mcp(
     Ok(())
 }
 
-/// Redact environment variable values in an MCP server config entry.
-/// Replaces all values inside the env-block object with "<redacted>" while
-/// preserving keys. This prevents secrets (API keys, tokens, etc.) from being
+/// Redact secret-bearing values in an MCP server config entry. Replaces all
+/// values inside env and header blocks with "<redacted>" while preserving
+/// keys. This prevents secrets (API keys, bearer tokens, etc.) from being
 /// stored in the harnesskit SQLite database when an MCP server is disabled.
 ///
-/// Two block names are handled: most agents use `"env"`, while OpenCode's
-/// schema names the same block `"environment"`. Only one will be present per
-/// entry, so iterating both keeps this helper format-agnostic without needing
-/// to thread `McpFormat` through every caller.
+/// The block names in `MCP_SECRET_BLOCK_KEYS` cover every format's spelling
+/// (`env`/`environment` for stdio, `headers`/`http_headers` for remote); at
+/// most one env and one header block is present per entry, so iterating all
+/// keeps this helper format-agnostic without needing to thread `McpFormat`
+/// through every caller.
 ///
 /// `PATH` is excluded — HarnessKit auto-injects it for agents whose
 /// `needs_path_injection()` returns true (see install.rs). It is an operational
@@ -293,9 +297,9 @@ fn toggle_mcp(
 /// can find its binary again.
 fn redact_mcp_env(entry: &serde_json::Value) -> serde_json::Value {
     let mut redacted = entry.clone();
-    for env_key in MCP_ENV_KEYS {
-        if let Some(env_obj) = redacted.get_mut(env_key).and_then(|v| v.as_object_mut()) {
-            for (key, value) in env_obj.iter_mut() {
+    for block_key in MCP_SECRET_BLOCK_KEYS {
+        if let Some(obj) = redacted.get_mut(block_key).and_then(|v| v.as_object_mut()) {
+            for (key, value) in obj.iter_mut() {
                 if key == "PATH" {
                     continue;
                 }
@@ -1960,6 +1964,28 @@ mod tests {
         assert_eq!(redacted["command"][0], "npx");
     }
 
+    #[test]
+    fn test_redact_mcp_env_covers_remote_header_blocks() {
+        // Remote MCP entries carry auth in `headers` (JSON/YAML agents) or
+        // `http_headers` (Codex TOML). Without redaction, disabling a remote
+        // server would store the bearer token in plaintext in SQLite.
+        let json_entry = serde_json::json!({
+            "type": "http",
+            "url": "https://mcp.linear.app/mcp",
+            "headers": {"Authorization": "Bearer realsecret"}
+        });
+        let redacted = super::redact_mcp_env(&json_entry);
+        assert_eq!(redacted["headers"]["Authorization"], "<redacted>");
+        assert_eq!(redacted["url"], "https://mcp.linear.app/mcp");
+
+        let toml_entry = serde_json::json!({
+            "url": "https://mcp.figma.com/mcp",
+            "http_headers": {"X-Api-Key": "realsecret"}
+        });
+        let redacted = super::redact_mcp_env(&toml_entry);
+        assert_eq!(redacted["http_headers"]["X-Api-Key"], "<redacted>");
+    }
+
     #[cfg(unix)]
     #[test]
     fn test_copy_dir_contents_skips_symlinks_with_recheck() {
@@ -2236,6 +2262,62 @@ mod tests {
     /// Lives here (not tests/toggle_integration.rs) because the redirectable
     /// `HermesAdapter::with_home` constructor is `#[cfg(test)]`-gated and so is
     /// only reachable from the crate's own unit tests, not integration tests.
+    #[test]
+    fn test_remote_mcp_disable_redacts_headers_and_enable_keeps_url() {
+        // Remote (HTTP) MCP disable→enable: the DB snapshot must never hold
+        // the bearer token in plaintext, and the url must survive the trip.
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        std::fs::write(
+            home.join(".claude.json"),
+            r#"{"mcpServers":{"linear":{"type":"http","url":"https://mcp.linear.app/mcp",
+                "headers":{"Authorization":"Bearer realsecret"}}}}"#,
+        )
+        .unwrap();
+
+        let store = crate::store::Store::open(&dir.path().join("test.db")).unwrap();
+        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![Box::new(
+            adapter::claude::ClaudeAdapter::with_home(home.to_path_buf()),
+        )];
+
+        let scanned = scanner::scan_mcp_servers(&*adapters[0]);
+        store.sync_extensions(&scanned).unwrap();
+        let ext = store
+            .list_extensions(Some(ExtensionKind::Mcp), None)
+            .unwrap()
+            .into_iter()
+            .find(|e| e.name == "linear")
+            .expect("linear mcp scanned");
+
+        // DISABLE — entry removed from config, snapshot redacted in DB.
+        toggle_extension_with_adapters(&store, &adapters, &ext.id, false).unwrap();
+        let config = std::fs::read_to_string(home.join(".claude.json")).unwrap();
+        assert!(!config.contains("linear"), "entry removed on disable");
+        let snapshot = store
+            .get_disabled_config(&ext.id)
+            .unwrap()
+            .expect("snapshot taken");
+        assert!(
+            !snapshot.contains("realsecret"),
+            "bearer token must not reach the DB in plaintext: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("<redacted>") && snapshot.contains("https://mcp.linear.app/mcp"),
+            "snapshot keeps structure + url: {snapshot}"
+        );
+
+        // ENABLE — url restored intact, header value stays redacted (the
+        // user is warned to re-set it; the secret itself is gone by design).
+        toggle_extension_with_adapters(&store, &adapters, &ext.id, true).unwrap();
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(home.join(".claude.json")).unwrap())
+                .unwrap();
+        let entry = &doc["mcpServers"]["linear"];
+        assert_eq!(entry["url"], "https://mcp.linear.app/mcp");
+        assert_eq!(entry["type"], "http");
+        assert_eq!(entry["headers"]["Authorization"], "<redacted>");
+    }
+
     #[test]
     fn test_hermes_mcp_native_disable_enable_in_place() {
         let dir = TempDir::new().unwrap();

--- a/crates/hk-core/src/models.rs
+++ b/crates/hk-core/src/models.rs
@@ -32,6 +32,11 @@ pub struct Extension {
     /// Global for backwards compatibility with rows scanned before scope tracking.
     #[serde(default = "default_scope_global")]
     pub scope: ConfigScope,
+    /// MCP rows only: the server's transport (stdio/http/sse), so the UI can
+    /// gate install targets by `AgentCapabilities.mcp_remote`. `None` for
+    /// non-MCP kinds and for rows scanned before transport tracking.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_transport: Option<crate::adapter::McpTransport>,
 }
 
 fn default_scope_global() -> ConfigScope {
@@ -361,6 +366,18 @@ pub struct AgentCapabilities {
     /// Whether user-level (global) hook install works upstream
     /// (false only for Kiro today, kirodotdev/Kiro#5440).
     pub global_hook_install: bool,
+    /// Which remote MCP transports the agent's config can express
+    /// (derived from `AgentAdapter::remote_mcp_schema`). Gates installing
+    /// http/sse MCP servers to this agent.
+    #[serde(default)]
+    pub mcp_remote: RemoteTransportFlags,
+}
+
+/// Remote MCP transports an agent supports. Both false = stdio-only.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct RemoteTransportFlags {
+    pub http: bool,
+    pub sse: bool,
 }
 
 // --- Dashboard Stats ---

--- a/crates/hk-core/src/scanner.rs
+++ b/crates/hk-core/src/scanner.rs
@@ -1,4 +1,4 @@
-use crate::adapter::AgentAdapter;
+use crate::adapter::{AgentAdapter, McpTransport};
 use crate::models::*;
 use chrono::{DateTime, Utc};
 use regex::Regex;
@@ -240,6 +240,7 @@ pub fn scan_skill_dir(dir: &Path, agent_name: &str) -> Vec<Extension> {
             cli_meta: None,
             install_meta: None,
             scope: ConfigScope::Global,
+            mcp_transport: None,
         });
     }
     extensions
@@ -255,77 +256,10 @@ pub fn scan_mcp_servers(adapter: &dyn AgentAdapter) -> Vec<Extension> {
         .read_mcp_servers()
         .into_iter()
         .map(|server| {
-            let cmd_basename = Path::new(&server.command)
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string();
-
-            let mut permissions = Vec::new();
-            if !server.env.is_empty() {
-                permissions.push(Permission::Env {
-                    keys: server.env.keys().cloned().collect(),
-                });
-            }
-            permissions.push(Permission::Shell {
-                commands: vec![cmd_basename.clone()],
-            });
-            if cmd_basename == "npx" || cmd_basename == "uvx" {
-                permissions.push(Permission::Network {
-                    domains: vec!["*".into()],
-                });
+            let (permissions, description) = if server.transport != McpTransport::Stdio {
+                mcp_remote_profile(&server)
             } else {
-                let domains: Vec<String> = server
-                    .args
-                    .iter()
-                    .flat_map(|a| SKILL_URL_DOMAINS.captures_iter(a).map(|c| c[1].to_string()))
-                    .collect::<HashSet<_>>()
-                    .into_iter()
-                    .collect();
-                if !domains.is_empty() {
-                    permissions.push(Permission::Network { domains });
-                }
-            }
-
-            // Extract filesystem paths from args (e.g. /Users/zoe/projects or ~/workspace)
-            let fs_paths: Vec<String> = server
-                .args
-                .iter()
-                .filter(|a| {
-                    (a.starts_with('/')
-                        || a.starts_with("~/")
-                        || crate::sanitize::is_windows_abs_path(a))
-                        && !a.starts_with("//")
-                })
-                .cloned()
-                .collect::<HashSet<_>>()
-                .into_iter()
-                .collect();
-            if !fs_paths.is_empty() {
-                permissions.push(Permission::FileSystem { paths: fs_paths });
-            }
-
-            // Build a human-readable description from the command
-            let description = if cmd_basename == "npx" || cmd_basename == "uvx" {
-                // Show the package name (usually the last meaningful arg)
-                let pkg = server.args.iter().rfind(|a| !a.starts_with('-'));
-                match pkg {
-                    Some(p) => format!("Runs {} via {}", p, cmd_basename),
-                    None => format!("Runs via {}", cmd_basename),
-                }
-            } else {
-                let args_summary: Vec<&str> = server
-                    .args
-                    .iter()
-                    .filter(|a| !a.starts_with('-'))
-                    .map(|s| s.as_str())
-                    .take(2)
-                    .collect();
-                if args_summary.is_empty() {
-                    format!("Runs {}", cmd_basename)
-                } else {
-                    format!("Runs {} {}", cmd_basename, args_summary.join(" "))
-                }
+                mcp_stdio_profile(&server)
             };
 
             // If server name looks like "owner/repo", derive GitHub source link
@@ -383,9 +317,126 @@ pub fn scan_mcp_servers(adapter: &dyn AgentAdapter) -> Vec<Extension> {
                 cli_meta: None,
                 install_meta: None,
                 scope: ConfigScope::Global,
+                mcp_transport: Some(server.transport),
             }
         })
         .collect()
+}
+
+/// Permission profile + description for a remote (HTTP/SSE) MCP server:
+/// no subprocess, no filesystem — just the network endpoint (and any
+/// header keys, surfaced like env keys since both can carry credentials).
+fn mcp_remote_profile(server: &crate::adapter::McpServerEntry) -> (Vec<Permission>, String) {
+    let mut permissions = Vec::new();
+    if !server.headers.is_empty() {
+        permissions.push(Permission::Env {
+            keys: server.headers.keys().cloned().collect(),
+        });
+    }
+    let url = server.url.as_deref().unwrap_or_default();
+    let authority = url
+        .split("://")
+        .nth(1)
+        .unwrap_or(url)
+        .split('/')
+        .next()
+        .unwrap_or_default();
+    // Drop any userinfo (`user:pass@host`) so credentials embedded in the
+    // URL never leak into the permission list or description.
+    let host = authority
+        .rsplit('@')
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    permissions.push(Permission::Network {
+        domains: vec![if host.is_empty() { "*".into() } else { host.clone() }],
+    });
+    let label = match server.transport {
+        crate::adapter::McpTransport::Sse => "SSE",
+        _ => "HTTP",
+    };
+    let description = if host.is_empty() {
+        format!("Remote MCP server ({label})")
+    } else {
+        format!("Remote MCP server at {host} ({label})")
+    };
+    (permissions, description)
+}
+
+/// Permission profile + description for a stdio MCP server, derived from
+/// its command line.
+fn mcp_stdio_profile(server: &crate::adapter::McpServerEntry) -> (Vec<Permission>, String) {
+    let cmd_basename = Path::new(&server.command)
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    let mut permissions = Vec::new();
+    if !server.env.is_empty() {
+        permissions.push(Permission::Env {
+            keys: server.env.keys().cloned().collect(),
+        });
+    }
+    permissions.push(Permission::Shell {
+        commands: vec![cmd_basename.clone()],
+    });
+    if cmd_basename == "npx" || cmd_basename == "uvx" {
+        permissions.push(Permission::Network {
+            domains: vec!["*".into()],
+        });
+    } else {
+        let domains: Vec<String> = server
+            .args
+            .iter()
+            .flat_map(|a| SKILL_URL_DOMAINS.captures_iter(a).map(|c| c[1].to_string()))
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        if !domains.is_empty() {
+            permissions.push(Permission::Network { domains });
+        }
+    }
+
+    // Extract filesystem paths from args (e.g. /Users/zoe/projects or ~/workspace)
+    let fs_paths: Vec<String> = server
+        .args
+        .iter()
+        .filter(|a| {
+            (a.starts_with('/') || a.starts_with("~/") || crate::sanitize::is_windows_abs_path(a))
+                && !a.starts_with("//")
+        })
+        .cloned()
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    if !fs_paths.is_empty() {
+        permissions.push(Permission::FileSystem { paths: fs_paths });
+    }
+
+    // Build a human-readable description from the command
+    let description = if cmd_basename == "npx" || cmd_basename == "uvx" {
+        // Show the package name (usually the last meaningful arg)
+        let pkg = server.args.iter().rfind(|a| !a.starts_with('-'));
+        match pkg {
+            Some(p) => format!("Runs {} via {}", p, cmd_basename),
+            None => format!("Runs via {}", cmd_basename),
+        }
+    } else {
+        let args_summary: Vec<&str> = server
+            .args
+            .iter()
+            .filter(|a| !a.starts_with('-'))
+            .map(|s| s.as_str())
+            .take(2)
+            .collect();
+        if args_summary.is_empty() {
+            format!("Runs {}", cmd_basename)
+        } else {
+            format!("Runs {} {}", cmd_basename, args_summary.join(" "))
+        }
+    };
+    (permissions, description)
 }
 
 /// Scan hooks from an agent adapter
@@ -437,6 +488,7 @@ pub fn scan_hooks(adapter: &dyn AgentAdapter) -> Vec<Extension> {
                         cli_meta: None,
                         install_meta: None,
                         scope: ConfigScope::Global,
+                        mcp_transport: None,
                     }
                 })
         })
@@ -527,6 +579,7 @@ pub fn scan_plugins(adapter: &dyn AgentAdapter) -> Vec<Extension> {
                 cli_meta: None,
                 install_meta: None,
                 scope: ConfigScope::Global,
+                mcp_transport: None,
             }
         })
         .collect()
@@ -921,6 +974,7 @@ fn scan_cli_binaries(
             }),
             install_meta: None,
             scope: ConfigScope::Global,
+            mcp_transport: None,
         });
     }
 
@@ -991,30 +1045,12 @@ pub fn scan_project_extensions(
         let config_created = file_created_time(&mcp_path);
         let config_modified = file_modified_time(&mcp_path);
         for server in adapter.read_mcp_servers_from(&mcp_path) {
-            let cmd_basename = Path::new(&server.command)
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string();
-
-            let mut permissions = Vec::new();
-            if !server.env.is_empty() {
-                permissions.push(Permission::Env {
-                    keys: server.env.keys().cloned().collect(),
-                });
-            }
-            permissions.push(Permission::Shell {
-                commands: vec![cmd_basename.clone()],
-            });
-
-            let description = if cmd_basename == "npx" || cmd_basename == "uvx" {
-                let pkg = server.args.iter().rfind(|a| !a.starts_with('-'));
-                match pkg {
-                    Some(p) => format!("Runs {} via {}", p, cmd_basename),
-                    None => format!("Runs via {}", cmd_basename),
-                }
+            // Same permission/description profiles as the global scan, so
+            // remote entries surface identically in both scopes.
+            let (permissions, description) = if server.transport != McpTransport::Stdio {
+                mcp_remote_profile(&server)
             } else {
-                format!("Runs {}", cmd_basename)
+                mcp_stdio_profile(&server)
             };
 
             let id = stable_id_with_scope(&server.name, "mcp", adapter.name(), &scope);
@@ -1049,6 +1085,7 @@ pub fn scan_project_extensions(
                 cli_meta: None,
                 install_meta: None,
                 scope: scope.clone(),
+                mcp_transport: Some(server.transport),
             });
         }
     }
@@ -1093,6 +1130,7 @@ pub fn scan_project_extensions(
                     cli_meta: None,
                     install_meta: None,
                     scope: scope.clone(),
+                    mcp_transport: None,
                 });
             }
         }
@@ -2318,6 +2356,55 @@ mod tests {
         if let Some(Permission::FileSystem { paths }) = fs_perm {
             assert_eq!(paths, &vec!["/Users/zoe/projects".to_string()]);
         }
+    }
+
+    #[test]
+    fn test_mcp_remote_server_profile() {
+        // Remote entries get a Network permission for their host (not an
+        // empty Shell permission), header keys surfaced like env keys, a
+        // host-based description, and the transport recorded on the row.
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join(".claude.json"),
+            r#"{"mcpServers":{"linear":{"type":"http","url":"https://mcp.linear.app/mcp",
+                "headers":{"Authorization":"Bearer tok"}}}}"#,
+        )
+        .unwrap();
+        let adapter = crate::adapter::claude::ClaudeAdapter::with_home(dir.path().to_path_buf());
+        let extensions = scan_mcp_servers(&adapter);
+        assert_eq!(extensions.len(), 1);
+        let ext = &extensions[0];
+
+        assert_eq!(ext.mcp_transport, Some(McpTransport::Http));
+        assert!(
+            ext.description.contains("mcp.linear.app"),
+            "{}",
+            ext.description
+        );
+        assert!(
+            !ext.permissions
+                .iter()
+                .any(|p| matches!(p, Permission::Shell { .. })),
+            "remote servers spawn no subprocess"
+        );
+        let net = ext
+            .permissions
+            .iter()
+            .find_map(|p| match p {
+                Permission::Network { domains } => Some(domains.clone()),
+                _ => None,
+            })
+            .expect("Network permission");
+        assert_eq!(net, vec!["mcp.linear.app".to_string()]);
+        let env_keys = ext
+            .permissions
+            .iter()
+            .find_map(|p| match p {
+                Permission::Env { keys } => Some(keys.clone()),
+                _ => None,
+            })
+            .expect("header keys surfaced");
+        assert_eq!(env_keys, vec!["Authorization".to_string()]);
     }
 
     #[test]

--- a/crates/hk-core/src/service.rs
+++ b/crates/hk-core/src/service.rs
@@ -1363,7 +1363,7 @@ pub fn install_to_agent(
                         "{target_agent} does not support project-level MCP servers"
                     ))
                 })?;
-            deployer::deploy_mcp_server(&config_path, &entry, target_adapter.mcp_format())?;
+            deployer::deploy_mcp_server(&config_path, &entry, target_adapter.as_ref())?;
             Ok(entry.name)
         }
         ExtensionKind::Hook => {
@@ -2847,6 +2847,87 @@ mod tests {
         assert!(
             matches!(&err, HkError::Validation(msg) if msg.contains("no skill directory")),
             "hermes has no project-level skills (hermes-agent#4667), got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_install_to_agent_remote_mcp_claude_to_codex() {
+        // Issue #105 repro: `claude mcp add --transport http linear <url>`
+        // then install to Codex must produce `url = "..."`, not `command = ""`.
+        use crate::adapter;
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let store = Mutex::new(Store::open(&home.join("test.db")).unwrap());
+
+        std::fs::write(
+            home.join(".claude.json"),
+            r#"{"mcpServers":{
+                "linear":{"type":"http","url":"https://mcp.linear.app/mcp",
+                          "headers":{"Authorization":"Bearer tok"}},
+                "events":{"type":"sse","url":"https://example.com/sse"}
+            }}"#,
+        )
+        .unwrap();
+        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![
+            Box::new(adapter::claude::ClaudeAdapter::with_home(
+                home.to_path_buf(),
+            )),
+            Box::new(adapter::codex::CodexAdapter::with_home(home.to_path_buf())),
+        ];
+        let seed = |name: &str| {
+            let id = scanner::stable_id_for(name, "mcp", "claude");
+            let mut ext = make_skill(ConfigScope::Global, None);
+            ext.id = id.clone();
+            ext.kind = ExtensionKind::Mcp;
+            ext.name = name.into();
+            ext.source_path = None;
+            store.lock().insert_extension(&ext).unwrap();
+            id
+        };
+
+        let linear_id = seed("linear");
+        install_to_agent(
+            &store,
+            &adapters,
+            &linear_id,
+            "codex",
+            None,
+            &ConfigScope::Global,
+        )
+        .unwrap();
+        let toml_str =
+            std::fs::read_to_string(home.join(".codex").join("config.toml")).unwrap();
+        let doc: toml::Table = toml_str.parse().unwrap();
+        let entry = doc["mcp_servers"]["linear"].as_table().unwrap();
+        assert_eq!(
+            entry["url"].as_str(),
+            Some("https://mcp.linear.app/mcp"),
+            "remote install must write url, got: {toml_str}"
+        );
+        assert_eq!(
+            entry["http_headers"]["Authorization"].as_str(),
+            Some("Bearer tok")
+        );
+        assert!(
+            !entry.contains_key("command"),
+            "no empty command key for remote entries: {toml_str}"
+        );
+
+        // Codex has no SSE support — refuse instead of writing a dead config.
+        let sse_id = seed("events");
+        let err = install_to_agent(
+            &store,
+            &adapters,
+            &sse_id,
+            "codex",
+            None,
+            &ConfigScope::Global,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(&err, HkError::Validation(msg) if msg.contains("not SSE")),
+            "expected SSE rejection for codex, got: {err:?}"
         );
     }
 

--- a/crates/hk-core/src/service.rs
+++ b/crates/hk-core/src/service.rs
@@ -527,6 +527,10 @@ pub fn audit_extensions(
                             cmd = Some(server.command);
                             args = server.args;
                             env = server.env;
+                            // Remote entries carry their secrets in headers,
+                            // not env — merge them in so the secret-scanning
+                            // audit rules cover Authorization tokens too.
+                            env.extend(server.headers);
                             break;
                         }
                     }
@@ -1127,10 +1131,25 @@ pub fn get_extension_content(
                         &ext.scope,
                     );
                     if candidate == id {
-                        let mut lines = vec![format!("Command: {}", server.command)];
-                        if !server.args.is_empty() {
-                            lines.push(format!("Args: {}", server.args.join(" ")));
-                        }
+                        let mut lines = if let Some(url) = &server.url {
+                            let mut lines = vec![
+                                format!("Transport: {}", server.transport.as_str()),
+                                format!("URL: {}", url),
+                            ];
+                            if !server.headers.is_empty() {
+                                lines.push("Headers:".into());
+                                for k in server.headers.keys() {
+                                    lines.push(format!("  {} = ****", k));
+                                }
+                            }
+                            lines
+                        } else {
+                            let mut lines = vec![format!("Command: {}", server.command)];
+                            if !server.args.is_empty() {
+                                lines.push(format!("Args: {}", server.args.join(" ")));
+                            }
+                            lines
+                        };
                         if !server.env.is_empty() {
                             lines.push("Environment:".into());
                             for k in server.env.keys() {
@@ -1511,6 +1530,7 @@ mod tests {
             source_path: None,
             cli_parent_id: None,
             cli_meta: None,
+            mcp_transport: None,
         }
     }
 
@@ -1957,6 +1977,7 @@ mod tests {
             cli_meta: None,
             install_meta: Some(install_meta.clone()),
             scope: ConfigScope::Global,
+            mcp_transport: None,
         };
         store.lock().insert_extension(&source_ext).unwrap();
 
@@ -2061,6 +2082,7 @@ mod tests {
             cli_meta: None,
             install_meta: None,
             scope: ConfigScope::Global,
+            mcp_transport: None,
         };
         store.lock().insert_extension(&source_ext).unwrap();
 
@@ -2184,6 +2206,7 @@ mod tests {
                 cli_meta: None,
                 install_meta: Some(install_meta.clone()),
                 scope: ConfigScope::Global,
+                mcp_transport: None,
             })
             .unwrap();
 

--- a/crates/hk-core/src/store.rs
+++ b/crates/hk-core/src/store.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use crate::models::*;
 
 /// Latest schema version supported by this binary.
-const LATEST_SCHEMA_VERSION: i64 = 8;
+const LATEST_SCHEMA_VERSION: i64 = 9;
 
 /// One row of `custom_config_paths`: (id, path, label, category, scope_json).
 /// `scope_json` is `None` for legacy rows that predate v4 schema migration.
@@ -75,8 +75,8 @@ fn skill_entry_path(source_path: &str) -> &Path {
 /// Upsert SQL for scanner-derived extensions (18 columns, no install meta).
 /// Used by `sync_extensions` and `sync_extensions_for_agent`.
 const UPSERT_EXTENSION_SQL: &str =
-    "INSERT INTO extensions (id, kind, name, description, source_json, agents_json, tags_json, permissions_json, enabled, trust_score, installed_at, updated_at, category, source_path, cli_parent_id, cli_meta_json, pack, scope_json)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+    "INSERT INTO extensions (id, kind, name, description, source_json, agents_json, tags_json, permissions_json, enabled, trust_score, installed_at, updated_at, category, source_path, cli_parent_id, cli_meta_json, pack, scope_json, mcp_transport)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
      ON CONFLICT(id) DO UPDATE SET
        kind = excluded.kind,
        name = excluded.name,
@@ -91,13 +91,14 @@ const UPSERT_EXTENSION_SQL: &str =
        source_path = excluded.source_path,
        cli_parent_id = excluded.cli_parent_id,
        cli_meta_json = excluded.cli_meta_json,
-       scope_json = excluded.scope_json
+       scope_json = excluded.scope_json,
+       mcp_transport = excluded.mcp_transport
        /* install meta columns intentionally excluded — preserved across re-scans */";
 
 /// Full upsert SQL for `insert_extension` (27 columns, includes install meta).
 const UPSERT_EXTENSION_FULL_SQL: &str =
-    "INSERT INTO extensions (id, kind, name, description, source_json, agents_json, tags_json, permissions_json, enabled, trust_score, installed_at, updated_at, category, source_path, cli_parent_id, cli_meta_json, install_type, install_url, install_url_resolved, install_branch, install_subpath, install_revision, remote_revision, checked_at, check_error, pack, scope_json)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)
+    "INSERT INTO extensions (id, kind, name, description, source_json, agents_json, tags_json, permissions_json, enabled, trust_score, installed_at, updated_at, category, source_path, cli_parent_id, cli_meta_json, install_type, install_url, install_url_resolved, install_branch, install_subpath, install_revision, remote_revision, checked_at, check_error, pack, scope_json, mcp_transport)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28)
      ON CONFLICT(id) DO UPDATE SET
        kind = excluded.kind,
        name = excluded.name,
@@ -112,7 +113,8 @@ const UPSERT_EXTENSION_FULL_SQL: &str =
        source_path = excluded.source_path,
        cli_parent_id = excluded.cli_parent_id,
        cli_meta_json = excluded.cli_meta_json,
-       scope_json = excluded.scope_json";
+       scope_json = excluded.scope_json,
+       mcp_transport = excluded.mcp_transport";
 
 pub struct Store {
     conn: Connection,
@@ -205,6 +207,7 @@ impl Store {
         if current_version < 6 { self.migrate_v6()?; }
         if current_version < 7 { self.migrate_v7()?; }
         if current_version < 8 { self.migrate_v8()?; }
+        if current_version < 9 { self.migrate_v9()?; }
 
         // Update schema version to latest
         if current_version < LATEST_SCHEMA_VERSION {
@@ -406,6 +409,14 @@ impl Store {
             "DROP INDEX IF EXISTS idx_project_stacks_project;
              DROP TABLE IF EXISTS project_stacks;",
         )?;
+        Ok(())
+    }
+
+    /// Schema v9: mcp_transport column on extensions (stdio/http/sse) so the
+    /// UI can gate remote-MCP install targets. NULL for non-MCP rows and rows
+    /// scanned before transport tracking.
+    fn migrate_v9(&self) -> Result<(), HkError> {
+        self.migrate_add_column("ALTER TABLE extensions ADD COLUMN mcp_transport TEXT");
         Ok(())
     }
 
@@ -626,6 +637,7 @@ impl Store {
                 im.and_then(|m| m.check_error.as_deref()),
                 ext.pack,
                 serde_json::to_string(&ext.scope)?,
+                ext.mcp_transport.map(|t| t.as_str()),
             ],
         )?;
         // Keep extension_agents join table in sync
@@ -635,7 +647,7 @@ impl Store {
 
     pub fn get_extension(&self, id: &str) -> Result<Option<Extension>, HkError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, kind, name, description, source_json, agents_json, tags_json, permissions_json, enabled, trust_score, installed_at, updated_at, category, source_path, cli_parent_id, cli_meta_json, install_type, install_url, install_url_resolved, install_branch, install_subpath, install_revision, remote_revision, checked_at, check_error, pack, scope_json
+            "SELECT id, kind, name, description, source_json, agents_json, tags_json, permissions_json, enabled, trust_score, installed_at, updated_at, category, source_path, cli_parent_id, cli_meta_json, install_type, install_url, install_url_resolved, install_branch, install_subpath, install_revision, remote_revision, checked_at, check_error, pack, scope_json, mcp_transport
              FROM extensions WHERE id = ?1"
         )?;
         let mut rows = stmt.query_map(params![id], |row| Ok(self.row_to_extension(row)))?;
@@ -652,7 +664,7 @@ impl Store {
         kind: Option<ExtensionKind>,
         agent: Option<&str>,
     ) -> Result<Vec<Extension>, HkError> {
-        let ext_cols = "e.id, e.kind, e.name, e.description, e.source_json, e.agents_json, e.tags_json, e.permissions_json, e.enabled, e.trust_score, e.installed_at, e.updated_at, e.category, e.source_path, e.cli_parent_id, e.cli_meta_json, e.install_type, e.install_url, e.install_url_resolved, e.install_branch, e.install_subpath, e.install_revision, e.remote_revision, e.checked_at, e.check_error, e.pack, e.scope_json";
+        let ext_cols = "e.id, e.kind, e.name, e.description, e.source_json, e.agents_json, e.tags_json, e.permissions_json, e.enabled, e.trust_score, e.installed_at, e.updated_at, e.category, e.source_path, e.cli_parent_id, e.cli_meta_json, e.install_type, e.install_url, e.install_url_resolved, e.install_branch, e.install_subpath, e.install_revision, e.remote_revision, e.checked_at, e.check_error, e.pack, e.scope_json, e.mcp_transport";
 
         let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
 
@@ -981,6 +993,7 @@ impl Store {
                     ext.cli_meta.as_ref().map(|m| serde_json::to_string(m).unwrap_or_default()),
                     ext.pack,
                     serde_json::to_string(&ext.scope)?,
+                    ext.mcp_transport.map(|t| t.as_str()),
                 ],
             )?;
             // Keep extension_agents join table in sync
@@ -1109,6 +1122,7 @@ impl Store {
                     ext.cli_meta.as_ref().map(|m| serde_json::to_string(m).unwrap_or_default()),
                     ext.pack,
                     serde_json::to_string(&ext.scope)?,
+                    ext.mcp_transport.map(|t| t.as_str()),
                 ],
             )?;
             // Keep extension_agents join table in sync
@@ -1565,6 +1579,12 @@ impl Store {
             .and_then(|s| serde_json::from_str::<ConfigScope>(&s).ok())
             .unwrap_or(ConfigScope::Global);
 
+        let mcp_transport = row
+            .get::<_, Option<String>>(27)
+            .ok()
+            .flatten()
+            .and_then(|s| s.parse().ok());
+
         Ok(Extension {
             id: row.get(0)?,
             kind: kind_str
@@ -1590,6 +1610,7 @@ impl Store {
             cli_meta: cli_meta_json.and_then(|s| serde_json::from_str::<CliMeta>(&s).ok()),
             install_meta,
             scope,
+            mcp_transport,
         })
     }
 
@@ -1926,6 +1947,7 @@ mod tests {
             cli_meta: None,
             install_meta: None,
             scope: ConfigScope::Global,
+            mcp_transport: None,
         }
     }
 
@@ -1946,6 +1968,46 @@ mod tests {
         assert_eq!(fetched.kind, ExtensionKind::Skill);
         assert_eq!(fetched.agents, vec!["claude"]);
         assert_eq!(fetched.tags, vec!["test"]);
+    }
+
+    #[test]
+    fn test_extension_mcp_transport_round_trip() {
+        let (store, _dir) = test_store();
+
+        let mut remote = sample_extension();
+        remote.id = "remote-mcp".into();
+        remote.kind = ExtensionKind::Mcp;
+        remote.mcp_transport = Some(crate::adapter::McpTransport::Sse);
+        store.insert_extension(&remote).unwrap();
+        let fetched = store.get_extension("remote-mcp").unwrap().unwrap();
+        assert_eq!(
+            fetched.mcp_transport,
+            Some(crate::adapter::McpTransport::Sse)
+        );
+
+        // Non-MCP rows (and legacy NULLs) come back as None.
+        let skill = sample_extension();
+        let skill_id = skill.id.clone();
+        store.insert_extension(&skill).unwrap();
+        assert_eq!(
+            store.get_extension(&skill_id).unwrap().unwrap().mcp_transport,
+            None
+        );
+
+        // sync_extensions (the scanner upsert) must persist it too.
+        let mut synced = sample_extension();
+        synced.id = "synced-mcp".into();
+        synced.kind = ExtensionKind::Mcp;
+        synced.mcp_transport = Some(crate::adapter::McpTransport::Http);
+        store.sync_extensions(std::slice::from_ref(&synced)).unwrap();
+        assert_eq!(
+            store
+                .get_extension("synced-mcp")
+                .unwrap()
+                .unwrap()
+                .mcp_transport,
+            Some(crate::adapter::McpTransport::Http)
+        );
     }
 
     #[test]
@@ -3345,6 +3407,7 @@ mod tests {
             cli_meta: None,
             install_meta: None,
             scope: ConfigScope::Global,
+            mcp_transport: None,
         };
         store.insert_extension(&ext_claude).unwrap();
 

--- a/crates/hk-core/tests/toggle_integration.rs
+++ b/crates/hk-core/tests/toggle_integration.rs
@@ -110,6 +110,7 @@ fn test_disabled_mcp_survives_rescan() {
         cli_meta: None,
         install_meta: None,
         scope: ConfigScope::Global,
+        mcp_transport: None,
     };
     store.insert_extension(&ext).unwrap();
     store.set_enabled("mcp-test", false).unwrap();
@@ -170,6 +171,7 @@ fn test_shared_skill_sibling_detection() {
         cli_meta: None,
         install_meta: None,
         scope: ConfigScope::Global,
+        mcp_transport: None,
     };
     store.insert_extension(&ext1).unwrap();
 
@@ -225,6 +227,7 @@ fn sample_plugin(id: &str, agent: &str) -> Extension {
         cli_meta: None,
         install_meta: None,
         scope: ConfigScope::Global,
+        mcp_transport: None,
     }
 }
 

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -23,7 +23,10 @@ import { SkillFileSection } from "@/components/extensions/skill-file-section";
 import { AgentMascot } from "@/components/shared/agent-mascot/agent-mascot";
 import { HermesCategoryPicker } from "@/components/shared/hermes-category-picker";
 import { ScopeTargetField } from "@/components/shared/scope-target-field";
-import { canInstallAtScope } from "@/lib/agent-capabilities";
+import {
+  canInstallAtScope,
+  canReceiveMcpTransport,
+} from "@/lib/agent-capabilities";
 import i18n from "@/lib/i18n";
 import { api } from "@/lib/invoke";
 import { isDesktop } from "@/lib/transport";
@@ -601,8 +604,23 @@ export function ExtensionDetail() {
                       group.kind,
                       scopeForCheck,
                     );
+                    // Remote (HTTP/SSE) MCP servers can only go to agents
+                    // whose config can express that transport — e.g. Codex
+                    // takes Streamable HTTP but not SSE. The deployer
+                    // enforces the same rule; greying out here means users
+                    // never hit that error (issue #105).
+                    const mcpTransport =
+                      group.kind === "mcp"
+                        ? group.instances[0]?.mcp_transport
+                        : undefined;
+                    const transportUnsupported =
+                      group.kind === "mcp" &&
+                      !canReceiveMcpTransport(agent, mcpTransport);
                     const blocked =
-                      hookUnsupported || globalHookBlocked || scopeIncapable;
+                      hookUnsupported ||
+                      globalHookBlocked ||
+                      scopeIncapable ||
+                      transportUnsupported;
                     // Already has a copy in the target scope: shown as
                     // installed (check icon) instead of hidden, so the user
                     // can see WHERE this extension already lives.
@@ -632,7 +650,14 @@ export function ExtensionDetail() {
                                       agent: agentDisplayName(agent.name),
                                       kind: group.kind,
                                     })
-                                  : undefined
+                                  : transportUnsupported
+                                    ? t("detail.remoteTransportUnsupported", {
+                                        agent: agentDisplayName(agent.name),
+                                        transport: (
+                                          mcpTransport ?? "http"
+                                        ).toUpperCase(),
+                                      })
+                                    : undefined
                         }
                         onClick={async () => {
                           if (blocked || isInstalled || !effectiveTarget)
@@ -657,9 +682,10 @@ export function ExtensionDetail() {
                               );
                               const seen = new Set<string>();
                               // A CLI bundle can mix kinds (skills + MCP).
-                              // Skip children the target agent can't take at
-                              // this scope instead of failing mid-loop with a
-                              // partial install.
+                              // Skip children the target agent can't take —
+                              // wrong scope, or a remote MCP transport the
+                              // agent can't express — instead of failing
+                              // mid-loop with a partial install.
                               let skipped = 0;
                               for (const child of children) {
                                 if (seen.has(child.name + child.kind)) continue;
@@ -669,7 +695,12 @@ export function ExtensionDetail() {
                                     agent,
                                     child.kind,
                                     scopeForCheck,
-                                  )
+                                  ) ||
+                                  (child.kind === "mcp" &&
+                                    !canReceiveMcpTransport(
+                                      agent,
+                                      child.mcp_transport,
+                                    ))
                                 ) {
                                   skipped += 1;
                                   continue;

--- a/src/lib/__tests__/agent-capabilities.test.ts
+++ b/src/lib/__tests__/agent-capabilities.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { canInstallAtScope } from "@/lib/agent-capabilities";
+import {
+  canInstallAtScope,
+  canReceiveMcpTransport,
+} from "@/lib/agent-capabilities";
 import type { AgentCapabilities, AgentInfo } from "@/lib/types";
 import type { ScopeValue } from "@/stores/scope-store";
 
@@ -68,5 +71,37 @@ describe("canInstallAtScope", () => {
 
   it("returns false at project scope for kinds without a project flag", () => {
     expect(canInstallAtScope(CLAUDE, "plugin", PROJECT)).toBe(false);
+  });
+});
+
+describe("canReceiveMcpTransport", () => {
+  const codex = agent("codex", {
+    project_install: { skill: true, mcp: true, hook: true, cli: true },
+    hooks_supported: true,
+    global_hook_install: true,
+    mcp_remote: { http: true, sse: false },
+  });
+  const claudeRemote = agent("claude", {
+    ...CLAUDE.capabilities,
+    mcp_remote: { http: true, sse: true },
+  });
+
+  it("always allows stdio (including absent transport on legacy rows)", () => {
+    expect(canReceiveMcpTransport(codex, "stdio")).toBe(true);
+    expect(canReceiveMcpTransport(codex, undefined)).toBe(true);
+    expect(canReceiveMcpTransport(undefined, undefined)).toBe(true);
+  });
+
+  it("gates remote transports by the backend-derived flags", () => {
+    expect(canReceiveMcpTransport(claudeRemote, "http")).toBe(true);
+    expect(canReceiveMcpTransport(claudeRemote, "sse")).toBe(true);
+    // Codex speaks Streamable HTTP only.
+    expect(canReceiveMcpTransport(codex, "http")).toBe(true);
+    expect(canReceiveMcpTransport(codex, "sse")).toBe(false);
+  });
+
+  it("gates remote transports off when capabilities are absent (old backend / unknown agent)", () => {
+    expect(canReceiveMcpTransport(CLAUDE, "http")).toBe(false);
+    expect(canReceiveMcpTransport(undefined, "http")).toBe(false);
   });
 });

--- a/src/lib/agent-capabilities.ts
+++ b/src/lib/agent-capabilities.ts
@@ -1,5 +1,23 @@
-import type { AgentInfo, ExtensionKind } from "@/lib/types";
+import type { AgentInfo, ExtensionKind, McpTransport } from "@/lib/types";
 import type { ScopeValue } from "@/stores/scope-store";
+
+/** Whether `agent` can receive an MCP server of the given transport.
+ *
+ *  Same source of truth as `canInstallAtScope`: the backend derives
+ *  `capabilities.mcp_remote` from each adapter's RemoteMcpSchema, and the
+ *  deployer enforces the same rule (e.g. Codex takes Streamable HTTP but
+ *  not SSE). Stdio always passes; an absent transport (legacy rows) is
+ *  treated as stdio; absent capabilities (agent unknown / old backend)
+ *  gate remote transports off. */
+export function canReceiveMcpTransport(
+  agent: AgentInfo | undefined,
+  transport: McpTransport | undefined,
+): boolean {
+  if (!transport || transport === "stdio") return true;
+  const flags = agent?.capabilities?.mcp_remote;
+  if (!flags) return false;
+  return transport === "http" ? flags.http : flags.sse;
+}
 
 /** Whether `agent` can take an install of `kind` at `scope`.
  *

--- a/src/lib/i18n/locales/en/extensions.json
+++ b/src/lib/i18n/locales/en/extensions.json
@@ -87,6 +87,7 @@
     "hooksNotSupported": "Hooks not supported",
     "kiroGlobalHooksPending": "Kiro does not load user-level (global) hooks yet (upstream kirodotdev/Kiro#5440) - install this hook per-project instead",
     "projectScopeUnsupported": "{{agent}} doesn't support project-level {{kind}} installs yet",
+    "remoteTransportUnsupported": "{{agent}} doesn't support {{transport}} remote MCP servers",
     "cliChildrenSkipped": "Skipped {{count}} bundled item(s) this agent can't install at project scope",
     "installToSuccess": "Installed to {{agent}}. Takes effect in new sessions",
     "installToFailed": "Failed to install to {{agent}}",

--- a/src/lib/i18n/locales/zh/extensions.json
+++ b/src/lib/i18n/locales/zh/extensions.json
@@ -87,6 +87,7 @@
     "hooksNotSupported": "不支持 hook",
     "kiroGlobalHooksPending": "Kiro 尚未加载用户级（全局）hook（上游 kirodotdev/Kiro#5440），请改用项目级安装",
     "projectScopeUnsupported": "{{agent}} 尚不支持项目级 {{kind}} 安装",
+    "remoteTransportUnsupported": "{{agent}} 不支持 {{transport}} 远程 MCP 服务器",
     "cliChildrenSkipped": "已跳过 {{count}} 个该智能体无法在项目级安装的捆绑项",
     "installToSuccess": "已安装到 {{agent}}。将在新会话中生效",
     "installToFailed": "安装到 {{agent}} 失败",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,7 +38,13 @@ export interface Extension {
   /** Whether this extension is installed globally or in a specific project.
    *  Defaults to global on rows scanned before scope tracking (DB v3+). */
   scope: ConfigScope;
+  /** MCP rows only: the server's transport. Absent for non-MCP kinds and
+   *  rows scanned before transport tracking (DB v9) — treat absent as
+   *  stdio for gating purposes. */
+  mcp_transport?: McpTransport;
 }
+
+export type McpTransport = "stdio" | "http" | "sse";
 
 export interface Source {
   origin: SourceOrigin;
@@ -328,6 +334,14 @@ export interface AgentCapabilities {
   project_install: KindFlags;
   hooks_supported: boolean;
   global_hook_install: boolean;
+  /** Which remote MCP transports the agent's config can express. Absent
+   *  on responses from pre-transport backends — treat as stdio-only. */
+  mcp_remote?: RemoteTransportFlags;
+}
+
+export interface RemoteTransportFlags {
+  http: boolean;
+  sse: boolean;
 }
 
 export type ConfigCategory =


### PR DESCRIPTION
## Summary

Fixes #105.

Remote MCP servers (`claude mcp add --transport http linear https://mcp.linear.app/mcp`) were parsed into an empty `command`, and cross-agent install wrote a dead `command = ""` block into the target config. Root cause: the MCP data model was stdio-only — `McpServerEntry` had no concept of a URL, so every reader dropped it on scan and every writer emitted the stdio shape.

### Model (`8c1ace0`)
- `McpServerEntry` gains `transport` (stdio/http/sse), `url`, and `headers`. All serde-defaulted; stdio Kit blobs stay byte-identical.
- New `RemoteMcpSchema` enum records how each agent's config spells a remote entry — the single source of truth for transport capability.
- All 11 adapter readers parse their agent's native remote schema (every field name verified against official docs / upstream source):
  - claude / copilot / omp: `{type: "http"|"sse", url, headers}` (incl. the `streamable-http` spec alias)
  - cursor / kiro: `{url, headers}` · windsurf / antigravity: `{serverUrl, headers}`
  - gemini: `httpUrl` (HTTP) / `url` (SSE) · codex: TOML `url` + `http_headers` · hermes: `url` + `headers` + `transport: sse`
  - opencode: `type: "remote"` entries were previously skipped entirely — now surfaced
- Removes the url-in-command round-trip hack from the omp/hermes/kiro readers.

### Deploy (`9fd03d7`)
- `deploy_mcp_server` validates remote entries against the target's schema before writing: unsupported targets get a clean `Validation` error, and Codex (Streamable HTTP only — no SSE variant in upstream `mcp_types.rs`) refuses SSE entries instead of writing a config it can't load.
- Each writer emits the target's native remote spelling (JSON variants, TOML `url`/`http_headers`, OpenCode `{type: "remote", …}`, Hermes YAML).
- TOML restore now transcodes disable-snapshots wholesale — previously a field-by-field copy destroyed `url`/`http_headers` on re-enable.
- Auth headers are redacted in disable-snapshots (alongside env) and stripped from Kit blobs; Kits now accept remote entries.
- `ensure_path_injection` skips remote entries (no binary to resolve).

### Scan / DB / capabilities (`facf634`)
- Schema v9 adds a nullable `extensions.mcp_transport` column; `AgentInfo.capabilities` gains `mcp_remote {http, sse}` derived from each adapter's schema.
- Remote entries get an accurate permission profile — `network: <host>` (URL userinfo stripped) plus header keys — replacing the empty `shell` permission, and a "Remote MCP server at <host>" description. Global and project MCP scans now share one profile helper.
- The MCP content preview shows Transport/URL/Headers (values masked); remote headers feed the secret-scanning audit rules.

### UI (`6e3f739`)
- "Install to agent" greys out targets that can't express the entry's transport, with an explanatory tooltip (en/zh) — mirroring the existing scope gating. CLI-bundle installs skip transport-incapable MCP children the same way.

## Verification
- `cargo test -p hk-core`: 577 + 8 pass · `cargo check --workspace --all-targets` clean · `tsc --noEmit` clean · `vitest`: 268 pass. Each commit compiles independently.
- End-to-end regression test pins the exact #105 repro (Claude HTTP entry → Codex install → `url =` written, no `command` key; SSE → Codex rejected), plus disable→enable round-trips preserving `url` with headers redacted in the DB.
- Manually reproduced the issue against a live config: the original command sequence now produces `[mcp_servers.linear]\nurl = "https://mcp.linear.app/mcp"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)