### PR TITLE
fix(updater): show the What's Changed tail in all languages

### DIFF
--- a/src/lib/i18n/__tests__/changelog.test.ts
+++ b/src/lib/i18n/__tests__/changelog.test.ts
@@ -73,3 +73,24 @@ describe("localizeChangelog comment blocks", () => {
     expect(zh).not.toContain("English line");
   });
 });
+
+describe("language-neutral What's Changed tail", () => {
+  it("appends the tail to non-English sections with a localized heading", () => {
+    const zh = localizeChangelog(COMMENT_BLOCK, "zh");
+    expect(zh).toContain("中文行");
+    expect(zh).toContain("## 变更列表");
+    expect(zh).toContain("* some PR");
+    expect(zh).not.toContain("## What's Changed");
+  });
+
+  it("keeps the English heading and tail for English", () => {
+    const en = localizeChangelog(COMMENT_BLOCK, "en");
+    expect(en).toMatch(/English line[\s\S]*## What's Changed[\s\S]*\* some PR/);
+    expect(en).not.toContain("变更列表");
+  });
+
+  it("extracts blocks from CRLF bodies (GitHub API line endings)", () => {
+    const crlf = COMMENT_BLOCK.replace(/\n/g, "\r\n");
+    expect(localizeChangelog(crlf, "zh")).toContain("中文行");
+  });
+});

--- a/src/lib/i18n/changelog.ts
+++ b/src/lib/i18n/changelog.ts
@@ -35,11 +35,20 @@ const LANG_COMMENT_BLOCK = /<!--\s*lang:([a-z-]+)[ \t]*\n([\s\S]*?)-->/gi;
  * the first section present. Notes without any fence or block are returned
  * unchanged, so single-language releases keep working.
  */
+// GitHub's auto-generated release tail. It sits in the English plain text,
+// but PR titles are English regardless of UI language — non-English
+// sections borrow it from the English one (with a localized heading).
+const NEUTRAL_TAIL = /^## What's Changed\s*$/m;
+
 export function localizeChangelog(body: string, language: string): string {
   const sections: Record<string, string> = {};
 
+  // Bodies fetched from the GitHub API use \r\n; LANG_COMMENT_BLOCK anchors
+  // on \n, so normalize first or block extraction silently fails.
+  const normalized = body.replace(/\r\n/g, "\n");
+
   // Pass 1: pull out comment-block translations; what remains is plain text.
-  const remainder = body
+  const remainder = normalized
     .replace(LANG_COMMENT_BLOCK, (_match, code: string, content: string) => {
       const key = mapLocaleToSupportedLanguage(code) ?? code.toLowerCase();
       sections[key] = content.trim();
@@ -65,10 +74,21 @@ export function localizeChangelog(body: string, language: string): string {
     sections.en = remainder;
   }
 
-  if (Object.keys(sections).length === 0) return body.trim();
+  if (Object.keys(sections).length === 0) return normalized.trim();
 
   const lang = mapLocaleToSupportedLanguage(language) ?? "en";
-  return (
-    sections[lang] ?? sections.en ?? Object.values(sections)[0] ?? body.trim()
-  );
+  const selected =
+    sections[lang] ?? sections.en ?? Object.values(sections)[0] ?? normalized.trim();
+
+  // Borrow the English tail for non-English sections.
+  if (lang !== "en" && sections.en && selected !== sections.en) {
+    const tailStart = sections.en.search(NEUTRAL_TAIL);
+    if (tailStart !== -1) {
+      const tail = sections.en
+        .slice(tailStart)
+        .replace(NEUTRAL_TAIL, "## 变更列表");
+      return `${selected}\n\n${tail}`;
+    }
+  }
+  return selected;
 }


### PR DESCRIPTION
## Summary

The in-app update dialog localizes release notes by language: hand-written translations live in `<!-- lang:zh -->` comment blocks, while GitHub's auto-generated `## What's Changed` PR list sits in the English plain text. `localizeChangelog` therefore handed the PR list only to the English section — the Chinese view showed nothing but the highlights.

- The tail is language-neutral (PR titles are English regardless of UI language), so non-English sections now borrow it verbatim from the English section, with the heading localized (`## 变更列表`). English output stays byte-identical; the GitHub release page is untouched.
- Also fixes a latent bug surfaced while testing against the real v1.8.0 body: bodies fetched from the GitHub API use `\r\n`, which the comment-block regex never matched — language extraction silently fell through to the raw body. Line endings are normalized on entry.

## Verification

- 3 new test cases (localized tail for zh, byte-identical English, CRLF regression); `vitest` 270 pass, `tsc --noEmit` clean.
- Verified against the published v1.8.0 release body: Chinese view renders 更新亮点 + 变更列表 with clickable PR links; English view unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)