### PR TITLE
release: v1.8.2

### DIFF
--- a/.github/release-notes/v1.8.2.md
+++ b/.github/release-notes/v1.8.2.md
@@ -1,0 +1,13 @@
+## ✨ Highlights
+
+- **Traditional Chinese** — the app is now available in Traditional Chinese. Pick it in Settings → Language. Thanks @lotushj1! (#110)
+- **Rules in subfolders are now detected** — if you organize your rules in subdirectories (like `~/.claude/rules/frontend/`), HarnessKit now finds them, matching how each agent actually loads rules.
+- **Preview files right in the app** — click any file in a skill's Documentation section to read it on the spot, then copy its path or open it from there. Web mode adds Copy Path buttons for files and folders.
+
+<!-- lang:zh
+## ✨ 更新亮点
+
+- **繁體中文界面** — 应用现已支持繁体中文，在 设置 → 语言 中切换。感谢 @lotushj1！(#110)
+- **子目录里的规则文件也能识别了** — 如果你把 rules 按子目录组织（比如 `~/.claude/rules/frontend/`），HarnessKit 现在能正确扫描到，与各 Agent 的实际加载行为保持一致。
+- **应用内直接预览文件** — 在 skill 的文档区点击任意文件即可当场查看内容，并可一键复制路径或打开。Web 模式为文件和文件夹新增了"复制路径"按钮。
+-->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk-cli"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "hk-core"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "hk-desktop"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "hk-web"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hk-core", "crates/hk-cli", "crates/hk-desktop", "crates/hk-we
 resolver = "2"
 
 [workspace.package]
-version = "1.8.1"
+version = "1.8.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/hk-desktop/tauri.conf.json
+++ b/crates/hk-desktop/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "HarnessKit",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "identifier": "com.harnesskit.app",
   "build": {
     "frontendDist": "../../dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "harnesskit-frontend",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harnesskit-frontend",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harnesskit-frontend",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Cross-platform extension management for AI coding agents",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to 1.8.2 (Cargo.toml / Cargo.lock / package.json / package-lock.json / tauri.conf.json) plus bilingual release notes at `.github/release-notes/v1.8.2.md`.

Ships:
- Traditional Chinese locale — #110 (thanks @lotushj1)
- Recursive scanning for nested rules directories across agents — #111
- Inline file previews in the documentation tree + web copy-path — #112

After merge: tag `v1.8.2` on main to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)