### PR TITLE
feat(extensions): inline file previews in the documentation tree + web copy-path

### DIFF
--- a/src/components/agents/agent-detail.tsx
+++ b/src/components/agents/agent-detail.tsx
@@ -98,7 +98,11 @@ export function AgentDetail() {
         : scope.path;
 
   return (
-    <div className="flex-1 overflow-y-auto overscroll-contain p-5">
+    // Keyed by agent so switching agents resets the scroll position.
+    <div
+      key={agent.name}
+      className="flex-1 overflow-y-auto overscroll-contain p-5"
+    >
       <div className="flex items-start justify-between mb-6">
         <div>
           <h2 className="text-2xl font-bold tracking-tight">

--- a/src/components/agents/config-file-entry.tsx
+++ b/src/components/agents/config-file-entry.tsx
@@ -271,7 +271,14 @@ export function ConfigFileEntry({
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      openInEditor(file.path);
+                      // Directories reveal in the file manager (matching the
+                      // button label); a bare `open <dir>` would hardcode
+                      // Finder instead of the user's default.
+                      if (file.is_dir) {
+                        revealInFinder(file.path);
+                      } else {
+                        openInEditor(file.path);
+                      }
                     }}
                     className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent"
                   >

--- a/src/components/extensions/__tests__/skill-file-section.test.tsx
+++ b/src/components/extensions/__tests__/skill-file-section.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SkillFileSection } from "../skill-file-section";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+// Web mode: no Open button, copy path available.
+vi.mock("@/lib/transport", () => ({
+  isDesktop: () => false,
+}));
+
+const copyPathToClipboard = vi.fn();
+vi.mock("@/lib/copy-path", () => ({
+  copyPathToClipboard: (path: string) => copyPathToClipboard(path),
+}));
+
+vi.mock("@/lib/invoke", () => ({
+  api: {
+    listSkillFiles: vi.fn(async () => [
+      { name: "SKILL.md", path: "/skill/SKILL.md", is_dir: false },
+      { name: "LICENSE.txt", path: "/skill/LICENSE.txt", is_dir: false },
+      {
+        name: "agents",
+        path: "/skill/agents",
+        is_dir: true,
+        children: [
+          {
+            name: "openai.yaml",
+            path: "/skill/agents/openai.yaml",
+            is_dir: false,
+          },
+        ],
+      },
+      {
+        name: "references",
+        path: "/skill/references",
+        is_dir: true,
+        children: [
+          { name: "cli.md", path: "/skill/references/cli.md", is_dir: false },
+        ],
+      },
+    ]),
+    readConfigFilePreview: vi.fn(async (path: string) => `CONTENT:${path}`),
+    openInSystem: vi.fn(),
+    revealInFileManager: vi.fn(),
+  },
+}));
+
+function renderSection() {
+  return render(<SkillFileSection dirPath="/skill" loading={false} />);
+}
+
+describe("SkillFileSection file previews", () => {
+  it("expands a file preview on click and collapses it on second click", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(await screen.findByText("SKILL.md"));
+    expect(
+      await screen.findByText("CONTENT:/skill/SKILL.md"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByText("SKILL.md"));
+    expect(
+      screen.queryByText("CONTENT:/skill/SKILL.md"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps at most one file preview open (accordion)", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(await screen.findByText("SKILL.md"));
+    await screen.findByText("CONTENT:/skill/SKILL.md");
+
+    await user.click(screen.getByText("LICENSE.txt"));
+    expect(
+      await screen.findByText("CONTENT:/skill/LICENSE.txt"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("CONTENT:/skill/SKILL.md"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps at most one sibling directory open (accordion)", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(await screen.findByText("agents"));
+    expect(await screen.findByText("openai.yaml")).toBeInTheDocument();
+
+    await user.click(screen.getByText("references"));
+    expect(await screen.findByText("cli.md")).toBeInTheDocument();
+    expect(screen.queryByText("openai.yaml")).not.toBeInTheDocument();
+  });
+
+  it("collapsing a directory also collapses the preview inside it", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(await screen.findByText("agents"));
+    await user.click(await screen.findByText("openai.yaml"));
+    await screen.findByText("CONTENT:/skill/agents/openai.yaml");
+
+    await user.click(screen.getByText("agents")); // collapse
+    await user.click(screen.getByText("agents")); // re-expand
+    expect(await screen.findByText("openai.yaml")).toBeInTheDocument();
+    expect(
+      screen.queryByText("CONTENT:/skill/agents/openai.yaml"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("web mode offers Copy Path but no Open button in the preview block", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(await screen.findByText("SKILL.md"));
+    await screen.findByText("CONTENT:/skill/SKILL.md");
+
+    expect(screen.queryByText("fileTree.open")).not.toBeInTheDocument();
+    await user.click(screen.getByText("file.copyPath"));
+    await waitFor(() =>
+      expect(copyPathToClipboard).toHaveBeenCalledWith("/skill/SKILL.md"),
+    );
+  });
+});

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -2,6 +2,7 @@ import { clsx } from "clsx";
 import {
   AlertTriangle,
   Calendar,
+  Copy,
   Download,
   Folder,
   FolderOpen,
@@ -27,6 +28,7 @@ import {
   canInstallAtScope,
   canReceiveMcpTransport,
 } from "@/lib/agent-capabilities";
+import { copyPathToClipboard } from "@/lib/copy-path";
 import i18n from "@/lib/i18n";
 import { api } from "@/lib/invoke";
 import { isDesktop } from "@/lib/transport";
@@ -64,6 +66,8 @@ export function ExtensionDetail() {
   const { t } = useTranslation("extensions");
   const { t: tc } = useTranslation("common");
   const { t: tm } = useTranslation("marketplace");
+  // Copy-path strings are shared with the Agents page rows.
+  const { t: ta } = useTranslation("agents");
   const grouped = useExtensionStore((s) => s.grouped);
   const selectedId = useExtensionStore((s) => s.selectedId);
   const setSelectedId = useExtensionStore((s) => s.setSelectedId);
@@ -282,8 +286,12 @@ export function ExtensionDetail() {
         onClose={() => setSelectedId(null)}
       />
 
-      {/* Scrollable body */}
-      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-5 py-4">
+      {/* Scrollable body — keyed by group so switching extensions remounts
+          the container and the scroll position starts at the top. */}
+      <div
+        key={group.groupKey}
+        className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-5 py-4"
+      >
         <p className="text-sm text-muted-foreground">
           {cliParent && (
             <>
@@ -885,17 +893,25 @@ export function ExtensionDetail() {
                   const activePath = activeInstanceId
                     ? instanceData.get(activeInstanceId)?.path
                     : undefined;
-                  return (
-                    isDesktop() &&
-                    activePath && (
-                      <button
-                        onClick={() => api.revealInFileManager(activePath)}
-                        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        <FolderOpen size={12} />
-                        {t("detail.openInFinder")}
-                      </button>
-                    )
+                  if (!activePath) return null;
+                  // Web mode can't open Finder, so the same slot offers
+                  // Copy Path instead (same split as the Agents page rows).
+                  return isDesktop() ? (
+                    <button
+                      onClick={() => api.revealInFileManager(activePath)}
+                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      <FolderOpen size={12} />
+                      {t("detail.openInFinder")}
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => copyPathToClipboard(activePath)}
+                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      <Copy size={12} />
+                      {ta("file.copyPath")}
+                    </button>
                   );
                 })()}
               </div>
@@ -919,14 +935,11 @@ export function ExtensionDetail() {
                 </div>
               )}
 
-              {/* File tree + SKILL.md content */}
+              {/* File tree with expandable per-file previews */}
               {activeInstanceId && (
                 <SkillFileSection
-                  instanceId={activeInstanceId}
-                  content={instanceData.get(activeInstanceId)?.content ?? null}
                   dirPath={instanceData.get(activeInstanceId)?.path ?? null}
                   loading={loadingContent}
-                  kind={group.kind}
                 />
               )}
             </div>

--- a/src/components/extensions/file-tree-node.tsx
+++ b/src/components/extensions/file-tree-node.tsx
@@ -1,96 +1,243 @@
 import {
   ChevronRight,
+  Copy,
   ExternalLink,
   File,
   FolderClosed,
   FolderOpen as FolderOpenIcon,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useScrollPassthrough } from "@/hooks/use-scroll-passthrough";
+import { copyPathToClipboard } from "@/lib/copy-path";
 import { api } from "@/lib/invoke";
 import { isDesktop } from "@/lib/transport";
 import type { FileEntry } from "@/lib/types";
 
 const MAX_FILES_PER_DIR = 3;
 
+interface FileAccordion {
+  /** Path of the single expanded file in this tree (accordion), if any. */
+  expandedPath: string | null;
+  onToggle: (path: string) => void;
+}
+
 export function FileTreeNode({
   entry,
   depth,
-}: {
+  expandedPath,
+  onToggle,
+  dirExpanded,
+  onToggleDir,
+}: FileAccordion & {
   entry: FileEntry;
   depth: number;
+  /** Whether this directory node is the one expanded among its siblings. */
+  dirExpanded: boolean;
+  onToggleDir: (path: string) => void;
+}) {
+  return entry.is_dir ? (
+    <DirNode
+      entry={entry}
+      depth={depth}
+      expandedPath={expandedPath}
+      onToggle={onToggle}
+      dirExpanded={dirExpanded}
+      onToggleDir={onToggleDir}
+    />
+  ) : (
+    <FileNode
+      entry={entry}
+      depth={depth}
+      expandedPath={expandedPath}
+      onToggle={onToggle}
+    />
+  );
+}
+
+function DirNode({
+  entry,
+  depth,
+  expandedPath,
+  onToggle,
+  dirExpanded,
+  onToggleDir,
+}: FileAccordion & {
+  entry: FileEntry;
+  depth: number;
+  dirExpanded: boolean;
+  onToggleDir: (path: string) => void;
 }) {
   const { t } = useTranslation("extensions");
-  const [expanded, setExpanded] = useState(false);
+  // Per-level accordion for THIS directory's subdirectories: at most one
+  // child dir open. Resets automatically when this node unmounts (i.e.
+  // when an ancestor collapses).
+  const [expandedChildDir, setExpandedChildDir] = useState<string | null>(null);
   const children = entry.children ?? [];
   const truncated = children.length > MAX_FILES_PER_DIR;
   const visibleChildren = truncated
     ? children.slice(0, MAX_FILES_PER_DIR)
     : children;
 
-  if (entry.is_dir) {
-    return (
-      <div>
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-xs text-foreground hover:bg-muted/60"
-          style={{ paddingLeft: `${depth * 16 + 4}px` }}
-        >
-          <ChevronRight
-            size={12}
-            className={`shrink-0 text-muted-foreground transition-transform duration-150 ${expanded ? "rotate-90" : ""}`}
-          />
-          {expanded ? (
-            <FolderOpenIcon size={13} className="shrink-0 text-primary/70" />
-          ) : (
-            <FolderClosed size={13} className="shrink-0 text-primary/70" />
-          )}
-          <span className="truncate">{entry.name}</span>
-        </button>
-        {expanded && (
-          <div>
-            {visibleChildren.map((child) => (
-              <FileTreeNode key={child.path} entry={child} depth={depth + 1} />
-            ))}
-            {isDesktop() &&
-              (truncated ? (
-                <button
-                  onClick={() => api.openInSystem(entry.path)}
-                  className="flex items-center gap-1.5 rounded px-1 py-0.5 text-xs text-muted-foreground hover:text-primary hover:bg-muted/60"
-                  style={{ paddingLeft: `${(depth + 1) * 16 + 4}px` }}
-                >
-                  <ExternalLink size={11} className="shrink-0" />
-                  <span>
-                    {t("fileTree.moreFiles", {
-                      count: children.length - MAX_FILES_PER_DIR,
-                    })}
-                  </span>
-                </button>
-              ) : (
-                <button
-                  onClick={() => api.openInSystem(entry.path)}
-                  className="flex items-center gap-1.5 rounded px-1 py-0.5 text-xs text-muted-foreground hover:text-primary hover:bg-muted/60"
-                  style={{ paddingLeft: `${(depth + 1) * 16 + 4}px` }}
-                >
-                  <ExternalLink size={11} className="shrink-0" />
-                  <span>{t("fileTree.openInFinder")}</span>
-                </button>
-              ))}
-          </div>
+  return (
+    <div>
+      <button
+        onClick={() => onToggleDir(entry.path)}
+        className="flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-xs text-foreground hover:bg-muted/60"
+        style={{ paddingLeft: `${depth * 16 + 4}px` }}
+      >
+        <ChevronRight
+          size={12}
+          className={`shrink-0 text-muted-foreground transition-transform duration-150 ${dirExpanded ? "rotate-90" : ""}`}
+        />
+        {dirExpanded ? (
+          <FolderOpenIcon size={13} className="shrink-0 text-primary/70" />
+        ) : (
+          <FolderClosed size={13} className="shrink-0 text-primary/70" />
         )}
-      </div>
-    );
-  }
+        <span className="truncate">{entry.name}</span>
+      </button>
+      {dirExpanded && (
+        <div>
+          {visibleChildren.map((child) => (
+            <FileTreeNode
+              key={child.path}
+              entry={child}
+              depth={depth + 1}
+              expandedPath={expandedPath}
+              onToggle={onToggle}
+              dirExpanded={expandedChildDir === child.path}
+              onToggleDir={(path) =>
+                setExpandedChildDir((current) =>
+                  current === path ? null : path,
+                )
+              }
+            />
+          ))}
+          {isDesktop() && (
+            <button
+              onClick={() => api.revealInFileManager(entry.path)}
+              className="flex items-center gap-1.5 rounded px-1 py-0.5 text-xs text-muted-foreground hover:text-primary hover:bg-muted/60"
+              style={{ paddingLeft: `${(depth + 1) * 16 + 4}px` }}
+            >
+              <ExternalLink size={11} className="shrink-0" />
+              <span>
+                {truncated
+                  ? t("fileTree.moreFiles", {
+                      count: children.length - MAX_FILES_PER_DIR,
+                    })
+                  : t("fileTree.openInFinder")}
+              </span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FileNode({
+  entry,
+  depth,
+  expandedPath,
+  onToggle,
+}: FileAccordion & { entry: FileEntry; depth: number }) {
+  // Files expand in place to a read-only preview (accordion: the tree root
+  // keeps a single expandedPath). Open/copy actions live inside the
+  // expanded block, mirroring the Agents page config rows.
+  const isExpanded = expandedPath === entry.path;
+
+  // If this node unmounts while expanded (its parent folder collapsed or
+  // was displaced by a sibling), clear the shared accordion so re-expanding
+  // the folder shows the file collapsed again.
+  const unmountRef = useRef({ isExpanded, path: entry.path, onToggle });
+  unmountRef.current = { isExpanded, path: entry.path, onToggle };
+  useEffect(
+    () => () => {
+      const { isExpanded: open, path, onToggle: toggle } = unmountRef.current;
+      if (open) toggle(path);
+    },
+    [],
+  );
 
   return (
-    <button
-      onClick={() => isDesktop() && api.openInSystem(entry.path)}
-      className="flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/60"
-      style={{ paddingLeft: `${depth * 16 + 20}px` }}
-      title={entry.path}
-    >
-      <File size={12} className="shrink-0" />
-      <span className="truncate">{entry.name}</span>
-    </button>
+    <div>
+      <button
+        onClick={() => onToggle(entry.path)}
+        className={`flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/60 ${isExpanded ? "bg-muted/60 text-foreground" : ""}`}
+        style={{ paddingLeft: `${depth * 16 + 20}px` }}
+        title={entry.path}
+      >
+        <File size={12} className="shrink-0" />
+        <span className="truncate">{entry.name}</span>
+      </button>
+      {isExpanded && <FilePreview path={entry.path} />}
+    </div>
+  );
+}
+
+/** Read-only preview + actions for the expanded file. Fetches once per
+ *  mount; binary or unreadable files surface as "preview unavailable". */
+function FilePreview({ path }: { path: string }) {
+  const { t } = useTranslation("extensions");
+  const { t: ta } = useTranslation("agents");
+  const { t: tc } = useTranslation("common");
+  const handleNestedWheel = useScrollPassthrough();
+  const [preview, setPreview] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .readConfigFilePreview(path)
+      .then((content) => {
+        if (!cancelled) setPreview(content);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+
+  const actionButton =
+    "inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent";
+
+  return (
+    <div className="my-1 rounded-md border border-border/50 bg-muted/30 px-2.5 py-2">
+      {failed ? (
+        <div className="mb-2 text-[11px] text-muted-foreground">
+          {ta("file.previewUnavailable")}
+        </div>
+      ) : preview === null ? (
+        <div className="mb-2 text-[11px] text-muted-foreground">
+          {tc("status.loading")}
+        </div>
+      ) : (
+        <pre
+          onWheel={handleNestedWheel}
+          className="mb-2 max-h-[200px] overflow-y-auto whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-muted-foreground"
+        >
+          {preview || ta("file.emptyFile")}
+        </pre>
+      )}
+      <div className="flex gap-2">
+        {isDesktop() && (
+          <button
+            onClick={() => api.openInSystem(path)}
+            className={actionButton}
+          >
+            <ExternalLink size={11} /> {t("fileTree.open")}
+          </button>
+        )}
+        <button
+          onClick={() => copyPathToClipboard(path)}
+          className={actionButton}
+        >
+          <Copy size={11} /> {ta("file.copyPath")}
+        </button>
+      </div>
+    </div>
   );
 }

--- a/src/components/extensions/skill-file-section.tsx
+++ b/src/components/extensions/skill-file-section.tsx
@@ -2,23 +2,26 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FileTreeNode } from "@/components/extensions/file-tree-node";
 import { api } from "@/lib/invoke";
-import type { ExtensionKind, FileEntry } from "@/lib/types";
+import type { FileEntry } from "@/lib/types";
 
 export function SkillFileSection({
   dirPath,
   loading,
 }: {
-  instanceId: string;
-  content: string | null;
   dirPath: string | null;
   loading: boolean;
-  kind: ExtensionKind;
 }) {
   const { t } = useTranslation("extensions");
   const { t: tc } = useTranslation("common");
   const [fileTree, setFileTree] = useState<FileEntry[] | null>(null);
+  // Accordion: at most one file preview open across the whole tree, and at
+  // most one root-level directory expanded (nested levels manage their own).
+  const [expandedPath, setExpandedPath] = useState<string | null>(null);
+  const [expandedDir, setExpandedDir] = useState<string | null>(null);
 
   useEffect(() => {
+    setExpandedPath(null);
+    setExpandedDir(null);
     if (!dirPath) {
       setFileTree(null);
       return;
@@ -46,7 +49,19 @@ export function SkillFileSection({
   return (
     <div className="rounded-lg border border-border bg-muted/20 p-2">
       {fileTree.map((entry) => (
-        <FileTreeNode key={entry.path} entry={entry} depth={0} />
+        <FileTreeNode
+          key={entry.path}
+          entry={entry}
+          depth={0}
+          expandedPath={expandedPath}
+          onToggle={(path) =>
+            setExpandedPath((current) => (current === path ? null : path))
+          }
+          dirExpanded={expandedDir === entry.path}
+          onToggleDir={(path) =>
+            setExpandedDir((current) => (current === path ? null : path))
+          }
+        />
       ))}
     </div>
   );

--- a/src/lib/copy-path.ts
+++ b/src/lib/copy-path.ts
@@ -1,0 +1,13 @@
+import i18n from "@/lib/i18n";
+import { toast } from "@/stores/toast-store";
+
+/** Copy a filesystem path to the clipboard, toasting success or failure.
+ *  Web mode's stand-in for "open in Finder / open in editor" affordances. */
+export async function copyPathToClipboard(path: string) {
+  try {
+    await navigator.clipboard.writeText(path);
+    toast.success(i18n.t("agents:toast.pathCopied"));
+  } catch {
+    toast.error(i18n.t("agents:toast.failedCopyPath"));
+  }
+}

--- a/src/lib/i18n/locales/en/extensions.json
+++ b/src/lib/i18n/locales/en/extensions.json
@@ -193,6 +193,7 @@
   },
   "fileTree": {
     "moreFiles": "{{count}} more — Open in Finder",
+    "open": "Open",
     "openInFinder": "Open in Finder"
   },
   "newSkills": {

--- a/src/lib/i18n/locales/zh-TW/extensions.json
+++ b/src/lib/i18n/locales/zh-TW/extensions.json
@@ -193,6 +193,7 @@
   },
   "fileTree": {
     "moreFiles": "還有 {{count}} 個，在 Finder 中開啟",
+    "open": "開啟",
     "openInFinder": "在 Finder 中開啟"
   },
   "newSkills": {

--- a/src/lib/i18n/locales/zh/extensions.json
+++ b/src/lib/i18n/locales/zh/extensions.json
@@ -193,6 +193,7 @@
   },
   "fileTree": {
     "moreFiles": "还有 {{count}} 个 — 在访达中打开",
+    "open": "打开",
     "openInFinder": "在访达中打开"
   },
   "newSkills": {

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -647,8 +647,12 @@ export default function MarketplacePage() {
                 </button>
               </div>
 
-              {/* Scrollable body */}
-              <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-5 py-4">
+              {/* Scrollable body — keyed by item so switching selections
+                  remounts the container and scroll starts at the top. */}
+              <div
+                key={selectedItem.id}
+                className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-5 py-4"
+              >
                 {selectedItem.description && (
                   <p className="text-sm text-muted-foreground">
                     {selectedItem.description}

--- a/src/stores/agent-config-store.ts
+++ b/src/stores/agent-config-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { copyPathToClipboard } from "@/lib/copy-path";
 import { humanizeError } from "@/lib/errors";
 import i18n from "@/lib/i18n";
 import { api } from "@/lib/invoke";
@@ -164,12 +165,7 @@ export const useAgentConfigStore = create<AgentConfigState>((set, get) => ({
   },
 
   async copyPath(path: string) {
-    try {
-      await navigator.clipboard.writeText(path);
-      toast.success(i18n.t("agents:toast.pathCopied"));
-    } catch {
-      toast.error(i18n.t("agents:toast.failedCopyPath"));
-    }
+    await copyPathToClipboard(path);
   },
 
   async addCustomPath(agent, path, label, category, targetScope) {


### PR DESCRIPTION
## Problem

In web mode the DOCUMENTATION section offered nothing: **Open in Finder** is desktop-only, and clicking a file was a silent no-op. Beyond that, neither platform could read a skill's files without leaving the app — deciding whether to keep or enable a skill meant opening SKILL.md in an external editor.

## Changes

**Inline file previews (both platforms)**
- Clicking a file expands a read-only preview in place (`<pre>`, 200px max height), reusing the existing `read_config_file_preview` channel — 30-line cap with a `... (N more lines)` tail; binary files degrade to "preview unavailable". Text-based files (including `.svg`, which is XML) preview as-is; no rendering, no editing.
- Accordion at both levels: at most one file preview open across the tree, and at most one subdirectory open per level. Collapsing a folder also collapses any preview inside it.
- Actions move into the expanded block, mirroring the Agents page config rows: **Open** (desktop) and **Copy Path** (both platforms).

**Web copy-path affordances**
- The section header shows **Copy Path** on web where Open in Finder can't work.
- One shared `copyPathToClipboard` helper now backs every copy-path site (Agents rows, section header, preview block) — the duplicated clipboard+toast logic in the agents store was removed.

**Reveal-in-file-manager consistency (desktop)**
- Directory rows in the file tree used a bare `open <dir>`, which hardcodes Finder; they now use `reveal_in_file_manager` like the section header, respecting the user's default file manager.
- Same fix on the Agents page: directory custom paths labeled "Reveal in Finder" actually called the open-in-editor path.

**Detail panels reset scroll on selection change**
- Extensions, Agents, and Marketplace detail panels kept the previous item's scroll position when switching selections. The scroll containers are now keyed by the selected item's identity so each selection starts at the top.

**Cleanup**
- `SkillFileSection`'s dead `content`/`instanceId`/`kind` props (declared but never rendered since the component split) are removed.
- The file tree is split into `DirNode`/`FileNode` so each node type only carries its own state and effects.

## Testing

- `npm run test`: 286 passed (5 new tests: expand/collapse, file accordion, sibling-dir accordion, preview reset on folder collapse, web-mode button set)
- `npx tsc --noEmit` and `biome check` clean (2 pre-existing warnings untouched)
- Verified end to end in both `cargo tauri dev` (desktop) and `hk serve` + Vite (web): previews, both accordions, folder-collapse reset, copy path on header/files, reveal behavior on directory rows, and scroll reset across Extensions / Agents / Marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)