### PR TITLE
feat: DeepSeek Harness (dsh) agent support — skills, MCP scan + native toggle, audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ HarnessKit manages **all five extension types** from a unified interface — **S
 | **Hermes** | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **Kiro** | ✓ | ✓ | — | ✓ | ✓ |
 | **Oh My Pi** | ✓ | ✓ | ✓ | — | ✓ |
+| **DeepSeek Harness** | ✓ | ✓ | — | — | ✓ |
 
 <small><i>* "—" indicates the agent currently does not support this extension type. Devin Desktop support keeps legacy Windsurf paths compatible.</i></small>
 
@@ -88,7 +89,7 @@ HarnessKit manages **all five extension types** from a unified interface — **S
 
 ### 🤖 Agent Configs, Memory & Rules
 
-HarnessKit manages every agent's **Configs**, **Memory**, **Rules**, **Subagents**, and **Ignore** files from one place. Currently supporting **11 agents**: **Claude Code**, **Codex**, **Gemini CLI**, **Cursor**, **Antigravity**, **Copilot**, **Devin Desktop**, **OpenCode**, **Hermes**, **Kiro**, and **Oh My Pi**.
+HarnessKit manages every agent's **Configs**, **Memory**, **Rules**, **Subagents**, and **Ignore** files from one place. Currently supporting **12 agents**: **Claude Code**, **Codex**, **Gemini CLI**, **Cursor**, **Antigravity**, **Copilot**, **Devin Desktop**, **OpenCode**, **Hermes**, **Kiro**, **Oh My Pi**, and **DeepSeek Harness**.
 
 - **Config file tracking** — Automatically discovers every agent's config files — both global and per-project. Add your project directories or custom paths and HarnessKit picks them up alongside the global ones.
 - **Per-agent dashboard** — Each agent gets its own page with all files organized by category, showing scope, path, file size, and a summary of installed extensions. Expand any file to preview its content right in the app.
@@ -176,7 +177,7 @@ HarnessKit ships a standalone command-line interface (`hk`) for terminal-first w
 
 ```shell
 $ hk status
-  Agents        11 detected (claude · codex · gemini · cursor · antigravity · copilot · windsurf · opencode · hermes · kiro · omp)
+  Agents        12 detected (claude · codex · gemini · cursor · antigravity · copilot · windsurf · opencode · hermes · kiro · omp · dsh)
   Extensions    136 total (124 skills · 2 mcp · 8 plugins · 1 hooks · 1 clis)
 
 $ hk list --kind skill --agent claude    # filter by type and agent

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,6 +69,7 @@ HarnessKit 通过统一界面管理 **全部五种扩展类型** —— **Skill*
 | **Hermes** | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **Kiro** | ✓ | ✓ | — | ✓ | ✓ |
 | **Oh My Pi** | ✓ | ✓ | ✓ | — | ✓ |
+| **DeepSeek Harness** | ✓ | ✓ | — | — | ✓ |
 
 <small><i>* "—" 表示该 Agent 目前不支持此扩展类型。Devin Desktop 支持会继续兼容旧 Windsurf 路径。</i></small>
 
@@ -88,7 +89,7 @@ HarnessKit 通过统一界面管理 **全部五种扩展类型** —— **Skill*
 
 ### 🤖 Agent 配置、记忆与规则
 
-HarnessKit 统一管理每个 Agent 的 **配置**、**记忆**、**规则**、**子 Agent** 与 **忽略**（Ignore）文件。目前支持 **11 个 Agent**：**Claude Code**、**Codex**、**Gemini CLI**、**Cursor**、**Antigravity**、**Copilot**、**Devin Desktop**、**OpenCode**、**Hermes**、**Kiro** 与 **Oh My Pi**。
+HarnessKit 统一管理每个 Agent 的 **配置**、**记忆**、**规则**、**子 Agent** 与 **忽略**（Ignore）文件。目前支持 **12 个 Agent**：**Claude Code**、**Codex**、**Gemini CLI**、**Cursor**、**Antigravity**、**Copilot**、**Devin Desktop**、**OpenCode**、**Hermes**、**Kiro**、**Oh My Pi** 与 **DeepSeek Harness**。
 
 - **配置文件跟踪** —— 自动发现每个 Agent 的全局与项目级配置文件。添加项目目录或自定义路径后，HarnessKit 会将它们与全局配置一同纳入管理。
 - **Agent 专属面板** —— 每个 Agent 拥有独立页面，文件按类别组织，列出范围、路径、文件大小以及已安装扩展的概览。展开任意文件即可在应用内预览。
@@ -176,7 +177,7 @@ HarnessKit 提供独立命令行工具（`hk`），面向偏好终端的工作�
 
 ```shell
 $ hk status
-  Agents        11 detected (claude · codex · gemini · cursor · antigravity · copilot · windsurf · opencode · hermes · kiro · omp)
+  Agents        12 detected (claude · codex · gemini · cursor · antigravity · copilot · windsurf · opencode · hermes · kiro · omp · dsh)
   Extensions    136 total (124 skills · 2 mcp · 8 plugins · 1 hooks · 1 clis)
 
 $ hk list --kind skill --agent claude    # 按类型与 Agent 筛选

--- a/crates/hk-core/src/adapter/dsh.rs
+++ b/crates/hk-core/src/adapter/dsh.rs
@@ -19,7 +19,9 @@
 // - Rules: packages/context/agent-instructions — `$DSH_HOME/AGENTS.md` global,
 //   project chain reads AGENTS.md / CLAUDE.md + AGENTS.local.md / CLAUDE.local.md.
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, McpTransport, ProjectMarker};
+use super::{
+    AgentAdapter, HookEntry, HookFormat, McpFormat, McpServerEntry, McpTransport, ProjectMarker,
+};
 use std::path::{Path, PathBuf};
 
 pub struct DshAdapter {
@@ -339,9 +341,13 @@ impl AgentAdapter for DshAdapter {
         HookFormat::None
     }
 
-    // mcp_format + supports_native_mcp_toggle overridden in Task 3
-    // (McpFormat::DshCordis doesn't exist yet; trait defaults — McpServers /
-    // false — apply until then).
+    fn mcp_format(&self) -> McpFormat {
+        McpFormat::DshCordis
+    }
+
+    fn supports_native_mcp_toggle(&self) -> bool {
+        true
+    }
 
     fn read_mcp_servers(&self) -> Vec<McpServerEntry> {
         self.read_mcp_servers_from(&self.mcp_config_path())

--- a/crates/hk-core/src/adapter/dsh.rs
+++ b/crates/hk-core/src/adapter/dsh.rs
@@ -19,7 +19,7 @@
 // - Rules: packages/context/agent-instructions — `$DSH_HOME/AGENTS.md` global,
 //   project chain reads AGENTS.md / CLAUDE.md + AGENTS.local.md / CLAUDE.local.md.
 
-use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker};
+use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, McpTransport, ProjectMarker};
 use std::path::{Path, PathBuf};
 
 pub struct DshAdapter {
@@ -96,6 +96,207 @@ impl DshAdapter {
     }
 }
 
+/// dsh's `@deepseek-ai/dsh-mcp-client` plugin name — the marker for MCP rows.
+const MCP_CLIENT_PLUGIN: &str = "@deepseek-ai/dsh-mcp-client";
+
+/// One entry parsed from a patch file. `from_insert` distinguishes row
+/// DEFINITIONS (inside `insert:`) from id-targeted overrides — upstream, an
+/// override can never create a row.
+struct CordisRow {
+    id: Option<String>,
+    name: Option<String>,
+    /// Literal booleans, plus `null` ≡ `false` (static upstream rule,
+    /// vendor/loader/src/config/entry.ts:104-107). Only absent keys and
+    /// `!!js` expressions (which arrive as tag-stripped strings) read as
+    /// None — upstream evaluates js `disabled` at runtime; HK can't, so it
+    /// shows the base state.
+    disabled: Option<bool>,
+    config: serde_yaml::Value,
+    from_insert: bool,
+}
+
+/// Parse one patch file into ordered entries. `{id, insert}` (group append)
+/// is out of scope and skipped. A parse failure returns empty WITH a stderr
+/// diagnostic — silence here would read as "dsh has no MCP".
+fn parse_patch_rows(text: &str, origin: &Path) -> Vec<CordisRow> {
+    let doc: serde_yaml::Value = match serde_yaml::from_str(text) {
+        Ok(doc) => doc,
+        Err(err) => {
+            eprintln!("[hk] warning: cannot parse {}: {err}", origin.display());
+            return vec![];
+        }
+    };
+    let Some(items) = doc.as_sequence() else {
+        eprintln!(
+            "[hk] warning: {} is not a YAML list (cordis patch files are top-level arrays)",
+            origin.display()
+        );
+        return vec![];
+    };
+    let mut rows = Vec::new();
+    for item in items {
+        let Some(map) = item.as_mapping() else { continue };
+        let has_id = map.get("id").is_some();
+        let insert = map.get("insert").and_then(|v| v.as_sequence());
+        match (has_id, insert) {
+            (false, Some(inserted)) => {
+                for row in inserted {
+                    let Some(rm) = row.as_mapping() else { continue };
+                    rows.push(CordisRow {
+                        id: yaml_str(rm, "id"),
+                        name: yaml_str(rm, "name"),
+                        disabled: yaml_disabled(rm.get("disabled")),
+                        config: rm.get("config").cloned().unwrap_or(serde_yaml::Value::Null),
+                        from_insert: true,
+                    });
+                }
+            }
+            (true, None) => rows.push(CordisRow {
+                id: yaml_str(map, "id"),
+                name: yaml_str(map, "name"),
+                disabled: yaml_disabled(map.get("disabled")),
+                config: map.get("config").cloned().unwrap_or(serde_yaml::Value::Null),
+                from_insert: false,
+            }),
+            // {id, insert} = group append; bare junk = neither. Both skipped.
+            _ => {}
+        }
+    }
+    rows
+}
+
+fn yaml_str(map: &serde_yaml::Mapping, key: &str) -> Option<String> {
+    map.get(key).and_then(|v| v.as_str()).map(String::from)
+}
+
+fn yaml_disabled(v: Option<&serde_yaml::Value>) -> Option<bool> {
+    match v {
+        Some(serde_yaml::Value::Null) => Some(false), // upstream: null ≡ false
+        Some(serde_yaml::Value::Bool(b)) => Some(*b),
+        _ => None, // absent, or !!js expression (arrives as String — HK can't evaluate)
+    }
+}
+
+fn yaml_config_str(config: &serde_yaml::Value, key: &str) -> Option<String> {
+    config.get(key).and_then(|v| v.as_str()).map(String::from)
+}
+
+/// Folded final state of one MCP row within one patch file (single ordered
+/// apply, later entries win — mirrors upstream applyEntryPatches).
+struct McpRowState {
+    id: Option<String>,
+    disabled: bool,
+    config: serde_yaml::Value,
+}
+
+impl DshAdapter {
+    fn fold_mcp_rows_in_text(text: &str, origin: &Path) -> Vec<McpRowState> {
+        let mut order: Vec<String> = Vec::new();
+        let mut by_id: std::collections::HashMap<String, McpRowState> =
+            std::collections::HashMap::new();
+        let mut anon: Vec<McpRowState> = Vec::new();
+
+        for row in parse_patch_rows(text, origin) {
+            let CordisRow { id, name, disabled, config, from_insert } = row;
+            let is_mcp_def = from_insert && name.as_deref() == Some(MCP_CLIENT_PLUGIN);
+            match id {
+                Some(id) if is_mcp_def => {
+                    order.push(id.clone());
+                    by_id.insert(
+                        id.clone(),
+                        McpRowState { id: Some(id), disabled: disabled.unwrap_or(false), config },
+                    );
+                }
+                Some(id) if !from_insert => {
+                    // Override: only mutates an existing row (upstream:
+                    // unknown id is warn+skip, never a definition).
+                    if let Some(existing) = by_id.get_mut(&id) {
+                        if let Some(d) = disabled {
+                            existing.disabled = d;
+                        }
+                        if !config.is_null() {
+                            existing.config = config;
+                        }
+                    }
+                }
+                // From-insert definition of some other plugin — never an
+                // override; skip (even on a malformed id collision).
+                Some(_) => {}
+                None if is_mcp_def => {
+                    anon.push(McpRowState { id: None, disabled: disabled.unwrap_or(false), config })
+                }
+                None => {}
+            }
+        }
+        let mut out: Vec<McpRowState> =
+            order.into_iter().filter_map(|id| by_id.remove(&id)).collect();
+        out.extend(anon);
+        out
+    }
+
+    fn mcp_entries_in_text(text: &str, origin: &Path) -> Vec<McpServerEntry> {
+        Self::fold_mcp_rows_in_text(text, origin)
+            .into_iter()
+            .filter_map(|row| {
+                let config = &row.config;
+                let server_name = yaml_config_str(config, "serverName")?;
+                // Remote MCP: {url, headers?} — stdio MCP: {command, args, env}.
+                // `url` decides remote-vs-stdio FIRST (as in hermes.rs): dsh
+                // ships only stdio and streamable-http, so a url-bearing row is
+                // Streamable HTTP even when `transport` is omitted or carries
+                // some other value. Deciding on the transport string instead
+                // would emit a contradictory stdio entry with an empty command.
+                let url = yaml_config_str(config, "url");
+                let (transport, command) = match &url {
+                    Some(_) => (McpTransport::Http, String::new()),
+                    // Command may be absent on a malformed row; keep the entry
+                    // visible (empty command) rather than hiding it.
+                    None => (
+                        McpTransport::Stdio,
+                        yaml_config_str(config, "command").unwrap_or_default(),
+                    ),
+                };
+                Some(McpServerEntry {
+                    name: server_name,
+                    command,
+                    args: config
+                        .get("args")
+                        .and_then(|v| v.as_sequence())
+                        .map(|seq| {
+                            seq.iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                    env: super::yaml_string_map(config, "env"),
+                    transport,
+                    url,
+                    headers: super::yaml_string_map(config, "headers"),
+                    enabled: !row.disabled,
+                })
+            })
+            .collect()
+    }
+
+    /// Row id for a serverName (unique across live instances upstream).
+    /// Text-based so the deployer can evaluate the file it already read.
+    pub fn mcp_row_id_in_text(text: &str, server_name: &str) -> Option<String> {
+        Self::fold_mcp_rows_in_text(text, Path::new("cordis.patch.yml"))
+            .into_iter()
+            .find(|r| yaml_config_str(&r.config, "serverName").as_deref() == Some(server_name))
+            .and_then(|r| r.id)
+    }
+
+    /// serverName → enabled for the given home-layer text (deployer uses this
+    /// to compute base state with HK's managed block stripped).
+    pub fn mcp_enabled_in_text(text: &str) -> std::collections::HashMap<String, bool> {
+        Self::fold_mcp_rows_in_text(text, Path::new("cordis.patch.yml"))
+            .into_iter()
+            .filter_map(|r| Some((yaml_config_str(&r.config, "serverName")?, !r.disabled)))
+            .collect()
+    }
+}
+
 impl AgentAdapter for DshAdapter {
     fn name(&self) -> &str {
         "dsh"
@@ -143,8 +344,14 @@ impl AgentAdapter for DshAdapter {
     // false — apply until then).
 
     fn read_mcp_servers(&self) -> Vec<McpServerEntry> {
-        // Implemented in Task 2.
-        vec![]
+        self.read_mcp_servers_from(&self.mcp_config_path())
+    }
+
+    fn read_mcp_servers_from(&self, path: &Path) -> Vec<McpServerEntry> {
+        let Ok(text) = std::fs::read_to_string(path) else {
+            return vec![];
+        };
+        Self::mcp_entries_in_text(&text, path)
     }
 
     fn read_hooks(&self) -> Vec<HookEntry> {
@@ -267,5 +474,178 @@ mod tests {
         // No project-level MCP/hook config exists upstream.
         assert_eq!(adapter.project_mcp_config_relpath(), None);
         assert_eq!(adapter.project_hook_config_relpath(), None);
+    }
+
+    /// Pins the load-bearing dependency behavior: serde_yaml parses `!!js`
+    /// scalars (plain / quoted / block forms) WITHOUT error and silently
+    /// strips the tag, yielding the expression as a plain String. Every
+    /// reader below builds on this. If this test ever fails, serde_yaml's
+    /// tag handling changed — re-verify the readers before touching them.
+    #[test]
+    fn serde_yaml_strips_double_bang_tags_to_plain_strings() {
+        for (text, expected) in [
+            ("k: !!js process.cwd()", "process.cwd()"),
+            ("k: !!js '`Bearer ${process.env.T}`'", "`Bearer ${process.env.T}`"),
+            (
+                "k: !!js >-\n  process.env.X?.trim() ||\n  fallback()",
+                "process.env.X?.trim() || fallback()",
+            ),
+        ] {
+            let v: serde_yaml::Value = serde_yaml::from_str(text).unwrap();
+            assert_eq!(v.get("k").and_then(|v| v.as_str()), Some(expected), "input: {text}");
+        }
+    }
+
+    /// Home-layer fixture. The `env` block-scalar entry is copied from dsh's
+    /// own examples/mcp-memory/mcp-reference-memory.cordis.yml — its README
+    /// tells users to merge exactly this into the patch files HK reads.
+    const HOME_PATCH: &str = r#"# user layer — keep this comment
+- insert:
+    - id: mcp-github
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: github
+        transport: stdio
+        command: npx
+        args: ['-y', '@modelcontextprotocol/server-github']
+        cwd: !!js process.cwd()
+        env:
+          GITHUB_TOKEN: !!js process.env.GITHUB_TOKEN
+          MEMORY_FILE_PATH: !!js >-
+            process.env.MEMORY_FILE_PATH?.trim() ||
+            process.getBuiltinModule('node:path').join(process.cwd(), 'memory.json')
+    - id: mcp-web
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: web
+        transport: streamable-http
+        url: http://localhost:3000/mcp
+        headers:
+          Authorization: !!js '`Bearer ${process.env.MCP_TOKEN}`'
+- id: mcp-github
+  disabled: true
+"#;
+
+    fn write_home_patch(home: &Path, text: &str) {
+        std::fs::create_dir_all(home.join(".dsh")).unwrap();
+        std::fs::write(home.join(".dsh/cordis.patch.yml"), text).unwrap();
+    }
+
+    #[test]
+    fn read_mcp_servers_parses_home_layer_with_js_tags() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_home_patch(tmp.path(), HOME_PATCH);
+        let adapter = DshAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers();
+        assert_eq!(servers.len(), 2);
+
+        let gh = servers.iter().find(|s| s.name == "github").unwrap();
+        assert!(!gh.enabled, "later same-file override disabled mcp-github");
+        assert_eq!(gh.command, "npx");
+        assert_eq!(gh.args, vec!["-y", "@modelcontextprotocol/server-github"]);
+        // !!js values arrive tag-stripped as bare expression text — shown
+        // as-is, never evaluated (see the probe test above).
+        assert_eq!(gh.env["GITHUB_TOKEN"], "process.env.GITHUB_TOKEN");
+        assert!(gh.env["MEMORY_FILE_PATH"].starts_with("process.env.MEMORY_FILE_PATH?.trim()"));
+
+        let web = servers.iter().find(|s| s.name == "web").unwrap();
+        assert_eq!(web.transport, McpTransport::Http);
+        assert_eq!(web.url.as_deref(), Some("http://localhost:3000/mcp"));
+        assert_eq!(web.headers["Authorization"], "`Bearer ${process.env.MCP_TOKEN}`");
+        assert!(web.enabled);
+    }
+
+    #[test]
+    fn disabled_false_later_in_file_reenables() {
+        let tmp = tempfile::tempdir().unwrap();
+        let text = format!("{HOME_PATCH}- id: mcp-github\n  disabled: false\n");
+        write_home_patch(tmp.path(), &text);
+        let adapter = DshAdapter::with_home(tmp.path().to_path_buf());
+        let gh = adapter
+            .read_mcp_servers()
+            .into_iter()
+            .find(|s| s.name == "github")
+            .unwrap();
+        assert!(gh.enabled, "later entry wins (single ordered apply upstream)");
+    }
+
+    #[test]
+    fn bare_override_never_creates_a_row() {
+        // Upstream: a patch targeting an unknown id is warn+skip, never a
+        // definition (vendor/include/src/index.ts:107-112).
+        let tmp = tempfile::tempdir().unwrap();
+        write_home_patch(
+            tmp.path(),
+            "- id: ghost\n  name: '@deepseek-ai/dsh-mcp-client'\n  config:\n    serverName: ghost\n",
+        );
+        let adapter = DshAdapter::with_home(tmp.path().to_path_buf());
+        assert!(adapter.read_mcp_servers().is_empty());
+    }
+
+    #[test]
+    fn mcp_row_id_lookup_by_server_name() {
+        assert_eq!(
+            DshAdapter::mcp_row_id_in_text(HOME_PATCH, "github").as_deref(),
+            Some("mcp-github")
+        );
+        assert_eq!(DshAdapter::mcp_row_id_in_text(HOME_PATCH, "nope"), None);
+    }
+
+    #[test]
+    fn mcp_enabled_map_reflects_folded_state() {
+        let map = DshAdapter::mcp_enabled_in_text(HOME_PATCH);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["github"], false);
+        assert_eq!(map["web"], true);
+
+        // `disabled: null` ≡ false upstream (static rule, entry.ts:104-107) —
+        // a null override re-enables a previously disabled row.
+        let text = format!("{HOME_PATCH}- id: mcp-github\n  disabled: null\n");
+        let map = DshAdapter::mcp_enabled_in_text(&text);
+        assert_eq!(map["github"], true, "disabled: null re-enables");
+    }
+
+    #[test]
+    fn url_decides_remote_even_without_a_transport_key() {
+        // A url-bearing row with `transport` omitted (or set to anything other
+        // than streamable-http) is still remote — never a stdio entry with an
+        // empty command.
+        let tmp = tempfile::tempdir().unwrap();
+        write_home_patch(
+            tmp.path(),
+            r#"- insert:
+    - id: mcp-a
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: a
+        url: https://a.example/mcp
+    - id: mcp-b
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: b
+        transport: sse
+        url: https://b.example/mcp
+"#,
+        );
+        let adapter = DshAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers();
+        assert_eq!(servers.len(), 2);
+        for s in &servers {
+            assert_eq!(s.transport, McpTransport::Http, "{} should be remote", s.name);
+            assert!(s.command.is_empty(), "{} should carry no command", s.name);
+            assert!(s.url.is_some(), "{} should keep its url", s.name);
+        }
+    }
+
+    #[test]
+    fn read_mcp_servers_from_reads_the_given_file() {
+        // The service delete path locates entries via read_mcp_servers_from;
+        // returning them (instead of the trait's empty default) turns dsh MCP
+        // deletion into a loud DshCordis error instead of a silent no-op.
+        let tmp = tempfile::tempdir().unwrap();
+        write_home_patch(tmp.path(), HOME_PATCH);
+        let adapter = DshAdapter::with_home(tmp.path().to_path_buf());
+        let servers = adapter.read_mcp_servers_from(&tmp.path().join(".dsh/cordis.patch.yml"));
+        assert_eq!(servers.len(), 2);
     }
 }

--- a/crates/hk-core/src/adapter/dsh.rs
+++ b/crates/hk-core/src/adapter/dsh.rs
@@ -70,7 +70,8 @@ impl DshAdapter {
         }
     }
 
-    #[cfg(test)]
+    /// Test/deployer constructor rooting both homes under `home`; production
+    /// uses `new()`.
     pub fn with_home(home: PathBuf) -> Self {
         Self {
             dsh_home: home.join(".dsh"),

--- a/crates/hk-core/src/adapter/dsh.rs
+++ b/crates/hk-core/src/adapter/dsh.rs
@@ -1,0 +1,271 @@
+// DeepSeek Harness (dsh) config references — verified against
+// github.com/deepseek-ai/deepseek-harness @ v0.1.0-rc (2026-08-14):
+// - Home resolution: packages/util/home-paths (`$DSH_HOME` else `~/.dsh`;
+//   the harness keeps all user data under one root).
+// - Skills:  docs/subsystems/skills.md — roots (rank order) `<project>/.dsh/skills`,
+//   `<project>/.agents/skills`, `<dshHome>/skills` (skips `.system` child),
+//   `<agentsHome>/skills` where agentsHome = `$DSH_AGENTS_HOME` else `~/.agents`
+//   (packages/skill/skill-filesystem/src/index.ts). Bundle `<name>/SKILL.md` or
+//   flat `<name>.md`, one level deep — matches scan_skill_dir exactly, and the
+//   `.system` dir is naturally invisible to a one-level scan (its skills nest
+//   one level deeper).
+// - MCP: packages/mcp/mcp-client — servers are `@deepseek-ai/dsh-mcp-client`
+//   plugin rows in cordis patch files. dsh runs one profile at a time
+//   (profile patch, then home patch); HK reads the HOME layer only —
+//   `<dshHome>/cordis.patch.yml`, the one user layer every profile applies.
+//   No project-level MCP config exists.
+// - Hooks: packages/hooks — dsh has no own hook format; bridge plugins replay
+//   Claude Code / Codex hooks.json. HookFormat::None.
+// - Rules: packages/context/agent-instructions — `$DSH_HOME/AGENTS.md` global,
+//   project chain reads AGENTS.md / CLAUDE.md + AGENTS.local.md / CLAUDE.local.md.
+
+use super::{AgentAdapter, HookEntry, HookFormat, McpServerEntry, ProjectMarker};
+use std::path::{Path, PathBuf};
+
+pub struct DshAdapter {
+    /// `$DSH_HOME` else `~/.dsh`.
+    dsh_home: PathBuf,
+    /// `$DSH_AGENTS_HOME` else `~/.agents` (cross-vendor shared skills root).
+    agents_home: PathBuf,
+}
+
+impl Default for DshAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Resolve `(dsh_home, agents_home)` from the `DSH_HOME` / `DSH_AGENTS_HOME`
+/// overrides, falling back to `<home>/.dsh` / `<home>/.agents`. Pure so it can
+/// be tested with explicit inputs (mutating process env in tests is racy
+/// under parallel execution).
+fn resolve_homes(
+    dsh_home: Option<std::ffi::OsString>,
+    agents_home: Option<std::ffi::OsString>,
+    home: &Path,
+) -> (PathBuf, PathBuf) {
+    (
+        dsh_home
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".dsh")),
+        agents_home
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".agents")),
+    )
+}
+
+impl DshAdapter {
+    pub fn new() -> Self {
+        let home = dirs::home_dir().unwrap_or_default();
+        let (dsh_home, agents_home) = resolve_homes(
+            std::env::var_os("DSH_HOME"),
+            std::env::var_os("DSH_AGENTS_HOME"),
+            &home,
+        );
+        Self {
+            dsh_home,
+            agents_home,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_home(home: PathBuf) -> Self {
+        Self {
+            dsh_home: home.join(".dsh"),
+            agents_home: home.join(".agents"),
+        }
+    }
+
+    /// Existing per-profile patch files (settings listing only — MCP reading
+    /// is home-layer-only by design; see module header).
+    fn profile_patch_files(&self) -> Vec<PathBuf> {
+        let profiles = self.dsh_home.join("profiles");
+        let mut dirs: Vec<PathBuf> = std::fs::read_dir(&profiles)
+            .ok()
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.is_dir())
+            .collect();
+        dirs.sort();
+        dirs.into_iter()
+            .map(|d| d.join("cordis.patch.yml"))
+            .filter(|p| p.is_file())
+            .collect()
+    }
+}
+
+impl AgentAdapter for DshAdapter {
+    fn name(&self) -> &str {
+        "dsh"
+    }
+
+    fn base_dir(&self) -> PathBuf {
+        self.dsh_home.clone()
+    }
+
+    fn detect(&self) -> bool {
+        self.dsh_home.exists()
+    }
+
+    fn skill_dirs(&self) -> Vec<PathBuf> {
+        vec![
+            self.dsh_home.join("skills"),
+            self.agents_home.join("skills"),
+        ]
+    }
+
+    /// Home-level user patch — the highest always-applied user layer and the
+    /// canonical write target for HK's managed toggle block. NEVER point this
+    /// at `<profileDir>/cordis.yml`: dsh overwrites that file on every boot.
+    fn mcp_config_path(&self) -> PathBuf {
+        self.dsh_home.join("cordis.patch.yml")
+    }
+
+    fn hook_config_path(&self) -> PathBuf {
+        // dsh has no own hook config; return the settings doc so the default
+        // plugin_config_path() has a sane anchor. Never read for hooks
+        // (hook_format is None).
+        self.dsh_home.join("settings.yaml")
+    }
+
+    fn plugin_dirs(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
+    fn hook_format(&self) -> HookFormat {
+        HookFormat::None
+    }
+
+    // mcp_format + supports_native_mcp_toggle overridden in Task 3
+    // (McpFormat::DshCordis doesn't exist yet; trait defaults — McpServers /
+    // false — apply until then).
+
+    fn read_mcp_servers(&self) -> Vec<McpServerEntry> {
+        // Implemented in Task 2.
+        vec![]
+    }
+
+    fn read_hooks(&self) -> Vec<HookEntry> {
+        vec![]
+    }
+
+    fn global_rules_files(&self) -> Vec<PathBuf> {
+        vec![self.dsh_home.join("AGENTS.md")]
+    }
+
+    fn global_settings_files(&self) -> Vec<PathBuf> {
+        let mut files = vec![
+            self.dsh_home.join("settings.yaml"),
+            self.dsh_home.join("cordis.patch.yml"),
+        ];
+        files.extend(self.profile_patch_files());
+        files
+    }
+
+    fn project_rules_patterns(&self) -> Vec<String> {
+        vec![
+            "AGENTS.md".into(),
+            "CLAUDE.md".into(),
+            "AGENTS.local.md".into(),
+            "CLAUDE.local.md".into(),
+        ]
+    }
+
+    fn project_markers(&self) -> Vec<ProjectMarker> {
+        vec![ProjectMarker::Dir(".dsh")]
+    }
+
+    fn project_skill_dirs(&self) -> Vec<String> {
+        vec![".dsh/skills".into()]
+    }
+
+    fn project_skill_read_dirs(&self) -> Vec<String> {
+        vec![".agents/skills".into()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::AgentAdapter;
+    use super::*;
+
+    #[test]
+    fn resolve_homes_env_overrides_and_fallbacks() {
+        let home = Path::new("/home/u");
+
+        // Both env vars set → both override.
+        let (dsh, agents) = resolve_homes(
+            Some("/custom/dsh".into()),
+            Some("/custom/agents".into()),
+            home,
+        );
+        assert_eq!(dsh, PathBuf::from("/custom/dsh"));
+        assert_eq!(agents, PathBuf::from("/custom/agents"));
+
+        // Both unset → ~/.dsh and ~/.agents fallbacks.
+        let (dsh, agents) = resolve_homes(None, None, home);
+        assert_eq!(dsh, home.join(".dsh"));
+        assert_eq!(agents, home.join(".agents"));
+
+        // DSH_HOME set, DSH_AGENTS_HOME unset → mixed.
+        let (dsh, agents) = resolve_homes(Some("/custom/dsh".into()), None, home);
+        assert_eq!(dsh, PathBuf::from("/custom/dsh"));
+        assert_eq!(agents, home.join(".agents"));
+    }
+
+    #[test]
+    fn detect_requires_dsh_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = DshAdapter::with_home(tmp.path().to_path_buf());
+        assert!(!adapter.detect());
+        std::fs::create_dir_all(tmp.path().join(".dsh")).unwrap();
+        assert!(adapter.detect());
+    }
+
+    #[test]
+    fn skill_dirs_cover_dsh_and_agents_homes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let adapter = DshAdapter::with_home(tmp.path().to_path_buf());
+        assert_eq!(
+            adapter.skill_dirs(),
+            vec![
+                tmp.path().join(".dsh/skills"),
+                tmp.path().join(".agents/skills"),
+            ]
+        );
+        // Canonical install target is the dsh-owned dir (skill_dir_for uses first).
+        assert_eq!(adapter.project_skill_dirs(), vec![".dsh/skills".to_string()]);
+        assert_eq!(
+            adapter.project_skill_read_dirs(),
+            vec![".agents/skills".to_string()]
+        );
+    }
+
+    #[test]
+    fn config_discovery_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dsh_home = tmp.path().join(".dsh");
+        // settings files include existing per-profile patch files
+        std::fs::create_dir_all(dsh_home.join("profiles/web")).unwrap();
+        std::fs::write(dsh_home.join("profiles/web/cordis.patch.yml"), "[]\n").unwrap();
+        let adapter = DshAdapter::with_home(tmp.path().to_path_buf());
+
+        assert_eq!(adapter.global_rules_files(), vec![dsh_home.join("AGENTS.md")]);
+        let settings = adapter.global_settings_files();
+        assert!(settings.contains(&dsh_home.join("settings.yaml")));
+        assert!(settings.contains(&dsh_home.join("cordis.patch.yml")));
+        assert!(settings.contains(&dsh_home.join("profiles/web/cordis.patch.yml")));
+        assert_eq!(
+            adapter.project_rules_patterns(),
+            vec!["AGENTS.md", "CLAUDE.md", "AGENTS.local.md", "CLAUDE.local.md"]
+        );
+        // HK-side project-discovery marker (dsh's only project-level dir).
+        // dsh itself finds project roots by walking to the nearest `.git`.
+        assert_eq!(adapter.project_markers(), vec![super::super::ProjectMarker::Dir(".dsh")]);
+        // No project-level MCP/hook config exists upstream.
+        assert_eq!(adapter.project_mcp_config_relpath(), None);
+        assert_eq!(adapter.project_hook_config_relpath(), None);
+    }
+}

--- a/crates/hk-core/src/adapter/dsh.rs
+++ b/crates/hk-core/src/adapter/dsh.rs
@@ -346,6 +346,7 @@ impl AgentAdapter for DshAdapter {
     }
 
     fn supports_native_mcp_toggle(&self) -> bool {
+        // Toggle appends id-targeted patch rows via a managed block (deployer::set_dsh_mcp_enabled); never rewrites user YAML.
         true
     }
 

--- a/crates/hk-core/src/adapter/hermes.rs
+++ b/crates/hk-core/src/adapter/hermes.rs
@@ -14,22 +14,6 @@ use super::{
 };
 use std::path::{Path, PathBuf};
 
-/// Parse a YAML `key: {A: B, ...}` sub-mapping into a string map, dropping
-/// non-string values. Used for `env` and `headers` blocks.
-fn yaml_string_map(
-    val: &serde_yaml::Value,
-    key: &str,
-) -> std::collections::HashMap<String, String> {
-    val.get(key)
-        .and_then(|v| v.as_mapping())
-        .map(|m| {
-            m.iter()
-                .filter_map(|(k, v)| Some((k.as_str()?.to_string(), v.as_str()?.to_string())))
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
 pub struct HermesAdapter {
     home: PathBuf,
 }
@@ -268,10 +252,10 @@ impl AgentAdapter for HermesAdapter {
                     name,
                     command,
                     args,
-                    env: yaml_string_map(val, "env"),
+                    env: super::yaml_string_map(val, "env"),
                     transport,
                     url,
-                    headers: yaml_string_map(val, "headers"),
+                    headers: super::yaml_string_map(val, "headers"),
                     enabled,
                 })
             })

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -3,6 +3,7 @@ pub mod claude;
 pub mod codex;
 pub mod copilot;
 pub mod cursor;
+pub mod dsh;
 pub mod gemini;
 pub mod hermes;
 pub mod hook_events;

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -808,6 +808,8 @@ mod tests {
 
     #[test]
     fn test_supports_native_mcp_toggle_only_native_agents() {
+        // Adding a name here also requires a dispatch branch in
+        // manager.rs::toggle_mcp — the trailing else there errors out.
         let adapters = all_adapters();
         for a in &adapters {
             let expected = matches!(a.name(), "hermes" | "kiro" | "omp");

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -169,6 +169,22 @@ pub(crate) fn json_string_map(
         .unwrap_or_default()
 }
 
+/// Parse a YAML `key: {A: B, ...}` sub-mapping into a string map, dropping
+/// non-string values. Used for `env` and `headers` blocks.
+pub(crate) fn yaml_string_map(
+    val: &serde_yaml::Value,
+    key: &str,
+) -> std::collections::HashMap<String, String> {
+    val.get(key)
+        .and_then(|v| v.as_mapping())
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| Some((k.as_str()?.to_string(), v.as_str()?.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Transport + url for `{type: "http"|"sse", url}`-style entries (Claude,
 /// Copilot, omp — the `RemoteMcpSchema::TypeAndUrl` agents).
 /// `streamable-http` is the MCP spec's name for the HTTP transport and an

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -703,6 +703,7 @@ pub fn all_adapters() -> Vec<Box<dyn AgentAdapter>> {
         Box::new(hermes::HermesAdapter::new()),
         Box::new(kiro::KiroAdapter::new()),
         Box::new(omp::OmpAdapter::new()),
+        Box::new(dsh::DshAdapter::new()),
     ]
 }
 
@@ -743,14 +744,23 @@ mod tests {
 
     #[test]
     fn mcp_remote_capability_derivation() {
-        // Codex (TOML) is the only HTTP-only agent; every other adapter's
-        // remote schema supports both transports. Pinned so a future agent
-        // with partial support must consciously extend the derivation.
+        // Codex (TOML) is HTTP-only and dsh supports neither (remote entries
+        // are never deployed into cordis rows; see arm below); every other
+        // adapter's remote schema supports both transports. Pinned so a
+        // future agent with partial support must consciously extend the
+        // derivation.
         for a in all_adapters() {
             let caps = crate::models::AgentCapabilities::from_adapter(a.as_ref());
             match a.name() {
                 "codex" => {
                     assert!(caps.mcp_remote.http);
+                    assert!(!caps.mcp_remote.sse);
+                }
+                "dsh" => {
+                    // Remote schema Unsupported: HK never deploys remote
+                    // entries into cordis patch rows (home-layer read is
+                    // display-only for remote transports).
+                    assert!(!caps.mcp_remote.http);
                     assert!(!caps.mcp_remote.sse);
                 }
                 _ => {
@@ -762,9 +772,9 @@ mod tests {
     }
 
     #[test]
-    fn test_all_adapters_returns_eleven() {
+    fn test_all_adapters_returns_twelve() {
         let adapters = all_adapters();
-        assert_eq!(adapters.len(), 11);
+        assert_eq!(adapters.len(), 12);
         let names: Vec<&str> = adapters.iter().map(|a| a.name()).collect();
         assert!(names.contains(&"claude"));
         assert!(names.contains(&"cursor"));
@@ -777,6 +787,7 @@ mod tests {
         assert!(names.contains(&"hermes"));
         assert!(names.contains(&"kiro"));
         assert!(names.contains(&"omp"));
+        assert!(names.contains(&"dsh"));
     }
 
     #[test]
@@ -798,6 +809,7 @@ mod tests {
         // hurting cross-machine portability.
         for name in [
             "claude", "codex", "gemini", "cursor", "copilot", "opencode", "hermes", "kiro", "omp",
+            "dsh",
         ] {
             assert!(
                 !by_name[name].needs_path_injection(),
@@ -812,7 +824,7 @@ mod tests {
         // manager.rs::toggle_mcp — the trailing else there errors out.
         let adapters = all_adapters();
         for a in &adapters {
-            let expected = matches!(a.name(), "hermes" | "kiro" | "omp");
+            let expected = matches!(a.name(), "hermes" | "kiro" | "omp" | "dsh");
             assert_eq!(
                 a.supports_native_mcp_toggle(),
                 expected,
@@ -862,6 +874,7 @@ mod tests {
             ("kiro", true, true, true, true, false),     // kirodotdev/Kiro#5440
             ("omp", true, true, false, false, true),     // hooks are JS/TS modules
             ("hermes", false, false, false, true, true), // global-only (hermes-agent#4667)
+            ("dsh", true, false, false, false, true), // MCP is cordis-layer only; no own hook format
         ];
 
         let adapters = all_adapters();
@@ -993,6 +1006,7 @@ mod tests {
             ("opencode", ".opencode/skills"),
             ("kiro", ".kiro/skills"),
             ("omp", ".omp/skills"),
+            ("dsh", ".dsh/skills"),
             // hermes is global-only — no project skill dir (hermes-agent#4667).
         ]
         .into_iter()

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -320,6 +320,12 @@ pub enum McpFormat {
     /// Each entry is URL-based ({url, headers?, transport: sse?}) or
     /// command-based ({command, args?, env?}).
     HermesYaml,
+    /// DeepSeek Harness: MCP servers are `@deepseek-ai/dsh-mcp-client` plugin
+    /// rows in cordis patch files (YAML top-level array with `!!js` tags), not
+    /// a server map. Generic JSON/TOML writers must never touch these files —
+    /// every deployer arm for this variant errors; toggling goes through the
+    /// native in-place path (`set_dsh_mcp_enabled`).
+    DshCordis,
 }
 
 /// How an agent's config spells a remote (HTTP/SSE) MCP entry.

--- a/crates/hk-core/src/auditor/mod.rs
+++ b/crates/hk-core/src/auditor/mod.rs
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn test_auditor_runs_all_enabled_rules() {
         let auditor = Auditor::new();
-        assert_eq!(auditor.rules.len(), 18);
+        assert_eq!(auditor.rules.len(), 19);
     }
 
     #[test]

--- a/crates/hk-core/src/auditor/rules.rs
+++ b/crates/hk-core/src/auditor/rules.rs
@@ -14,7 +14,7 @@ pub use cli::{
 };
 pub use content::{
     CredentialTheft, DangerousCommands, PlaintextSecrets, PromptInjection, RemoteCodeExecution,
-    SafetyBypass,
+    SafetyBypass, SkillInvocationKeyCase,
 };
 pub use mcp::McpCommandInjection;
 pub use permissions::{
@@ -30,6 +30,7 @@ pub fn all_rules() -> Vec<Box<dyn AuditRule>> {
         Box::new(PlaintextSecrets),
         Box::new(SafetyBypass),
         Box::new(DangerousCommands),
+        Box::new(SkillInvocationKeyCase),
         Box::new(BroadPermissions),
         Box::new(SupplyChainRisk),
         Box::new(UnknownSource),

--- a/crates/hk-core/src/auditor/rules/content.rs
+++ b/crates/hk-core/src/auditor/rules/content.rs
@@ -386,6 +386,62 @@ impl AuditRule for DangerousCommands {
     }
 }
 
+/// dsh (DeepSeek Harness) rejects the camelCase invocation-key aliases
+/// `disableModelInvocation` / `modelInvocable` / `userInvocable` by dropping
+/// the WHOLE skill from discovery with only a log warning
+/// (deepseek-harness packages/skill/skill-filesystem: rejectLegacyInvocationKey).
+/// None of these spellings is valid in any supported agent — the canonical
+/// keys are kebab-case (`disable-model-invocation`, `user-invocable`).
+pub struct SkillInvocationKeyCase;
+
+const CAMELCASE_INVOCATION_KEYS: [(&str, &str); 3] = [
+    ("disableModelInvocation", "disable-model-invocation"),
+    ("modelInvocable", "disable-model-invocation (note: inverted meaning)"),
+    ("userInvocable", "user-invocable"),
+];
+
+impl AuditRule for SkillInvocationKeyCase {
+    fn id(&self) -> &str {
+        "skill-invocation-key-case"
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Medium
+    }
+
+    fn check(&self, input: &AuditInput) -> Vec<AuditFinding> {
+        if input.kind != ExtensionKind::Skill {
+            return vec![];
+        }
+        // Only inspect the frontmatter block: first line `---` … next `---`.
+        let mut lines = input.content.lines().enumerate();
+        if lines.next().map(|(_, line)| line.trim()) != Some("---") {
+            return vec![];
+        }
+        let mut findings = Vec::new();
+        for (i, line) in lines {
+            if line.trim() == "---" {
+                break;
+            }
+            for (key, suggestion) in CAMELCASE_INVOCATION_KEYS {
+                if line.trim_start().starts_with(&format!("{key}:")) {
+                    findings.push(AuditFinding {
+                        rule_id: self.id().into(),
+                        severity: self.severity(),
+                        message: format!(
+                            "Frontmatter key '{key}' is a rejected camelCase alias — \
+                             DeepSeek Harness silently drops the entire skill; \
+                             use '{suggestion}' instead"
+                        ),
+                        location: format!("{}:{}", input.file_path, i + 1),
+                    });
+                }
+            }
+        }
+        findings
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -572,6 +628,26 @@ mod tests {
             !rule.check(&input).is_empty(),
             "CLI child plugins should be audited independently"
         );
+    }
+
+    #[test]
+    fn test_skill_invocation_key_case_flags_camelcase_aliases() {
+        let rule = SkillInvocationKeyCase;
+        for (key, suggestion) in CAMELCASE_INVOCATION_KEYS {
+            let bad = format!("---\nname: my-skill\ndescription: d\n{key}: false\n---\nbody");
+            let findings = rule.check(&skill_input(&bad));
+            assert_eq!(findings.len(), 1, "expected exactly 1 finding for {key}");
+            assert!(findings[0].message.contains(key));
+            assert!(findings[0].message.contains(suggestion));
+        }
+
+        let good = "---\nname: my-skill\ndescription: d\nuser-invocable: false\n---\nbody";
+        assert!(rule.check(&skill_input(good)).is_empty());
+
+        // Key names in the body (outside frontmatter) must not fire.
+        let body_mention =
+            "---\nname: my-skill\ndescription: d\n---\nSet userInvocable: false in dsh? No.";
+        assert!(rule.check(&skill_input(body_mention)).is_empty());
     }
 
     #[test]

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -158,7 +158,10 @@ fn json_top_key(format: McpFormat) -> &'static str {
             unreachable!("HermesYaml format routes through dedicated YAML helpers")
         }
         McpFormat::DshCordis => {
-            unreachable!("DshCordis routes through the native patch-layer path (set_dsh_mcp_enabled)")
+            unreachable!(
+                "DshCordis never reaches the JSON writers — install/remove are refused, \
+                 toggling uses the native patch-layer path (set_dsh_mcp_enabled)"
+            )
         }
     }
 }
@@ -655,6 +658,183 @@ pub fn set_omp_mcp_enabled(
         }
         Ok(())
     })
+}
+
+const DSH_BLOCK_BEGIN: &str = "# >>> managed by HarnessKit — do not edit this block >>>";
+const DSH_BLOCK_END: &str = "# <<< managed by HarnessKit <<<";
+
+/// Flip a dsh MCP server via the official patch-layer mechanism: an
+/// id-targeted `disabled:` override inside an HK-owned marked block at the
+/// END of the home-level `cordis.patch.yml` (the last always-applied user
+/// layer — later entries win in dsh's single ordered apply).
+///
+/// Hard rules (upstream-verified):
+/// - Only ever writes `home_patch` — NEVER `<profileDir>/cordis.yml` (dsh
+///   overwrites that on boot) and never any profile's patch file.
+/// - User bytes outside the markers are preserved; the sole structural edits
+///   involve the `[]` empty-list placeholder (see render_dsh_patch).
+/// - The edited text must re-parse as a YAML sequence, else nothing is
+///   written (a broken file would make dsh keep last-good config and
+///   silently ignore all future edits).
+pub fn set_dsh_mcp_enabled(
+    home_patch: &Path,
+    server_name: &str,
+    enabled: bool,
+) -> Result<(), HkError> {
+    use crate::adapter::dsh::DshAdapter;
+
+    let original = match std::fs::read_to_string(home_patch) {
+        Ok(text) => text,
+        // Absent file = dsh not yet seeded its template; start from the
+        // valid empty form. Any other IO error must surface, not be
+        // mistaken for an empty file.
+        // Intentional error normalization: this text never reaches the write
+        // path — an empty patch has no rows, so the row-id lookup below fails
+        // first and the user sees "server not found" rather than a raw IO error.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => "[]\n".to_string(),
+        Err(e) => return Err(e.into()),
+    };
+    let (user_text, mut managed) = split_dsh_managed_block(&original)?;
+
+    let row_id = DshAdapter::mcp_row_id_in_text(&user_text, server_name).ok_or_else(|| {
+        HkError::NotFound(format!(
+            "MCP server '{server_name}' not found in {}",
+            home_patch.display()
+        ))
+    })?;
+
+    // Base state = the file WITHOUT our block.
+    let base_enabled = DshAdapter::mcp_enabled_in_text(&user_text)
+        .get(server_name)
+        .copied()
+        .unwrap_or(true);
+
+    if base_enabled == enabled {
+        managed.remove(&row_id);
+    } else {
+        managed.insert(row_id, !enabled); // value = disabled flag
+    }
+
+    let new_text = render_dsh_patch(&user_text, &managed);
+    let parsed: Result<serde_yaml::Value, _> = serde_yaml::from_str(&new_text);
+    if !matches!(parsed, Ok(serde_yaml::Value::Sequence(_))) {
+        return Err(HkError::ConfigCorrupted(format!(
+            "refusing to write {}: edited content is not a YAML list",
+            home_patch.display()
+        )));
+    }
+    atomic_write(home_patch, &new_text)
+}
+
+/// Split file text into (user text without the managed block, managed
+/// entries id → disabled). Unrecognized lines inside the block are dropped —
+/// the block is HK-owned by contract. `split_inclusive` keeps user lines
+/// byte-exact (including CRLF endings).
+///
+/// Unbalanced markers are a hard `ConfigCorrupted` error: a BEGIN without a
+/// matching END would otherwise swallow every user line to EOF (and the
+/// rewritten file could still parse as a valid YAML sequence, so the
+/// caller's post-edit guard would not catch the loss).
+fn split_dsh_managed_block(
+    text: &str,
+) -> Result<(String, std::collections::BTreeMap<String, bool>), HkError> {
+    let mut user = String::new();
+    let mut managed = std::collections::BTreeMap::new();
+    let mut in_block = false;
+    let mut current_id: Option<String> = None;
+    for raw in text.split_inclusive('\n') {
+        let line = raw.trim();
+        if line == DSH_BLOCK_BEGIN {
+            if in_block {
+                return Err(HkError::ConfigCorrupted(
+                    "unbalanced HarnessKit managed-block markers: \
+                     nested BEGIN marker inside the managed block"
+                        .into(),
+                ));
+            }
+            in_block = true;
+            continue;
+        }
+        if line == DSH_BLOCK_END {
+            if !in_block {
+                return Err(HkError::ConfigCorrupted(
+                    "unbalanced HarnessKit managed-block markers: \
+                     END marker without a preceding BEGIN"
+                        .into(),
+                ));
+            }
+            in_block = false;
+            current_id = None;
+            continue;
+        }
+        if in_block {
+            if let Some(id) = line.strip_prefix("- id: ") {
+                current_id = Some(id.trim().to_string());
+            } else if let Some(flag) = line.strip_prefix("disabled: ") {
+                if let (Some(id), Ok(b)) = (current_id.take(), flag.trim().parse::<bool>()) {
+                    managed.insert(id, b);
+                }
+            }
+        } else {
+            user.push_str(raw);
+        }
+    }
+    if in_block {
+        return Err(HkError::ConfigCorrupted(
+            "unbalanced HarnessKit managed-block markers: \
+             BEGIN marker without a matching END"
+                .into(),
+        ));
+    }
+    Ok((user, managed))
+}
+
+/// Reassemble user text + managed block. Structural rules:
+/// - Block present → any lone `[]` placeholder line is dropped (it can't
+///   coexist with block-style entries in one document).
+/// - Block absent → if the remaining text has no non-comment content, append
+///   `[]` (an empty/comment-only patch file is a dsh boot error).
+fn render_dsh_patch(
+    user_text: &str,
+    managed: &std::collections::BTreeMap<String, bool>,
+) -> String {
+    if managed.is_empty() {
+        let has_content = user_text
+            .lines()
+            .any(|l| !l.trim().is_empty() && !l.trim().starts_with('#') && l.trim() != "[]");
+        let has_placeholder = user_text.lines().any(|l| l.trim() == "[]");
+        if has_content || has_placeholder {
+            return user_text.to_string();
+        }
+        let mut out = user_text.to_string();
+        if !out.is_empty() && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str("[]\n");
+        return out;
+    }
+
+    let mut block = String::new();
+    block.push_str(DSH_BLOCK_BEGIN);
+    block.push('\n');
+    for (id, disabled) in managed {
+        block.push_str(&format!("- id: {id}\n  disabled: {disabled}\n"));
+    }
+    block.push_str(DSH_BLOCK_END);
+    block.push('\n');
+
+    // Drop `[]` placeholder lines byte-preservingly (keep every other raw line).
+    let mut out = String::new();
+    for raw in user_text.split_inclusive('\n') {
+        if raw.trim() != "[]" {
+            out.push_str(raw);
+        }
+    }
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(&block);
+    out
 }
 
 /// Flip a Kiro IDE hook's native `enabled` flag in place, keeping the entry
@@ -3973,5 +4153,150 @@ mod tests {
         let entries: Vec<(String, bool)> = serde_json::from_str(&result).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].0, "file:///plugin-b");
+    }
+}
+
+#[cfg(test)]
+mod dsh_toggle_tests {
+    use super::*;
+
+    const HOME_WITH_GH: &str = r#"# precious comment
+- insert:
+    - id: mcp-github
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: github
+        transport: stdio
+        command: npx
+        env:
+          GITHUB_TOKEN: !!js process.env.GITHUB_TOKEN
+"#;
+
+    fn patch_file(text: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("cordis.patch.yml");
+        std::fs::write(&path, text).unwrap();
+        (tmp, path)
+    }
+
+    #[test]
+    fn disable_appends_managed_block_and_enable_removes_it() {
+        let (_tmp, path) = patch_file(HOME_WITH_GH);
+
+        set_dsh_mcp_enabled(&path, "github", false).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.starts_with(HOME_WITH_GH), "user bytes preserved verbatim");
+        assert!(text.contains("- id: mcp-github\n  disabled: true"));
+        assert!(text.contains("managed by HarnessKit"));
+
+        // Enable: base state (the insert) is already enabled → block entry
+        // removed entirely; user content restored byte-for-byte.
+        set_dsh_mcp_enabled(&path, "github", true).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), HOME_WITH_GH);
+    }
+
+    #[test]
+    fn enable_overrides_user_disable_with_disabled_false() {
+        // User disabled it themselves → HK writes an explicit disabled: false
+        // override (upstream e2e-covered semantics).
+        let text = format!("{HOME_WITH_GH}- id: mcp-github\n  disabled: true\n");
+        let (_tmp, path) = patch_file(&text);
+        set_dsh_mcp_enabled(&path, "github", true).unwrap();
+        let out = std::fs::read_to_string(&path).unwrap();
+        assert!(out.starts_with(&text), "user bytes preserved");
+        assert!(out.contains("- id: mcp-github\n  disabled: false"));
+    }
+
+    #[test]
+    fn template_file_toggle_errors_not_found() {
+        // dsh's seeded patch template: comment header + literal []. No row
+        // exists in it → toggling must error, and the file must be untouched.
+        let template = "# header comment\n[]\n";
+        let (_tmp, path) = patch_file(template);
+        let err = set_dsh_mcp_enabled(&path, "github", false).unwrap_err();
+        assert!(matches!(err, HkError::NotFound(_)));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), template);
+    }
+
+    #[test]
+    fn roundtrip_always_leaves_valid_yaml_list() {
+        // After any disable→enable cycle the file must re-parse as a YAML
+        // list — an empty/comment-only patch file is a dsh boot error.
+        let (_tmp, path) = patch_file(HOME_WITH_GH);
+        set_dsh_mcp_enabled(&path, "github", false).unwrap();
+        set_dsh_mcp_enabled(&path, "github", true).unwrap();
+        let out = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert!(parsed.is_sequence(), "file must stay a valid YAML list");
+    }
+
+    #[test]
+    fn unknown_server_errors() {
+        let (_tmp, path) = patch_file(HOME_WITH_GH);
+        let err = set_dsh_mcp_enabled(&path, "nope", false).unwrap_err();
+        assert!(matches!(err, HkError::NotFound(_)));
+    }
+
+    #[test]
+    fn toggle_is_idempotent() {
+        let (_tmp, path) = patch_file(HOME_WITH_GH);
+        set_dsh_mcp_enabled(&path, "github", false).unwrap();
+        let once = std::fs::read_to_string(&path).unwrap();
+        set_dsh_mcp_enabled(&path, "github", false).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), once);
+    }
+
+    #[test]
+    fn unbalanced_markers_error_and_leave_file_untouched() {
+        let text = format!(
+            "{HOME_WITH_GH}{}\n- id: mcp-github\n  disabled: true\n",
+            DSH_BLOCK_BEGIN
+        );
+        let (_tmp, path) = patch_file(&text); // BEGIN without END
+        let err = set_dsh_mcp_enabled(&path, "github", false).unwrap_err();
+        assert!(matches!(err, HkError::ConfigCorrupted(_)));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), text);
+    }
+
+    #[test]
+    fn user_content_after_block_survives_roundtrip() {
+        // Documented out-vote mechanism: user lines AFTER the managed block
+        // must never be lost. (They may legitimately be reordered before the
+        // re-appended block on the next toggle — base-state semantics.)
+        let (_tmp, path) = patch_file(HOME_WITH_GH);
+        set_dsh_mcp_enabled(&path, "github", false).unwrap();
+        let mut text = std::fs::read_to_string(&path).unwrap();
+        text.push_str("# user note after block\n");
+        std::fs::write(&path, &text).unwrap();
+        set_dsh_mcp_enabled(&path, "github", true).unwrap();
+        let out = std::fs::read_to_string(&path).unwrap();
+        assert!(out.contains("# user note after block"));
+        assert!(!out.contains("managed by HarnessKit"), "override no longer needed");
+    }
+
+    #[test]
+    fn two_servers_share_one_managed_block() {
+        let text = format!(
+            "{HOME_WITH_GH}    - id: mcp-web\n      name: '@deepseek-ai/dsh-mcp-client'\n      config:\n        serverName: web\n        transport: streamable-http\n        url: http://localhost:3000/mcp\n"
+        );
+        let (_tmp, path) = patch_file(&text);
+        set_dsh_mcp_enabled(&path, "github", false).unwrap();
+        set_dsh_mcp_enabled(&path, "web", false).unwrap();
+        let out = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(out.matches(DSH_BLOCK_BEGIN).count(), 1, "exactly one block");
+        assert!(out.contains("- id: mcp-github\n  disabled: true"));
+        assert!(out.contains("- id: mcp-web\n  disabled: true"));
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert!(parsed.is_sequence());
+    }
+
+    #[test]
+    fn remove_mcp_server_refuses_dsh_cordis() {
+        // Pin: the generic remove path must never touch the dsh patch file —
+        // create the file so the early-return-on-missing-file path isn't taken.
+        let (_tmp, path) = patch_file(HOME_WITH_GH);
+        let err = remove_mcp_server(&path, "github", McpFormat::DshCordis).unwrap_err();
+        assert!(matches!(&err, HkError::Validation(m) if m.contains("cordis.patch.yml")));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), HOME_WITH_GH);
     }
 }

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -157,6 +157,9 @@ fn json_top_key(format: McpFormat) -> &'static str {
         McpFormat::HermesYaml => {
             unreachable!("HermesYaml format routes through dedicated YAML helpers")
         }
+        McpFormat::DshCordis => {
+            unreachable!("DshCordis routes through the native patch-layer path (set_dsh_mcp_enabled)")
+        }
     }
 }
 
@@ -184,6 +187,12 @@ pub fn deploy_mcp_server(
         McpFormat::Toml => deploy_mcp_server_toml(config_path, entry),
         McpFormat::Opencode => deploy_mcp_server_opencode(config_path, entry),
         McpFormat::HermesYaml => deploy_mcp_server_hermes_yaml(config_path, entry),
+        McpFormat::DshCordis => Err(HkError::Validation(
+            "dsh MCP servers are composition rows in cordis.patch.yml; \
+             installing or removing them for dsh is not supported yet — \
+             use enable/disable (native patch-layer path) or edit the file"
+                .into(),
+        )),
     }
 }
 
@@ -1067,6 +1076,12 @@ pub fn remove_mcp_server(
             }
             Ok(())
         }),
+        McpFormat::DshCordis => Err(HkError::Validation(
+            "dsh MCP servers are composition rows in cordis.patch.yml; \
+             installing or removing them for dsh is not supported yet — \
+             use enable/disable (native patch-layer path) or edit the file"
+                .into(),
+        )),
         _ => locked_modify_json(config_path, |config| {
             let key = json_top_key(format);
             if let Some(servers) = config.get_mut(key).and_then(|v| v.as_object_mut()) {
@@ -1235,6 +1250,10 @@ pub fn restore_mcp_server(
         McpFormat::HermesYaml => unreachable!(
             "Hermes MCP uses native in-place enable/disable (set_hermes_mcp_enabled); \
              the remove+snapshot+restore path is never reached for Hermes"
+        ),
+        McpFormat::DshCordis => unreachable!(
+            "dsh MCP uses native in-place enable/disable (set_dsh_mcp_enabled); \
+             the remove+snapshot+restore path is never reached for dsh"
         ),
         _ => {
             let key = json_top_key(format);
@@ -1718,6 +1737,10 @@ pub fn read_mcp_server_config(
             "Hermes MCP uses native in-place enable/disable (set_hermes_mcp_enabled); \
              the read-config-for-snapshot path is never reached for Hermes"
         ),
+        McpFormat::DshCordis => unreachable!(
+            "dsh MCP uses native in-place enable/disable (set_dsh_mcp_enabled); \
+             the read-config-for-snapshot path is never reached for dsh"
+        ),
         _ => {
             let config = read_or_create_json(config_path)?;
             let key = json_top_key(format);
@@ -2024,6 +2047,7 @@ mod tests {
             McpFormat::Toml => Box::new(codex::CodexAdapter::with_home(home)),
             McpFormat::Opencode => Box::new(opencode::OpencodeAdapter::with_home(home)),
             McpFormat::HermesYaml => Box::new(hermes::HermesAdapter::with_home(home)),
+            McpFormat::DshCordis => Box::new(dsh::DshAdapter::with_home(home)),
         }
     }
 

--- a/crates/hk-core/src/kits/install_plan.rs
+++ b/crates/hk-core/src/kits/install_plan.rs
@@ -62,6 +62,9 @@ fn mcp_entry_exists(config_path: &Path, name: &str, format: McpFormat) -> bool {
                 .and_then(|v| v.get(name))
                 .is_some()
         }
+        // dsh MCP can't be Kit-installed (cordis patch files are never a Kit
+        // install target), so no conflict is ever detectable.
+        McpFormat::DshCordis => false,
     }
 }
 

--- a/crates/hk-core/src/manager.rs
+++ b/crates/hk-core/src/manager.rs
@@ -201,8 +201,23 @@ fn toggle_mcp(
                     &ext.name,
                     enabled,
                 )?;
-            } else {
+            } else if a.name() == "dsh" {
+                // Official mechanism: id-targeted `disabled` override in the
+                // home-level cordis.patch.yml (HK-managed block). Hot-reloaded
+                // by dsh; state is read back from the patch layers on rescan.
+                deployer::set_dsh_mcp_enabled(&config_path, &ext.name, enabled)?;
+            } else if a.name() == "hermes" {
+                // Per-server `enabled` field flipped in place in config.yaml.
                 deployer::set_hermes_mcp_enabled(&config_path, &ext.name, enabled)?;
+            } else {
+                // Every native-toggle agent needs its own writer; a missing
+                // branch must fail loudly instead of falling through to some
+                // other agent's format and corrupting its config. Pinned by
+                // adapter::tests::test_supports_native_mcp_toggle_only_native_agents.
+                return Err(HkError::Internal(format!(
+                    "agent '{}' claims supports_native_mcp_toggle but has no MCP toggle dispatch branch",
+                    a.name()
+                )));
             }
             // Clear any legacy redacted snapshot so the store.rs upsert CASE uses
             // the on-disk enabled state (disabled_config IS NULL).

--- a/crates/hk-core/tests/toggle_integration.rs
+++ b/crates/hk-core/tests/toggle_integration.rs
@@ -398,3 +398,50 @@ fn test_single_agent_extension_toggle_state() {
     assert_eq!(all.len(), 1);
     assert!(all[0].enabled, "Single extension should show enabled");
 }
+
+#[test]
+fn test_dsh_mcp_native_toggle_roundtrip() {
+    use hk_core::adapter::dsh::DshAdapter;
+    use hk_core::adapter::AgentAdapter;
+
+    let dir = TempDir::new().unwrap();
+    let store = Store::open(&dir.path().join("test.db")).unwrap();
+    std::fs::create_dir_all(dir.path().join(".dsh")).unwrap();
+    std::fs::write(
+        dir.path().join(".dsh/cordis.patch.yml"),
+        r#"- insert:
+    - id: mcp-github
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: github
+        transport: stdio
+        command: npx
+"#,
+    )
+    .unwrap();
+
+    let adapter = DshAdapter::with_home(dir.path().to_path_buf());
+    let servers = adapter.read_mcp_servers();
+    assert_eq!(servers.len(), 1);
+    assert!(servers[0].enabled);
+
+    // Store the extension the way the scanner would, then toggle through the
+    // manager with only the dsh adapter mounted.
+    let exts = hk_core::scanner::scan_mcp_servers(&adapter);
+    assert_eq!(exts.len(), 1);
+    store.sync_extensions(&exts).unwrap();
+    let ext_id = store.list_extensions(None, None).unwrap()[0].id.clone();
+
+    let adapters: Vec<Box<dyn AgentAdapter>> =
+        vec![Box::new(DshAdapter::with_home(dir.path().to_path_buf()))];
+    hk_core::manager::toggle_extension_with_adapters(&store, &adapters, &ext_id, false).unwrap();
+
+    // On-disk state flipped via the managed block; no DB snapshot taken.
+    let servers = DshAdapter::with_home(dir.path().to_path_buf()).read_mcp_servers();
+    assert!(!servers[0].enabled);
+    assert!(store.get_disabled_config(&ext_id).unwrap().is_none());
+
+    hk_core::manager::toggle_extension_with_adapters(&store, &adapters, &ext_id, true).unwrap();
+    let servers = DshAdapter::with_home(dir.path().to_path_buf()).read_mcp_servers();
+    assert!(servers[0].enabled);
+}

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -325,6 +325,17 @@ export function ExtensionDetail() {
           </div>
         )}
 
+        {/* dsh naming bridge — DeepSeek Harness has no MCP-servers page; its
+         * Settings→Plugins list shows every MCP server as an "mcp-client"
+         * plugin card (@deepseek-ai/dsh-mcp-client) rather than by server
+         * name. Surface that mapping so users can locate this server there. */}
+        {group.kind === "mcp" && group.agents.includes("dsh") && (
+          <div className="mt-3 flex items-start gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-foreground">
+            <Info size={14} className="mt-0.5 shrink-0 text-primary" />
+            <span>{t("detail.dshMcpPluginNote")}</span>
+          </div>
+        )}
+
         {/* 1. Status + Source row */}
         <div className="mt-4 flex items-center gap-2">
           <button

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -43,6 +43,7 @@ import {
   sortAgents,
 } from "@/lib/types";
 import { useAgentStore } from "@/stores/agent-store";
+import { useAuditStore } from "@/stores/audit-store";
 import {
   agentsInScope,
   findCliChildren,
@@ -85,6 +86,10 @@ export function ExtensionDetail() {
   );
   const [loadingContent, setLoadingContent] = useState(false);
   const agents = useAgentStore((s) => s.agents);
+  // Live audit results (cached at App start, refreshed by Run Audit). Used
+  // to surface functional-breakage findings inline; purely derived, so the
+  // warning disappears as soon as a re-run no longer reports the finding.
+  const auditResults = useAuditStore((s) => s.results);
   const agentOrder = useAgentStore((s) => s.agentOrder);
   const scope = useScopeStore((s) => s.current);
   // Install to Agent targets the active scope. In All-scopes mode the user
@@ -335,6 +340,25 @@ export function ExtensionDetail() {
             <span>{t("detail.dshMcpPluginNote")}</span>
           </div>
         )}
+
+        {/* Silent skill-drop warning — the `skill-invocation-key-case` audit
+         * rule means DeepSeek Harness discards this ENTIRE skill (functional
+         * breakage, not just a score deduction), so it warrants an inline
+         * warning here, not only an Audit-page row. Derived from live audit
+         * results (extension_id === instance id), so it vanishes on the next
+         * audit run once the frontmatter key is fixed. */}
+        {group.kind === "skill" &&
+          auditResults.some(
+            (r) =>
+              r.findings.some(
+                (f) => f.rule_id === "skill-invocation-key-case",
+              ) && group.instances.some((i) => i.id === r.extension_id),
+          ) && (
+            <div className="mt-3 flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
+              <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+              <span>{t("detail.skillInvocationKeyWarning")}</span>
+            </div>
+          )}
 
         {/* 1. Status + Source row */}
         <div className="mt-4 flex items-center gap-2">

--- a/src/components/extensions/extension-filters.tsx
+++ b/src/components/extensions/extension-filters.tsx
@@ -45,6 +45,7 @@ const AGENT_FILTER_COLORS: Record<string, string> = {
   hermes: "bg-agent-hermes/10 text-agent-hermes border-agent-hermes/30",
   kiro: "bg-agent-kiro/10 text-agent-kiro border-agent-kiro/30",
   omp: "bg-agent-omp/10 text-agent-omp border-agent-omp/30",
+  dsh: "bg-agent-dsh/10 text-agent-dsh border-agent-dsh/30",
 };
 
 export function ExtensionFilters() {

--- a/src/components/onboarding/onboarding.tsx
+++ b/src/components/onboarding/onboarding.tsx
@@ -266,6 +266,7 @@ const FLOAT_DELAYS: Record<(typeof AGENT_ORDER)[number], number> = {
   hermes: 1.9,
   kiro: 1.4,
   omp: 1.0,
+  dsh: 1.7,
 };
 const SCATTER_POSITIONS: Record<
   (typeof AGENT_ORDER)[number],
@@ -282,6 +283,7 @@ const SCATTER_POSITIONS: Record<
   hermes: { x: -60, y: -115, r: 18 },
   kiro: { x: 40, y: -126, r: -10 },
   omp: { x: -200, y: 60, r: 22 },
+  dsh: { x: 90, y: 135, r: 7 },
 };
 
 function HandAnnotation({

--- a/src/components/shared/agent-card.tsx
+++ b/src/components/shared/agent-card.tsx
@@ -31,7 +31,7 @@ export function AgentCard({ agent }: AgentCardProps) {
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onClick={handleClick}
-      className={`group flex w-[110px] flex-col items-center gap-1.5 rounded-lg border border-border/60 bg-card/50 px-3 py-2.5 text-center transition-all duration-200 hover:border-border hover:bg-card hover:shadow-sm hover:-translate-y-0.5 ${agent.name === "codex" || agent.name === "antigravity" || agent.name === "claude" || agent.name === "opencode" ? "overflow-hidden" : "overflow-visible"}`}
+      className={`group flex w-[110px] flex-col items-center gap-1.5 rounded-lg border border-border/60 bg-card/50 px-3 py-2.5 text-center transition-all duration-200 hover:border-border hover:bg-card hover:shadow-sm hover:-translate-y-0.5 ${agent.name === "codex" || agent.name === "antigravity" || agent.name === "claude" || agent.name === "opencode" || agent.name === "dsh" ? "overflow-hidden" : "overflow-visible"}`}
     >
       {/* dsh dives below its box on hover; clip around the mascot (with
           top headroom for the leap and the spout) so the whale vanishes

--- a/src/components/shared/agent-card.tsx
+++ b/src/components/shared/agent-card.tsx
@@ -13,6 +13,7 @@ const CLICK_DURATIONS: Partial<Record<AgentInfo["name"], number>> = {
   antigravity: 800,
   kiro: 1100,
   omp: 900,
+  dsh: 900,
 };
 
 export function AgentCard({ agent }: AgentCardProps) {

--- a/src/components/shared/agent-card.tsx
+++ b/src/components/shared/agent-card.tsx
@@ -13,7 +13,7 @@ const CLICK_DURATIONS: Partial<Record<AgentInfo["name"], number>> = {
   antigravity: 800,
   kiro: 1100,
   omp: 900,
-  dsh: 900,
+  dsh: 1200,
 };
 
 export function AgentCard({ agent }: AgentCardProps) {
@@ -33,12 +33,21 @@ export function AgentCard({ agent }: AgentCardProps) {
       onClick={handleClick}
       className={`group flex w-[110px] flex-col items-center gap-1.5 rounded-lg border border-border/60 bg-card/50 px-3 py-2.5 text-center transition-all duration-200 hover:border-border hover:bg-card hover:shadow-sm hover:-translate-y-0.5 ${agent.name === "codex" || agent.name === "antigravity" || agent.name === "claude" || agent.name === "opencode" ? "overflow-hidden" : "overflow-visible"}`}
     >
-      <AgentMascot
-        name={agent.name}
-        size={36}
-        animated={isHovered}
-        clicked={isClicked}
-      />
+      {/* dsh dives below its box on hover; clip around the mascot (with
+          top headroom for the leap and the spout) so the whale vanishes
+          above the label instead of sliding over the text */}
+      <div
+        className={
+          agent.name === "dsh" ? "-mx-3 -mt-4 overflow-hidden px-3 pt-4" : undefined
+        }
+      >
+        <AgentMascot
+          name={agent.name}
+          size={36}
+          animated={isHovered}
+          clicked={isClicked}
+        />
+      </div>
       <div className="min-w-0">
         <span className="block whitespace-nowrap text-sm font-medium text-foreground">
           {agentDisplayName(agent.name)}

--- a/src/components/shared/agent-mascot/agent-mascot.tsx
+++ b/src/components/shared/agent-mascot/agent-mascot.tsx
@@ -5,6 +5,7 @@ import { CodexMascot } from "./codex-mascot";
 import { CopilotMascot } from "./copilot-mascot";
 import { CursorMascot } from "./cursor-mascot";
 import { DevinMascot } from "./devin-mascot";
+import { DshMascot } from "./dsh-mascot";
 import { FallbackMascot } from "./fallback-mascot";
 import { GeminiMascot } from "./gemini-mascot";
 import { HermesMascot } from "./hermes-mascot";
@@ -74,6 +75,11 @@ const MASCOT_MAP: Record<
   omp: {
     component: OmpMascot,
     className: "mascot-omp",
+    scale: 0.95,
+  },
+  dsh: {
+    component: DshMascot,
+    className: "mascot-dsh",
     scale: 0.95,
   },
 };

--- a/src/components/shared/agent-mascot/dsh-mascot.tsx
+++ b/src/components/shared/agent-mascot/dsh-mascot.tsx
@@ -1,0 +1,34 @@
+// dsh (DeepSeek Harness) mascot — a minimal whale glyph on a dark rounded
+// tile, DeepSeek-blue gradient. Follows the omp-mascot structure.
+
+interface MascotSvgProps {
+  size: number;
+}
+
+export function DshMascot({ size }: MascotSvgProps) {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      style={{ overflow: "visible" }}
+    >
+      <defs>
+        <linearGradient id="dsh-grad" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="#4d6bfe" />
+          <stop offset="1" stopColor="#38bdf8" />
+        </linearGradient>
+      </defs>
+      <rect className="dsh-bg" width="64" height="64" rx="12" fill="#0b1020" />
+      {/* whale body + tail */}
+      <path
+        className="dsh-whale"
+        fill="url(#dsh-grad)"
+        d="M10 36c2-9 11-15 22-15 9 0 16 4 20 10l6-5c1-1 3 0 2 2l-3 7 3 7c1 2-1 3-2 2l-6-5c-4 6-11 10-20 10-11 0-20-6-22-13z"
+      />
+      {/* eye */}
+      <circle cx="22" cy="34" r="2.4" fill="#0b1020" />
+    </svg>
+  );
+}

--- a/src/components/shared/agent-mascot/dsh-mascot.tsx
+++ b/src/components/shared/agent-mascot/dsh-mascot.tsx
@@ -1,5 +1,6 @@
-// dsh (DeepSeek Harness) mascot — a minimal whale glyph on a dark rounded
-// tile, DeepSeek-blue gradient. Follows the omp-mascot structure.
+// dsh (DSH / DeepSeek Harness) mascot — the official DeepSeek whale logo in
+// brand blue (#4D6BFE), rendered bare (no tile) so it reads cleanly on both
+// light and dark themes. Motion lives on the .mascot-dsh wrapper in mascot.css.
 
 interface MascotSvgProps {
   size: number;
@@ -8,27 +9,37 @@ interface MascotSvgProps {
 export function DshMascot({ size }: MascotSvgProps) {
   return (
     <svg
-      viewBox="0 0 64 64"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
       width={size}
       height={size}
       style={{ overflow: "visible" }}
     >
-      <defs>
-        <linearGradient id="dsh-grad" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0" stopColor="#4d6bfe" />
-          <stop offset="1" stopColor="#38bdf8" />
-        </linearGradient>
-      </defs>
-      <rect className="dsh-bg" width="64" height="64" rx="12" fill="#0b1020" />
-      {/* whale body + tail */}
       <path
-        className="dsh-whale"
-        fill="url(#dsh-grad)"
-        d="M10 36c2-9 11-15 22-15 9 0 16 4 20 10l6-5c1-1 3 0 2 2l-3 7 3 7c1 2-1 3-2 2l-6-5c-4 6-11 10-20 10-11 0-20-6-22-13z"
+        fill="#4d6bfe"
+        d="M23.748 4.482c-.254-.124-.364.113-.512.234-.051.039-.094.09-.137.136-.372.397-.806.657-1.373.626-.829-.046-1.537.214-2.163.848-.133-.782-.575-1.248-1.247-1.548-.352-.156-.708-.311-.955-.65-.172-.241-.219-.51-.305-.774-.055-.16-.11-.323-.293-.35-.2-.031-.278.136-.356.276-.313.572-.434 1.202-.422 1.84.027 1.436.633 2.58 1.838 3.393.137.093.172.187.129.323-.082.28-.18.552-.266.833-.055.179-.137.217-.329.14a5.526 5.526 0 01-1.736-1.18c-.857-.828-1.631-1.742-2.597-2.458a11.365 11.365 0 00-.689-.471c-.985-.957.13-1.743.388-1.836.27-.098.093-.432-.779-.428-.872.004-1.67.295-2.687.684a3.055 3.055 0 01-.465.137 9.597 9.597 0 00-2.883-.102c-1.885.21-3.39 1.102-4.497 2.623C.082 8.606-.231 10.684.152 12.85c.403 2.284 1.569 4.175 3.36 5.653 1.858 1.533 3.997 2.284 6.438 2.14 1.482-.085 3.133-.284 4.994-1.86.47.234.962.327 1.78.397.63.059 1.236-.03 1.705-.128.735-.156.684-.837.419-.961-2.155-1.004-1.682-.595-2.113-.926 1.096-1.296 2.746-2.642 3.392-7.003.05-.347.007-.565 0-.845-.004-.17.035-.237.23-.256a4.173 4.173 0 001.545-.475c1.396-.763 1.96-2.015 2.093-3.517.02-.23-.004-.467-.247-.588zM11.581 18c-2.089-1.642-3.102-2.183-3.52-2.16-.392.024-.321.471-.235.763.09.288.207.486.371.739.114.167.192.416-.113.603-.673.416-1.842-.14-1.897-.167-1.361-.802-2.5-1.86-3.301-3.307-.774-1.393-1.224-2.887-1.298-4.482-.02-.386.093-.522.477-.592a4.696 4.696 0 011.529-.039c2.132.312 3.946 1.265 5.468 2.774.868.86 1.525 1.887 2.202 2.891.72 1.066 1.494 2.082 2.48 2.914.348.292.625.514.891.677-.802.09-2.14.11-3.054-.614zm1-6.44a.306.306 0 01.415-.287.302.302 0 01.2.288.306.306 0 01-.31.307.303.303 0 01-.304-.308zm3.11 1.596c-.2.081-.399.151-.59.16a1.245 1.245 0 01-.798-.254c-.274-.23-.47-.358-.552-.758a1.73 1.73 0 01.016-.588c.07-.327-.008-.537-.239-.727-.187-.156-.426-.199-.688-.199a.559.559 0 01-.254-.078c-.11-.054-.2-.19-.114-.358.028-.054.16-.186.192-.21.356-.202.767-.136 1.146.016.352.144.618.408 1.001.782.391.451.462.576.685.914.176.265.336.537.445.848.067.195-.019.354-.25.452z"
       />
-      {/* eye */}
-      <circle cx="22" cy="34" r="2.4" fill="#0b1020" />
+      {/* Water spout above the blowhole, modeled on the classic twemoji
+          spouting-whale: a filled teardrop column (round at the top,
+          tapering down to the blowhole — no straight strokes) with two
+          mirrored splash lobes curling out and down from the top, like a
+          fountain falling to both sides. Invisible until click; mascot.css
+          grows the column, bursts the lobes outward, then flings drops. */}
+      <g className="dsh-spout" fill="#2aa3e8">
+        <path
+          className="dsh-spout-stem"
+          d="M6.2 5.8 C5.3 4.2 4.5 0.6 4.5 -1.6 C4.5 -3 5.2 -3.2 6.2 -3.2 C7.2 -3.2 7.9 -3 7.9 -1.6 C7.9 0.6 7.1 4.2 6.2 5.8 Z"
+        />
+        <g className="dsh-spout-crown">
+          <path d="M6.2 -1.2 c0 -2.6 -5.2 -1.7 -5.2 0 s2.6 0.9 3.5 2.6 s1.7 -2.6 1.7 -2.6 z" />
+          <path d="M6.2 -1.2 c0 -2.6 5.2 -1.7 5.2 0 s-2.6 0.9 -3.5 2.6 s-1.7 -2.6 -1.7 -2.6 z" />
+        </g>
+        <g className="dsh-spout-drops">
+          <circle className="dsh-drop-1" cx="1.6" cy="-1.8" r="0.85" />
+          <circle className="dsh-drop-2" cx="6.2" cy="-3" r="1" />
+          <circle className="dsh-drop-3" cx="10.8" cy="-1.8" r="0.85" />
+        </g>
+      </g>
     </svg>
   );
 }

--- a/src/components/shared/agent-mascot/mascot.css
+++ b/src/components/shared/agent-mascot/mascot.css
@@ -1400,50 +1400,124 @@
   100% { transform: scale(1);    opacity: 1; }
 }
 
-/* === dsh (DeepSeek Harness) ===
-   The icon is a whale glyph on a dark tile with a blue gradient. Hover:
-   gentle float (a whale bobbing on the swell). Click: glow burst from the
-   tile + scale pulse on the whale. Mirrors the omp motion patterns. */
+/* === dsh (DSH / DeepSeek Harness) ===
+   The icon is the official DeepSeek whale logo (bare, no tile; head faces
+   left). Hover: a slow swim — bobbing with a slight pitch, like a whale
+   riding the swell. Click: the whale swims off the left edge of the card
+   (heading the way it faces), wraps around offscreen, and swims back in
+   from the right — the codex-roll teleport trick, swum instead of rolled.
+   Needs the card's overflow-hidden. Both are whole-glyph transforms on the
+   wrapper: the logo is a single path, so no per-part motion is possible. */
 
-/* Hover: float the whole tile + gently shift the gradient's hue */
+/* Hover: breach loop — the whale leaps up, pitches over and dives out
+   through the bottom of the card, holds a beat underwater, then rises
+   back to the surface. The breach and the bob live on separate elements —
+   the wrapper arcs while the svg keeps its own small bob cycle. Click: a
+   separate animation replaces the breach (codex-style) — the whale
+   surfaces at center, spouts, and settles. */
 .mascot-dsh.is-animated {
-  animation: dsh-float 2.2s ease-in-out infinite;
+  animation: dsh-breach 3.4s linear infinite;
 }
-.mascot-dsh.is-animated .dsh-whale {
-  animation: dsh-hue 3s ease-in-out infinite;
-}
-
-/* Click: glow burst from the tile, whale scales briefly */
-.mascot-dsh.is-clicked .dsh-bg {
-  animation: dsh-glow 0.9s ease-out;
-}
-.mascot-dsh.is-clicked .dsh-whale {
-  animation: dsh-pulse 0.9s cubic-bezier(0.25, 0.75, 0.25, 1);
-  transform-origin: 32px 32px;
+.mascot-dsh.is-animated svg {
+  animation: dsh-bob 0.9s ease-in-out infinite;
 }
 
-@keyframes dsh-float {
-  0%, 100% { transform: translateY(0); }
-  50%      { transform: translateY(-4px); }
+/* Click replaces the hover animations (these rules sit after .is-animated,
+   same specificity, so they win): the wrapper snaps home and the whale
+   rises to the surface, holds there while the spout fires, then settles. */
+.mascot-dsh.is-clicked {
+  animation: none;
+}
+.mascot-dsh.is-clicked svg {
+  animation: dsh-surface 1.2s ease-in-out;
 }
 
-/* Subtle blue-range hue drift (a full 360° cycle would leave DeepSeek blue) */
-@keyframes dsh-hue {
-  0%, 100% { filter: hue-rotate(0deg); }
-  50%      { filter: hue-rotate(-25deg); }
+/* Spout parts are invisible until the click animation reveals them — under
+   prefers-reduced-motion the animations are disabled and they never appear.
+   Sequence: the stem shoots up from the blowhole (scaleY from the base),
+   the splash crown pops open at its tip with a little overshoot, then the
+   droplets fling outward. fill-mode both keeps delayed parts hidden. */
+.mascot-dsh .dsh-spout-stem,
+.mascot-dsh .dsh-spout-crown,
+.mascot-dsh .dsh-spout-drops circle {
+  opacity: 0;
+  transform-box: fill-box;
+}
+.mascot-dsh.is-clicked .dsh-spout-stem {
+  transform-origin: 50% 100%;
+  animation: dsh-stem 1.1s ease-out both;
+}
+.mascot-dsh.is-clicked .dsh-spout-crown {
+  /* burst upward and outward from the column tip, not in place */
+  transform-origin: 50% 100%;
+  animation: dsh-crown 1.02s ease-out 0.08s both;
+}
+.mascot-dsh.is-clicked .dsh-spout-drops circle {
+  transform-origin: center;
+  animation: dsh-drop 0.85s ease-out 0.22s both;
+}
+.mascot-dsh.is-clicked .dsh-drop-1 { --fling-x: -3.5px; animation-delay: 0.26s; }
+.mascot-dsh.is-clicked .dsh-drop-2 { --fling-x: 0px; }
+.mascot-dsh.is-clicked .dsh-drop-3 { --fling-x: 3.5px; animation-delay: 0.3s; }
+
+/* Sine-like bob: per-segment timing functions so velocity peaks crossing
+   the midline and only reaches zero at the extremes — a single easing for
+   the whole animation would stall at every keyframe boundary instead. */
+@keyframes dsh-bob {
+  0%   { transform: translateY(0) rotate(0deg);     animation-timing-function: ease-out; }
+  25%  { transform: translateY(-3px) rotate(-3deg); animation-timing-function: ease-in-out; }
+  75%  { transform: translateY(2px) rotate(2.5deg); animation-timing-function: ease-in; }
+  100% { transform: translateY(0) rotate(0deg); }
 }
 
-@keyframes dsh-glow {
-  0%   { filter: drop-shadow(0 0 0 transparent); }
-  30%  { filter: drop-shadow(0 0 12px rgba(77, 107, 254, 0.8)); }
-  100% { filter: drop-shadow(0 0 0 transparent); }
+/* The whale rises to breathe, holds while the droplets fire, settles back */
+@keyframes dsh-surface {
+  0%   { transform: translateY(0); }
+  20%  { transform: translateY(-2.5px); }
+  80%  { transform: translateY(-2.5px); }
+  100% { transform: translateY(0); }
 }
 
-@keyframes dsh-pulse {
-  0%   { transform: scale(1);    opacity: 1; }
-  30%  { transform: scale(1.15); opacity: 1; }
-  60%  { transform: scale(0.95); opacity: 0.9; }
-  100% { transform: scale(1);    opacity: 1; }
+/* The stem shoots up from the base, holds, then dissolves */
+@keyframes dsh-stem {
+  0%   { transform: scaleY(0);    opacity: 0; }
+  14%  { transform: scaleY(1);    opacity: 1; }
+  70%  { transform: scaleY(1);    opacity: 0.9; }
+  100% { transform: scaleY(1.05); opacity: 0; }
+}
+
+/* The splash cloud erupts with a bounce, holds, then dissolves */
+@keyframes dsh-crown {
+  0%   { transform: scale(0);    opacity: 0; }
+  18%  { transform: scale(1.25); opacity: 1; }
+  32%  { transform: scale(1);    opacity: 1; }
+  68%  { transform: scale(1.05); opacity: 0.85; }
+  100% { transform: scale(1.15); opacity: 0; }
+}
+
+/* Droplets fling out and up from the cloud (--fling-x set per drop) */
+@keyframes dsh-drop {
+  0%   { transform: translate(0, 0) scale(0.4); opacity: 0; }
+  25%  { transform: translate(calc(var(--fling-x, 0px) * 0.5), -2.4px) scale(1); opacity: 1; }
+  100% { transform: translate(var(--fling-x, 0px), -6px) scale(0.8); opacity: 0; }
+}
+
+/* Positive rotation = head-up for the left-facing whale. +80px is well
+   past the bottom of the clip box around the mascot in agent-card.tsx
+   (which ends above the card's label, so the whale never covers the text).
+   The fall is a single ease-in segment — an intermediate keyframe there
+   would reset the velocity and read as a stutter — with the pitch-over
+   from +10° to -20° interpolating across the whole dive. The 42–58% hold
+   is the beat spent underwater, where the whale quietly turns back to
+   face upward before rising. */
+@keyframes dsh-breach {
+  0%   { transform: translateY(0) rotate(0deg);      animation-timing-function: ease-out; }
+  18%  { transform: translateY(-16px) rotate(10deg); animation-timing-function: ease-in; }
+  42%  { transform: translateY(80px) rotate(-20deg); }
+  58%  { transform: translateY(80px) rotate(4deg);   animation-timing-function: ease-out; }
+  78%  { transform: translateY(-2px) rotate(2deg);   animation-timing-function: ease-in-out; }
+  88%  { transform: translateY(0) rotate(0deg); }
+  100% { transform: translateY(0) rotate(0deg); }
 }
 
 /* === Hermes ===

--- a/src/components/shared/agent-mascot/mascot.css
+++ b/src/components/shared/agent-mascot/mascot.css
@@ -1400,6 +1400,52 @@
   100% { transform: scale(1);    opacity: 1; }
 }
 
+/* === dsh (DeepSeek Harness) ===
+   The icon is a whale glyph on a dark tile with a blue gradient. Hover:
+   gentle float (a whale bobbing on the swell). Click: glow burst from the
+   tile + scale pulse on the whale. Mirrors the omp motion patterns. */
+
+/* Hover: float the whole tile + gently shift the gradient's hue */
+.mascot-dsh.is-animated {
+  animation: dsh-float 2.2s ease-in-out infinite;
+}
+.mascot-dsh.is-animated .dsh-whale {
+  animation: dsh-hue 3s ease-in-out infinite;
+}
+
+/* Click: glow burst from the tile, whale scales briefly */
+.mascot-dsh.is-clicked .dsh-bg {
+  animation: dsh-glow 0.9s ease-out;
+}
+.mascot-dsh.is-clicked .dsh-whale {
+  animation: dsh-pulse 0.9s cubic-bezier(0.25, 0.75, 0.25, 1);
+  transform-origin: 32px 32px;
+}
+
+@keyframes dsh-float {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-4px); }
+}
+
+/* Subtle blue-range hue drift (a full 360° cycle would leave DeepSeek blue) */
+@keyframes dsh-hue {
+  0%, 100% { filter: hue-rotate(0deg); }
+  50%      { filter: hue-rotate(-25deg); }
+}
+
+@keyframes dsh-glow {
+  0%   { filter: drop-shadow(0 0 0 transparent); }
+  30%  { filter: drop-shadow(0 0 12px rgba(77, 107, 254, 0.8)); }
+  100% { filter: drop-shadow(0 0 0 transparent); }
+}
+
+@keyframes dsh-pulse {
+  0%   { transform: scale(1);    opacity: 1; }
+  30%  { transform: scale(1.15); opacity: 1; }
+  60%  { transform: scale(0.95); opacity: 0.9; }
+  100% { transform: scale(1);    opacity: 1; }
+}
+
 /* === Hermes ===
    The icon is a classical left-facing profile — a coin/cameo head. So the
    motion leans into that: hover catches a glint of light across the profile
@@ -1685,6 +1731,8 @@
   .mascot-kiro.is-animated *,
   .mascot-omp.is-animated,
   .mascot-omp.is-animated *,
+  .mascot-dsh.is-animated,
+  .mascot-dsh.is-animated *,
   .mascot-fallback.is-animated *,
   .mascot-claude.is-clicked,
   .mascot-claude.is-clicked *,
@@ -1706,6 +1754,8 @@
   .mascot-kiro.is-clicked *,
   .mascot-omp.is-clicked,
   .mascot-omp.is-clicked *,
+  .mascot-dsh.is-clicked,
+  .mascot-dsh.is-clicked *,
   .mascot-fallback.is-clicked * {
     animation: none;
     transition: none;

--- a/src/index.css
+++ b/src/index.css
@@ -99,6 +99,7 @@
   --agent-hermes: oklch(0.64 0.13 90);
   --agent-kiro: oklch(0.58 0.15 305);
   --agent-omp: oklch(0.58 0.13 160);
+  --agent-dsh: oklch(0.55 0.15 270);
   --toast-success-bg: oklch(0.94 0.06 155);
   --toast-success-border: oklch(0.72 0.16 155);
   --toast-success-text: oklch(0.4 0.1 155);
@@ -204,6 +205,7 @@
   --agent-hermes: oklch(0.83 0.15 90);
   --agent-kiro: oklch(0.78 0.13 305);
   --agent-omp: oklch(0.78 0.11 160);
+  --agent-dsh: oklch(0.75 0.13 270);
   --toast-success-bg: oklch(0.23 0.04 155);
   --toast-success-border: oklch(0.55 0.14 155);
   --toast-success-text: oklch(0.78 0.12 155);
@@ -303,6 +305,7 @@
   --agent-hermes: oklch(0.64 0.13 90);
   --agent-kiro: oklch(0.58 0.15 305);
   --agent-omp: oklch(0.58 0.13 160);
+  --agent-dsh: oklch(0.55 0.15 270);
   --toast-success-bg: oklch(0.94 0.06 155);
   --toast-success-border: oklch(0.65 0.15 155);
   --toast-success-text: oklch(0.4 0.1 155);
@@ -396,6 +399,7 @@
   --agent-hermes: oklch(0.83 0.15 90);
   --agent-kiro: oklch(0.78 0.13 305);
   --agent-omp: oklch(0.78 0.11 160);
+  --agent-dsh: oklch(0.75 0.13 270);
   --toast-success-bg: oklch(0.26 0.04 155);
   --toast-success-border: oklch(0.55 0.14 155);
   --toast-success-text: oklch(0.78 0.12 155);
@@ -501,6 +505,7 @@
   --agent-hermes: oklch(0.64 0.13 90);
   --agent-kiro: oklch(0.58 0.15 305);
   --agent-omp: oklch(0.58 0.13 160);
+  --agent-dsh: oklch(0.55 0.15 270);
   --toast-success-bg: oklch(0.94 0.06 155);
   --toast-success-border: oklch(0.72 0.16 155);
   --toast-success-text: oklch(0.4 0.1 155);
@@ -600,6 +605,7 @@
   --agent-hermes: oklch(0.83 0.15 90);
   --agent-kiro: oklch(0.78 0.13 305);
   --agent-omp: oklch(0.78 0.11 160);
+  --agent-dsh: oklch(0.75 0.13 270);
   --toast-success-bg: oklch(0.23 0.04 155);
   --toast-success-border: oklch(0.55 0.14 155);
   --toast-success-text: oklch(0.78 0.12 155);
@@ -677,6 +683,7 @@ html.dark[data-theme="tiesen"][data-web="true"] {
   --color-agent-hermes: var(--agent-hermes);
   --color-agent-kiro: var(--agent-kiro);
   --color-agent-omp: var(--agent-omp);
+  --color-agent-dsh: var(--agent-dsh);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -341,7 +341,7 @@ describe("agentDisplayName", () => {
     expect(agentDisplayName("opencode")).toBe("OpenCode");
     expect(agentDisplayName("kiro")).toBe("Kiro");
     expect(agentDisplayName("omp")).toBe("Oh My Pi");
-    expect(agentDisplayName("dsh")).toBe("DeepSeek Harness");
+    expect(agentDisplayName("dsh")).toBe("DSH");
   });
 
   it("capitalizes first letter for unknown agents", () => {

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -341,6 +341,7 @@ describe("agentDisplayName", () => {
     expect(agentDisplayName("opencode")).toBe("OpenCode");
     expect(agentDisplayName("kiro")).toBe("Kiro");
     expect(agentDisplayName("omp")).toBe("Oh My Pi");
+    expect(agentDisplayName("dsh")).toBe("DeepSeek Harness");
   });
 
   it("capitalizes first letter for unknown agents", () => {

--- a/src/lib/i18n/locales/en/audit.json
+++ b/src/lib/i18n/locales/en/audit.json
@@ -99,6 +99,10 @@
       "label": "Permission Combination Risk",
       "description": "Dangerous combination of permissions that could enable data exfiltration or RCE"
     },
+    "skillInvocationKeyCase": {
+      "label": "Skill Invocation Key Case",
+      "description": "Frontmatter uses a camelCase invocation key that DeepSeek Harness silently rejects, dropping the whole skill"
+    },
     "cliCredentialStorage": {
       "label": "CLI Credential Storage",
       "description": "CLI credential file has overly permissive permissions or unknown storage location"

--- a/src/lib/i18n/locales/en/extensions.json
+++ b/src/lib/i18n/locales/en/extensions.json
@@ -71,6 +71,7 @@
     "partOfSkillPrefix": "This skill is part of ",
     "codexHooksWarning": "Codex hooks must be trusted via `codex /hooks` before they run.",
     "dshMcpPluginNote": "In DeepSeek Harness this server appears in Settings → Plugins as an 'mcp-client' plugin card (search this server's name there to locate it).",
+    "skillInvocationKeyWarning": "This skill's frontmatter uses a camelCase invocation key — DeepSeek Harness silently drops the whole skill. Rename to the kebab-case form (see Audit for details); re-run the audit after fixing and this warning disappears.",
     "enabled": "Enabled",
     "disabled": "Disabled",
     "bindSource": "+ Bind source",

--- a/src/lib/i18n/locales/en/extensions.json
+++ b/src/lib/i18n/locales/en/extensions.json
@@ -70,6 +70,7 @@
     "partOfMcpPrefix": "This MCP server is part of ",
     "partOfSkillPrefix": "This skill is part of ",
     "codexHooksWarning": "Codex hooks must be trusted via `codex /hooks` before they run.",
+    "dshMcpPluginNote": "In DeepSeek Harness this server appears in Settings → Plugins as an 'mcp-client' plugin card (search this server's name there to locate it).",
     "enabled": "Enabled",
     "disabled": "Disabled",
     "bindSource": "+ Bind source",

--- a/src/lib/i18n/locales/zh-TW/audit.json
+++ b/src/lib/i18n/locales/zh-TW/audit.json
@@ -99,6 +99,10 @@
       "label": "權限組合風險",
       "description": "危險的權限組合可能導致資料外洩或遠端程式碼執行"
     },
+    "skillInvocationKeyCase": {
+      "label": "Skill 呼叫鍵大小寫",
+      "description": "Frontmatter 使用了 camelCase 呼叫鍵，DeepSeek Harness 會靜默捨棄整個 skill"
+    },
     "cliCredentialStorage": {
       "label": "CLI 憑證儲存",
       "description": "CLI 憑證檔權限過寬或儲存位置不明"

--- a/src/lib/i18n/locales/zh-TW/extensions.json
+++ b/src/lib/i18n/locales/zh-TW/extensions.json
@@ -70,6 +70,7 @@
     "partOfMcpPrefix": "這個 MCP server 屬於 ",
     "partOfSkillPrefix": "這個 skill 屬於 ",
     "codexHooksWarning": "Codex hook 必須先透過 `codex /hooks` 信任後才能執行。",
+    "dshMcpPluginNote": "在 DeepSeek Harness 中，此 server 顯示在 Settings → Plugins 裡，是名為 mcp-client 的 plugin 卡片（在其中搜尋此 server 名稱可定位）。",
     "enabled": "已啟用",
     "disabled": "已停用",
     "bindSource": "+ 綁定來源",

--- a/src/lib/i18n/locales/zh-TW/extensions.json
+++ b/src/lib/i18n/locales/zh-TW/extensions.json
@@ -71,6 +71,7 @@
     "partOfSkillPrefix": "這個 skill 屬於 ",
     "codexHooksWarning": "Codex hook 必須先透過 `codex /hooks` 信任後才能執行。",
     "dshMcpPluginNote": "在 DeepSeek Harness 中，此 server 顯示在 Settings → Plugins 裡，是名為 mcp-client 的 plugin 卡片（在其中搜尋此 server 名稱可定位）。",
+    "skillInvocationKeyWarning": "此 skill 的 frontmatter 使用了 camelCase 呼叫鍵——DeepSeek Harness 會靜默捨棄整個 skill。請改為 kebab-case 寫法（詳見稽核）；修正後重新執行稽核，此提示會消失。",
     "enabled": "已啟用",
     "disabled": "已停用",
     "bindSource": "+ 綁定來源",

--- a/src/lib/i18n/locales/zh/audit.json
+++ b/src/lib/i18n/locales/zh/audit.json
@@ -99,6 +99,10 @@
       "label": "权限组合风险",
       "description": "危险的权限组合可能导致数据外泄或远程代码执行"
     },
+    "skillInvocationKeyCase": {
+      "label": "Skill 调用键大小写",
+      "description": "Frontmatter 使用了 camelCase 调用键，DeepSeek Harness 会静默丢弃整个 skill"
+    },
     "cliCredentialStorage": {
       "label": "CLI 凭据存储",
       "description": "CLI 凭据文件权限过宽或存储位置未知"

--- a/src/lib/i18n/locales/zh/extensions.json
+++ b/src/lib/i18n/locales/zh/extensions.json
@@ -70,6 +70,7 @@
     "partOfMcpPrefix": "此 MCP server 属于 ",
     "partOfSkillPrefix": "此 skill 属于 ",
     "codexHooksWarning": "Codex hook 必须先通过 `codex /hooks` 信任后才能运行。",
+    "dshMcpPluginNote": "在 DeepSeek Harness 中，此 server 显示在 Settings → Plugins 里，是名为 mcp-client 的插件卡片（在其中搜索此 server 名称可定位）。",
     "enabled": "已启用",
     "disabled": "已禁用",
     "bindSource": "+ 绑定来源",

--- a/src/lib/i18n/locales/zh/extensions.json
+++ b/src/lib/i18n/locales/zh/extensions.json
@@ -71,6 +71,7 @@
     "partOfSkillPrefix": "此 skill 属于 ",
     "codexHooksWarning": "Codex hook 必须先通过 `codex /hooks` 信任后才能运行。",
     "dshMcpPluginNote": "在 DeepSeek Harness 中，此 server 显示在 Settings → Plugins 里，是名为 mcp-client 的插件卡片（在其中搜索此 server 名称可定位）。",
+    "skillInvocationKeyWarning": "此 skill 的 frontmatter 使用了 camelCase 调用键——DeepSeek Harness 会静默丢弃整个 skill。请改为 kebab-case 写法（详见审计）；修复后重新运行审计，此提示会消失。",
     "enabled": "已启用",
     "disabled": "已禁用",
     "bindSource": "+ 绑定来源",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -423,6 +423,7 @@ export const AGENT_ORDER = [
   "hermes",
   "kiro",
   "omp",
+  "dsh",
 ] as const;
 
 /** Sort an array of agents (or agent-like objects with a `name` field) by a given order. */
@@ -449,6 +450,7 @@ const AGENT_DISPLAY_NAMES: Record<string, string> = {
   hermes: "Hermes",
   kiro: "Kiro",
   omp: "Oh My Pi",
+  dsh: "DeepSeek Harness",
 };
 
 /** Get the display name for an agent (e.g. "claude" → "Claude Code"). */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -450,7 +450,7 @@ const AGENT_DISPLAY_NAMES: Record<string, string> = {
   hermes: "Hermes",
   kiro: "Kiro",
   omp: "Oh My Pi",
-  dsh: "DeepSeek Harness",
+  dsh: "DSH",
 };
 
 /** Get the display name for an agent (e.g. "claude" → "Claude Code"). */

--- a/src/pages/audit-utils.ts
+++ b/src/pages/audit-utils.ts
@@ -85,6 +85,15 @@ export const AUDIT_RULES = [
     kinds: ["skill", "mcp", "hook", "plugin"] as Kind[],
   },
   {
+    id: "skill-invocation-key-case",
+    label: "Skill Invocation Key Case",
+    severity: "Medium" as Severity,
+    deduction: 8,
+    description:
+      "Frontmatter uses a camelCase invocation key that DeepSeek Harness silently rejects, dropping the whole skill",
+    kinds: ["skill"] as Kind[],
+  },
+  {
     id: "cli-credential-storage",
     label: "CLI Credential Storage",
     severity: "High" as Severity,


### PR DESCRIPTION
Adds **DeepSeek Harness (dsh)** as the 12th supported agent.

## What's included

**Detection & config**
- Detects dsh via `$DSH_HOME`/`~/.dsh` profile signals (strong signal: `profiles/*/package.json` with `dsh.profile.bundles`); project signal: `.dsh/skills/`
- Context files: `~/.dsh/AGENTS.md` + project AGENTS.md/CLAUDE.md chain

**Skills**
- Scans all 4 skill roots (`~/.dsh/skills`, shared `~/.agents/skills`, project `.dsh/skills` / `.agents/skills`), non-recursive per dsh semantics, `.system` subdir skipped
- Enable/disable via `SKILL.md ⇄ SKILL.md.disabled` rename (picked up live by dsh's file watcher)
- Cross-agent skill install targets `.dsh/skills`; install validation rejects camelCase invocation keys (see audit rule below)

**MCP**
- New `McpFormat::DshCordis`: parses `@deepseek-ai/dsh-mcp-client` rows from the home-layer `cordis.patch.yml`, tolerating the cordis YAML dialect (`!!js` expression tags are preserved, never evaluated)
- Native enable/disable through an HK-managed marker block appended to the patch file — dsh's official id-targeted `disabled` override mechanism. Text-level only: user bytes are never re-serialized; removing the block restores the file byte-for-byte. Unbalanced markers fail hard (`ConfigCorrupted`) instead of silently dropping user content
- Install/remove is intentionally **not** supported yet (loud `Validation` error); the managed-block insert writer is the headline of the follow-up PR together with plugin scanning

**Audit**
- New rule `skill-invocation-key-case` (Medium): flags camelCase invocation keys (`disableModelInvocation` / `modelInvocable` / `userInvocable`) that dsh rejects fail-closed — the whole skill is silently dropped. Per-key kebab-case suggestions (including the inverted-meaning `modelInvocable` case) with file:line locations
- Finding is also surfaced as a warning in the skill's detail panel (derived from the audit store; disappears once fixed and re-audited)

**Frontend**
- dsh registered in agent order/display names, whale mascot (reduced-motion safe), brand-adjacent oklch color tokens, onboarding records
- Audit rule registered in the frontend rule registry + i18n (en / zh / zh-TW)
- MCP detail panel note bridging dsh's UI naming (servers appear in dsh Settings → Plugins as `mcp-client` plugin cards)

**Hardening beyond the plan** (all pinned by tests)
- `disabled: null` ≡ `false` (matches upstream entry semantics)
- Native-toggle dispatch: hermes is now an explicit branch; a future native-toggle agent without a dispatch branch fails loudly instead of silently writing another agent's format
- Remote-vs-stdio decided by `url` presence first (a `url` row with an omitted/unknown transport can't produce a contradictory empty-command stdio entry)

## Verification

- `cargo test --workspace`: 642 passed, 0 failed, no warnings
- `tsc`: 0 errors; `vitest`: 286/286
- Real-machine smoke against `@deepseek-ai/dsh@0.1.0-rc.6`: detect / skill scan (incl. shared `~/.agents` attribution) / MCP scan all correct; `hk disable` → dsh's own `--dump-config` assembles `disabled: true` (official loader consuming HK's write); `hk enable` → byte-identical restore (MD5 verified); audit rule fires with per-key suggestions; toggles hot-reload live in dsh's own web UI

## Known limitations (follow-up PR)

- The MCP install dialog still lists dsh as a target; submitting fails with a clear error. Deliberately not gated here — the next PR either makes install work (managed-block insert writer) or grays it out
- dsh plugin ecosystem (cordis rows) is not yet modeled; plugin scan/reconciliation is the next PR's main course
- Presets, hooks-bridge display, and precise cordis row-id display are tracked as P1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
