### PR TITLE
fix(scanner): recursively scan nested rules directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,6 +1966,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "uuid",
+ "walkdir",
  "zip 2.4.2",
 ]
 

--- a/crates/hk-core/Cargo.toml
+++ b/crates/hk-core/Cargo.toml
@@ -15,6 +15,7 @@ regex = "1"
 toml = "0.8"
 dirs = "6"
 glob = "0.3"
+walkdir = "2"
 jsonc-parser = { version = "0.32", features = ["serde", "serde_json", "cst"] }
 
 lru = "0.12"

--- a/crates/hk-core/src/adapter/antigravity.rs
+++ b/crates/hk-core/src/adapter/antigravity.rs
@@ -130,7 +130,9 @@ impl AgentAdapter for AntigravityAdapter {
     fn project_rules_patterns(&self) -> Vec<String> {
         // `.agents/` is canonical (1.18.4+); `.agent/` kept for backward compat.
         // Source: https://discuss.ai.google.dev/t/new-folder-for-rules/126165
-        vec![".agents/rules/*.md".into(), ".agent/rules/*.md".into()]
+        // Recursive: the language server (2.0.4) walks rule dirs with an
+        // unbounded recursive traversal, so nested subdirectories load too.
+        vec![".agents/rules/**/*.md".into(), ".agent/rules/**/*.md".into()]
     }
 
     fn project_settings_patterns(&self) -> Vec<String> {

--- a/crates/hk-core/src/adapter/claude.rs
+++ b/crates/hk-core/src/adapter/claude.rs
@@ -200,8 +200,12 @@ impl AgentAdapter for ClaudeAdapter {
 
     fn global_rules_files(&self) -> Vec<PathBuf> {
         let mut files = vec![self.base_dir().join("CLAUDE.md")];
-        // Also scan ~/.claude/rules/*.md
-        files.extend(super::files_with_ext(&self.base_dir().join("rules"), "md"));
+        // ~/.claude/rules/**/*.md — Claude Code discovers rules recursively
+        // and follows symlinked rule directories.
+        files.extend(super::files_with_ext_recursive(
+            &self.base_dir().join("rules"),
+            "md",
+        ));
         files
     }
 
@@ -257,7 +261,7 @@ impl AgentAdapter for ClaudeAdapter {
         vec![
             "CLAUDE.md".into(),
             ".claude/CLAUDE.md".into(),
-            ".claude/rules/*.md".into(),
+            ".claude/rules/**/*.md".into(),
         ]
     }
 
@@ -589,7 +593,7 @@ mod tests {
         let project_rules = adapter.project_rules_patterns();
         assert!(project_rules.contains(&"CLAUDE.md".to_string()));
         assert!(project_rules.contains(&".claude/CLAUDE.md".to_string()));
-        assert!(project_rules.contains(&".claude/rules/*.md".to_string()));
+        assert!(project_rules.contains(&".claude/rules/**/*.md".to_string()));
 
         let project_settings = adapter.project_settings_patterns();
         assert!(project_settings.contains(&".claude/settings.json".to_string()));

--- a/crates/hk-core/src/adapter/copilot.rs
+++ b/crates/hk-core/src/adapter/copilot.rs
@@ -154,7 +154,18 @@ impl AgentAdapter for CopilotAdapter {
     }
 
     fn global_rules_files(&self) -> Vec<PathBuf> {
-        vec![self.base_dir().join("copilot-instructions.md")]
+        let mut files = vec![self.base_dir().join("copilot-instructions.md")];
+        // ~/.copilot/instructions/**/*.instructions.md — modular user-level
+        // instructions, read by both Copilot CLI and VS Code's Agent Host.
+        files.extend(
+            super::files_with_ext_recursive(&self.base_dir().join("instructions"), "md")
+                .into_iter()
+                .filter(|p| {
+                    p.file_name()
+                        .is_some_and(|n| n.to_string_lossy().ends_with(".instructions.md"))
+                }),
+        );
+        files
     }
 
     fn global_settings_files(&self) -> Vec<PathBuf> {
@@ -191,7 +202,9 @@ impl AgentAdapter for CopilotAdapter {
     fn project_rules_patterns(&self) -> Vec<String> {
         vec![
             ".github/copilot-instructions.md".into(),
-            ".github/instructions/*.instructions.md".into(),
+            // VS Code searches .github/instructions recursively, so nested
+            // subdirectories (e.g. instructions/frontend/) are loaded too.
+            ".github/instructions/**/*.instructions.md".into(),
             "AGENTS.md".into(),
         ]
     }

--- a/crates/hk-core/src/adapter/cursor.rs
+++ b/crates/hk-core/src/adapter/cursor.rs
@@ -177,8 +177,10 @@ impl AgentAdapter for CursorAdapter {
     fn project_rules_patterns(&self) -> Vec<String> {
         vec![
             ".cursorrules".into(),
-            ".cursor/rules/*.mdc".into(),
-            ".cursor/rules/*.md".into(),
+            // Cursor loads .mdc rules from nested subfolders of .cursor/rules;
+            // plain .md files there are ignored by Cursor entirely, so they
+            // are deliberately not scanned.
+            ".cursor/rules/**/*.mdc".into(),
             "AGENTS.md".into(),
         ]
     }

--- a/crates/hk-core/src/adapter/gemini.rs
+++ b/crates/hk-core/src/adapter/gemini.rs
@@ -142,6 +142,11 @@ impl AgentAdapter for GeminiAdapter {
     }
 
     fn project_rules_patterns(&self) -> Vec<String> {
+        // Gemini CLI loads subdirectory GEMINI.md at any depth (startup BFS
+        // before v0.54, JIT on tool access since), but a `**/GEMINI.md` glob
+        // would walk the entire project tree (node_modules included) on every
+        // scan and surface vendored files. Two levels is a deliberate cap:
+        // deeper files still work in Gemini, they just aren't listed here.
         vec![
             "GEMINI.md".into(),
             "*/GEMINI.md".into(),

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -36,6 +36,25 @@ pub(crate) fn files_with_ext<'a>(
         .filter(move |path| path.extension().is_some_and(|e| e == ext))
 }
 
+/// Recursive variant of [`files_with_ext`]: walks `dir` and every subdirectory,
+/// following directory symlinks (walkdir reports symlink loops as errors, which
+/// are skipped like any unreadable entry). Only for rules-style directories
+/// whose agent documents recursive loading (Claude Code rules, Copilot
+/// instructions, ...) — keep single-level dirs on `files_with_ext` so we don't
+/// surface files the agent itself never reads. Depth-capped as a safety net
+/// against pathological trees.
+pub(crate) fn files_with_ext_recursive(dir: &Path, ext: &str) -> Vec<PathBuf> {
+    walkdir::WalkDir::new(dir)
+        .follow_links(true)
+        .max_depth(16)
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| entry.into_path())
+        .filter(|path| path.extension().is_some_and(|e| e == ext))
+        .collect()
+}
+
 /// Transport an MCP server entry uses. `Stdio` entries carry `command/args/env`;
 /// `Http` (Streamable HTTP) and `Sse` entries carry `url` (+ optional `headers`)
 /// and an empty `command`.

--- a/crates/hk-core/src/adapter/windsurf.rs
+++ b/crates/hk-core/src/adapter/windsurf.rs
@@ -196,7 +196,10 @@ impl AgentAdapter for WindsurfAdapter {
     }
 
     fn project_rules_patterns(&self) -> Vec<String> {
-        vec![".windsurfrules".into(), ".windsurf/rules/*.md".into()]
+        // Rules discovery in the official binary (Devin Desktop 3.6.27) uses
+        // the doublestar glob `**/.windsurf/rules/**/*.md`, so nested
+        // subdirectories inside rules/ are loaded.
+        vec![".windsurfrules".into(), ".windsurf/rules/**/*.md".into()]
     }
 
     fn project_memory_patterns(&self) -> Vec<String> {

--- a/crates/hk-core/src/scanner.rs
+++ b/crates/hk-core/src/scanner.rs
@@ -3075,6 +3075,95 @@ mod config_tests {
         assert_eq!(ignores.len(), 0);
     }
 
+    /// Nested-rules coverage for every adapter whose agent documents
+    /// recursive rules loading: Claude (global + project), Copilot (global
+    /// + project), Cursor (project, .mdc only). One fixture tree, one scan
+    /// per adapter, flat files double as the no-regression check.
+    #[test]
+    fn test_scan_agent_configs_nested_rules() {
+        use crate::adapter::copilot::CopilotAdapter;
+        use crate::adapter::cursor::CursorAdapter;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let project = tmp.path().join("myproject");
+        let rules_of = |adapter: &dyn crate::adapter::AgentAdapter| -> Vec<String> {
+            let projects = vec![(
+                "myproject".to_string(),
+                project.to_string_lossy().to_string(),
+            )];
+            scan_agent_configs(adapter, &projects)
+                .into_iter()
+                .filter(|c| c.category == ConfigCategory::Rules)
+                .map(|c| c.path)
+                .collect()
+        };
+        let write = |path: std::path::PathBuf| {
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, "# rule").unwrap();
+        };
+
+        // Claude: flat + nested at both levels.
+        write(home.join(".claude/rules/flat.md"));
+        write(home.join(".claude/rules/frontend/react.md"));
+        write(project.join(".claude/rules/style.md"));
+        write(project.join(".claude/rules/backend/api.md"));
+        // Symlinked rule dir must be followed; a circular symlink must not
+        // hang the walk (walkdir reports the loop as an error entry, skipped).
+        #[cfg(unix)]
+        {
+            let shared = tmp.path().join("shared-rules");
+            write(shared.join("shared.md"));
+            let rules = home.join(".claude/rules");
+            std::os::unix::fs::symlink(&shared, rules.join("linked")).unwrap();
+            std::os::unix::fs::symlink(&rules, rules.join("loop")).unwrap();
+        }
+        let claude = rules_of(&ClaudeAdapter::with_home(home.to_path_buf()));
+        assert!(claude.iter().any(|p| p.ends_with("rules/flat.md")));
+        assert!(claude.iter().any(|p| p.ends_with("frontend/react.md")));
+        assert!(claude.iter().any(|p| p.ends_with("rules/style.md")));
+        assert!(claude.iter().any(|p| p.ends_with("backend/api.md")));
+        #[cfg(unix)]
+        assert!(claude.iter().any(|p| p.ends_with("linked/shared.md")));
+
+        // Copilot: global ~/.copilot/instructions and project
+        // .github/instructions are both searched recursively; only
+        // *.instructions.md counts.
+        write(home.join(".copilot/instructions/style/tone.instructions.md"));
+        write(home.join(".copilot/instructions/notes.md"));
+        write(project.join(".github/instructions/general.instructions.md"));
+        write(project.join(".github/instructions/frontend/react.instructions.md"));
+        let copilot = rules_of(&CopilotAdapter::with_home(home.to_path_buf()));
+        assert!(copilot.iter().any(|p| p.ends_with("style/tone.instructions.md")));
+        assert!(copilot.iter().any(|p| p.ends_with("general.instructions.md")));
+        assert!(copilot
+            .iter()
+            .any(|p| p.ends_with("frontend/react.instructions.md")));
+        assert!(!copilot.iter().any(|p| p.ends_with("notes.md")));
+
+        // Cursor: nested .mdc rules are loaded; .md files anywhere in
+        // .cursor/rules are ignored by Cursor and must stay invisible.
+        write(project.join(".cursor/rules/top.mdc"));
+        write(project.join(".cursor/rules/frontend/comp.mdc"));
+        write(project.join(".cursor/rules/ignored.md"));
+        let cursor = rules_of(&CursorAdapter::with_home(home.to_path_buf()));
+        assert!(cursor.iter().any(|p| p.ends_with("rules/top.mdc")));
+        assert!(cursor.iter().any(|p| p.ends_with("frontend/comp.mdc")));
+        assert!(!cursor.iter().any(|p| p.ends_with("ignored.md")));
+
+        // Windsurf and Antigravity: nested rules load too (binary-verified).
+        // Flat-match regression for `**` is already covered above; only the
+        // per-adapter nested patterns need proving here.
+        use crate::adapter::antigravity::AntigravityAdapter;
+        use crate::adapter::windsurf::WindsurfAdapter;
+        write(project.join(".windsurf/rules/frontend/ws-deep.md"));
+        write(project.join(".agents/rules/frontend/ag-deep.md"));
+        let windsurf = rules_of(&WindsurfAdapter::with_home(home.to_path_buf()));
+        assert!(windsurf.iter().any(|p| p.ends_with("frontend/ws-deep.md")));
+        let anti = rules_of(&AntigravityAdapter::with_home(home.to_path_buf()));
+        assert!(anti.iter().any(|p| p.ends_with("frontend/ag-deep.md")));
+    }
+
     #[test]
     fn test_scan_agent_configs_skips_missing_files() {
         let tmp = tempfile::tempdir().unwrap();

--- a/src/components/agents/config-file-entry.tsx
+++ b/src/components/agents/config-file-entry.tsx
@@ -102,12 +102,13 @@ export function ConfigFileEntry({
     return () => clearTimeout(timer);
   }, [highlight]);
 
+  // Show the file's actual directory, not just the scope root — with nested
+  // rules dirs (.claude/rules/frontend/…) the root alone no longer locates
+  // the file, and same-named files in different subdirs would be ambiguous.
   const scopePath =
     file.custom_id != null
       ? file.path
-      : file.scope.type === "global"
-        ? file.path.slice(0, file.path.lastIndexOf(file.file_name))
-        : file.scope.path;
+      : file.path.slice(0, file.path.lastIndexOf(file.file_name));
   const sizeLabel = formatBytes(file.size_bytes);
 
   return (


### PR DESCRIPTION
Closes #109

## Problem

HarnessKit scanned only one directory level for rules-style config directories. Several agents load rules from nested subdirectories, so files like `~/.claude/rules/frontend/react.md` existed and took effect in the agent but never appeared in HarnessKit.

While investigating #109 (flat `~/.claude/rules/*.md` could not be reproduced as broken — that layout has been scanned since v1.0.0), the nested-directory gap turned out to be real and wider than Claude.

## Approach

Every adapter was verified against its agent's official documentation, open source, or shipped binary before deciding whether to recurse — recursion is only added where the agent itself loads nested files, so HarnessKit never lists files the agent ignores.

| Agent | Verdict | Evidence | Change |
|---|---|---|---|
| Claude | recursive + symlinked dirs | [official docs](https://code.claude.com/docs/en/memory#organize-rules-with-claude%2Frules%2F) | global + project `**/*.md` |
| Copilot | recursive; user-level instructions dir existed unscanned | [VS Code docs](https://code.visualstudio.com/docs/agent-customization/custom-instructions), [GitHub docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-custom-instructions) | project `**`; add `~/.copilot/instructions/**/*.instructions.md` |
| Cursor | nested `.mdc` loaded; plain `.md` ignored ("wrong extension") | [official docs](https://cursor.com/docs/context/rules) | `.mdc` recursive; drop misleading `*.md` pattern |
| Windsurf | recursive | official binary (3.6.27) globs `**/.windsurf/rules/**/*.md` | project `**/*.md` |
| Antigravity | recursive | language server (2.0.4) walks rule dirs recursively | project `**/*.md` (both `.agents/` and legacy `.agent/`) |
| Kiro | top level only | [upstream: closed as not planned](https://github.com/kirodotdev/Kiro/issues/3215) | none |
| omp | non-recursive | [source: `recursive` defaults to false](https://github.com/can1357/oh-my-pi/blob/master/packages/coding-agent/src/discovery/helpers.ts) | none |
| Codex | single root→cwd chain, no rules dir | [source](https://github.com/openai/codex/blob/main/codex-rs/core/src/agents_md.rs) | none |
| OpenCode | subdir AGENTS.md is lazy runtime injection, not startup scan | [source](https://github.com/sst/opencode/blob/main/packages/opencode/src/session/instruction.ts) | none |
| Hermes | single global SOUL.md, no rules dir of its own | [docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files) | none |
| Gemini | any depth, but JIT-loaded since v0.54 | [source](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/tools/jit-context.ts) | kept at two levels deliberately — `**/GEMINI.md` would walk the whole project tree (incl. `node_modules`); documented in code |

## Changes

- New shared `files_with_ext_recursive` helper (walkdir: `follow_links`, depth cap; symlink loops are reported as errors by walkdir and skipped)
- Adapter pattern updates per the table above
- Config file rows now display the file's actual directory instead of the project root — with nested dirs the root no longer locates the file, and same-named files in different subdirs were indistinguishable
- One consolidated scanner test covering the five changed adapters: nested + flat regression, symlinked rule dir, circular symlink, and negative assertions (Cursor `.md` stays invisible; Copilot only `*.instructions.md` counts)

## Testing

- `cargo test -p hk-core`: 578 passed
- `npm run test`: 281 passed
- Verified end to end in `cargo tauri dev` with real nested fixtures across Claude (global + project), Copilot (global dir), Cursor (nested `.mdc` shown, `.md` correctly absent), and Antigravity

🤖 Generated with [Claude Code](https://claude.com/claude-code)