### PR TITLE
release: v1.8.1

### DIFF
--- a/.github/release-notes/v1.8.1.md
+++ b/.github/release-notes/v1.8.1.md
@@ -1,0 +1,11 @@
+## ✨ Highlights
+
+- **Remote MCP servers (Streamable HTTP / SSE)** — HarnessKit now fully understands URL-based MCP servers. They scan with accurate transport and permission info, deploy to each agent in its native config schema (e.g. Codex gets `url` + `http_headers` instead of an empty `command`), and install targets that can't take a server's transport are greyed out up front instead of receiving a config they can't load. Fixes #105.
+- **Chinese update notes, completed** — the update dialog's Chinese view now includes the "变更列表" (What's Changed) PR list, and release-note parsing handles GitHub API line endings correctly.
+
+<!-- lang:zh
+## ✨ 更新亮点
+
+- **远程 MCP 服务器（Streamable HTTP / SSE）** — HarnessKit 现已完整支持 URL 型 MCP 服务器：扫描时正确识别 transport 与权限，跨 Agent 安装按各目标的原生格式写入（如 Codex 得到 `url` + `http_headers`，而不再是空的 `command`），不支持该 transport 的目标会在安装界面直接置灰，不会写出无法加载的配置。修复 #105。
+- **应用内更新说明中文视图补全** — 更新弹窗的中文视图现在也显示「变更列表」（PR 列表），并修复了 GitHub API 换行符导致的解析问题。
+-->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk-cli"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "hk-core"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "hk-desktop"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "hk-web"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hk-core", "crates/hk-cli", "crates/hk-desktop", "crates/hk-we
 resolver = "2"
 
 [workspace.package]
-version = "1.8.0"
+version = "1.8.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/hk-desktop/tauri.conf.json
+++ b/crates/hk-desktop/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "HarnessKit",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "identifier": "com.harnesskit.app",
   "build": {
     "frontendDist": "../../dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "harnesskit-frontend",
-  "version": "1.7.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harnesskit-frontend",
-      "version": "1.7.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harnesskit-frontend",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Cross-platform extension management for AI coding agents",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to 1.8.1 (Cargo.toml / Cargo.lock / package.json / package-lock.json / tauri.conf.json) plus bilingual release notes at `.github/release-notes/v1.8.1.md`.

Ships two fixes:
- Remote MCP transport support (Streamable HTTP / SSE) — #106, fixes #105
- Localized "What's Changed" tail in the update dialog + CRLF parsing fix — #107

After merge: tag `v1.8.1` on main to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)