### PR TITLE
Polish Extensions selected row indicator

### DIFF
--- a/src/components/extensions/extension-table.tsx
+++ b/src/components/extensions/extension-table.tsx
@@ -312,30 +312,39 @@ export function ExtensionTable({
             ))}
           </thead>
           <tbody className="divide-y divide-border">
-            {rows.map((row) => (
-              <tr
-                key={row.id}
-                id={`ext-row-${row.id}`}
-                onClick={() =>
-                  setSelectedId(
-                    row.original.groupKey === selectedId
-                      ? null
-                      : row.original.groupKey,
-                  )
-                }
-                className={`cursor-pointer transition-colors duration-150 ${
-                  row.original.groupKey === selectedId
-                    ? "bg-accent border-l-2 border-l-primary"
-                    : "hover:bg-muted/40"
-                }`}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <td key={cell.id} className="px-4 py-3 text-sm">
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-            ))}
+            {rows.map((row) => {
+              const isSelected = row.original.groupKey === selectedId;
+              return (
+                <tr
+                  key={row.id}
+                  id={`ext-row-${row.id}`}
+                  onClick={() =>
+                    setSelectedId(isSelected ? null : row.original.groupKey)
+                  }
+                  className={`cursor-pointer transition-colors duration-150 ${
+                    isSelected ? "bg-accent" : "hover:bg-muted/40"
+                  }`}
+                >
+                  {row.getVisibleCells().map((cell, i) => (
+                    <td
+                      key={cell.id}
+                      className={`px-4 py-3 text-sm${i === 0 ? " relative" : ""}`}
+                    >
+                      {i === 0 && isSelected && (
+                        <span
+                          aria-hidden="true"
+                          className="animate-grow-y absolute left-1 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-full bg-primary"
+                        />
+                      )}
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/src/components/extensions/extension-table.tsx
+++ b/src/components/extensions/extension-table.tsx
@@ -325,23 +325,29 @@ export function ExtensionTable({
                     isSelected ? "bg-accent" : "hover:bg-muted/40"
                   }`}
                 >
-                  {row.getVisibleCells().map((cell, i) => (
-                    <td
-                      key={cell.id}
-                      className={`px-4 py-3 text-sm${i === 0 ? " relative" : ""}`}
-                    >
-                      {i === 0 && isSelected && (
-                        <span
-                          aria-hidden="true"
-                          className="animate-grow-y absolute left-1 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-full bg-primary"
-                        />
-                      )}
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </td>
-                  ))}
+                  {row.getVisibleCells().map((cell) => {
+                    // The pill anchors to the "select" column by id, not by
+                    // position, so reordering or inserting columns can't
+                    // detach it from the row's left edge.
+                    const anchorsPill = cell.column.id === "select";
+                    return (
+                      <td
+                        key={cell.id}
+                        className={`px-4 py-3 text-sm${anchorsPill ? " relative" : ""}`}
+                      >
+                        {anchorsPill && isSelected && (
+                          <span
+                            aria-hidden="true"
+                            className="animate-grow-y absolute left-1 top-2.5 bottom-2.5 w-[3px] rounded-full bg-primary"
+                          />
+                        )}
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </td>
+                    );
+                  })}
                 </tr>
               );
             })}

--- a/src/index.css
+++ b/src/index.css
@@ -903,6 +903,18 @@ button:focus-visible,
   }
 }
 
+/* Selection pill "blooms" open from its vertical center toward both ends.
+   Uses the native `scale` property so it can't clash with Tailwind's
+   translate/transform utilities on the same element. */
+@keyframes grow-y {
+  from {
+    scale: 1 0;
+  }
+  to {
+    scale: 1 1;
+  }
+}
+
 @keyframes shimmer {
   0% {
     background-position: -200% 0;
@@ -1082,6 +1094,12 @@ button:focus-visible,
     animation: scale-in 150ms ease-out both;
   }
 
+  /* Slight back-out overshoot: the pill stretches a touch past its final
+     height, then settles — reads as a playful "pop". */
+  .animate-grow-y {
+    animation: grow-y 200ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+
   .animate-shimmer {
     background: linear-gradient(
       90deg,
@@ -1201,6 +1219,7 @@ button:focus-visible,
   .animate-fade-in,
   .animate-slide-in-right,
   .animate-scale-in,
+  .animate-grow-y,
   .animate-shimmer,
   .indeterminate-bar,
   .all-clear-pulse,


### PR DESCRIPTION
## Summary

- Move the indicator inward so it no longer clips awkwardly against the rounded table container on the last row.
- Refine the selected row indicator in the Extensions table.

## Snapshots

### Before
<img width="708" height="138" alt="image" src="https://github.com/user-attachments/assets/b248313a-a632-42c4-9692-70972372a5bb" />

### After
<img width="726" height="116" alt="image" src="https://github.com/user-attachments/assets/0d222dec-dc7f-430b-b322-c99875f96fe8" />