### PR TITLE
fix: one rule for what counts as an installed extension

### DIFF
--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -47,6 +47,7 @@ import { useAgentStore } from "@/stores/agent-store";
 import { useAuditStore } from "@/stores/audit-store";
 import {
   agentsInScope,
+  enabledAgentSet,
   findCliChildren,
   instancesInScope,
   pickSourceInstance,
@@ -581,14 +582,16 @@ export function ExtensionDetail() {
             {t("detail.agents")}
           </h4>
           <div className="flex flex-wrap gap-1">
-            {agentsInScope(group, scope).map((agent) => (
-              <span
-                key={agent}
-                className="inline-flex rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
-              >
-                {agentDisplayName(agent)}
-              </span>
-            ))}
+            {agentsInScope(group, scope, enabledAgentSet(agents)).map(
+              (agent) => (
+                <span
+                  key={agent}
+                  className="inline-flex rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                >
+                  {agentDisplayName(agent)}
+                </span>
+              ),
+            )}
           </div>
         </div>
 
@@ -989,7 +992,9 @@ export function ExtensionDetail() {
             // own manifests naming a package that is gone.
             const shipped = isVendorBaseline(
               group.pack,
-              agents.flatMap((a) => a.capabilities?.vendor_baseline_packs ?? []),
+              agents.flatMap(
+                (a) => a.capabilities?.vendor_baseline_packs ?? [],
+              ),
             );
             return (
               <button

--- a/src/components/extensions/extension-table.tsx
+++ b/src/components/extensions/extension-table.tsx
@@ -18,7 +18,7 @@ import { useScope } from "@/hooks/use-scope";
 import type { ExtensionKind, GroupedExtension } from "@/lib/types";
 import { agentDisplayName, sortAgentNames } from "@/lib/types";
 import { useAgentStore } from "@/stores/agent-store";
-import { agentsInScope } from "@/stores/extension-helpers";
+import { agentsInScope, enabledAgentSet } from "@/stores/extension-helpers";
 import { useExtensionStore } from "@/stores/extension-store";
 import { toast } from "@/stores/toast-store";
 
@@ -34,6 +34,8 @@ export function ExtensionTable({
   const { t } = useTranslation("extensions");
   const { t: tc } = useTranslation("common");
   const agentOrder = useAgentStore((s) => s.agentOrder);
+  const agents = useAgentStore((s) => s.agents);
+  const enabledAgents = useMemo(() => enabledAgentSet(agents), [agents]);
   const { scope } = useScope();
   const navigate = useNavigate();
   // Subscribe to trigger re-render; accessed via getState() in cell renderers
@@ -44,7 +46,8 @@ export function ExtensionTable({
   // Subscribe to trigger re-render; accessed via getState() in cell renderers
   useExtensionStore((s) => s.updateStatuses);
   const toggle = useExtensionStore((s) => s.toggle);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `scope` is a trigger sentinel — cell renderers read scope-dependent filter results via getState(); listing it forces a column rebuild on scope change.
+  // `scope` and `enabledAgents` are in the dep list because the badge cell
+  // renders through them; the rest of the cell renderers read via getState().
   const columns = useMemo(
     () => [
       col.display({
@@ -127,12 +130,12 @@ export function ExtensionTable({
       col.accessor("agents", {
         header: () => t("table.headers.agent"),
         // Badges show the agents present in the ACTIVE scope (union in All
-        // mode) so a project view never claims a global-only agent has a
-        // copy here. Group identity/`agents` stays the full union.
+        // mode) and still switched on, matching the rule that decides which
+        // rows exist at all. Group identity/`agents` stays the full union.
         cell: (info) => (
           <div className="flex items-end gap-1">
             {sortAgentNames(
-              agentsInScope(info.row.original, scope),
+              agentsInScope(info.row.original, scope, enabledAgents),
               agentOrder,
             ).map((name) => (
               <div
@@ -210,7 +213,16 @@ export function ExtensionTable({
     ],
     // selectedIds, updateStatuses accessed via getState() inside cell renderers
     // to avoid recomputing columns on every selection/status change.
-    [agentOrder, selectAll, clearSelection, toggleSelected, toggle, scope, t],
+    [
+      agentOrder,
+      enabledAgents,
+      selectAll,
+      clearSelection,
+      toggleSelected,
+      toggle,
+      scope,
+      t,
+    ],
   );
   const sorting = useExtensionStore((s) => s.tableSorting) as SortingState;
   const setStoreSorting = useExtensionStore((s) => s.setTableSorting);

--- a/src/pages/audit.tsx
+++ b/src/pages/audit.tsx
@@ -18,15 +18,16 @@ import { TrustBadge } from "@/components/shared/trust-badge";
 import { useScope } from "@/hooks/use-scope";
 import { api } from "@/lib/invoke";
 import type { ConfigScope, Extension } from "@/lib/types";
-import {
-  extensionGroupKey,
-  formatRelativeTime,
-  type TrustTier,
-  trustTier,
-} from "@/lib/types";
+import { formatRelativeTime, type TrustTier, trustTier } from "@/lib/types";
 import { isWeb, webSelectStyle } from "@/lib/web-select";
+import { useAgentStore } from "@/stores/agent-store";
 import { useAuditStore } from "@/stores/audit-store";
-import { buildGroups } from "@/stores/extension-store";
+import {
+  buildGroups,
+  enabledAgentSet,
+  groupHasEnabledAgent,
+  groupKeyById,
+} from "@/stores/extension-store";
 import { useScopeStore } from "@/stores/scope-store";
 import {
   AUDIT_RULES,
@@ -79,6 +80,7 @@ export default function AuditPage() {
   const [allExtensions, setAllExtensions] = useState<Extension[]>([]);
   const [extensionsReady, setExtensionsReady] = useState(false);
   const { scope } = useScope();
+  const agents = useAgentStore((s) => s.agents);
 
   // Close any expanded finding row when the user switches scope — the
   // previously-open extension may not exist in the new scope.
@@ -140,15 +142,20 @@ export default function AuditPage() {
     return map;
   }, [allExtensions]);
 
-  // Map extension ID → groupKey for audit deduplication.
-  // Group by extensionGroupKey (same as extensions page).
-  const groupKeyMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const ext of allExtensions) {
-      map.set(ext.id, extensionGroupKey(ext));
-    }
-    return map;
-  }, [allExtensions]);
+  // The rows this page is allowed to report on: the Extensions list's own
+  // grouping, minus groups that live only on switched-off agents.
+  const visibleGroups = useMemo(() => {
+    const enabled = enabledAgentSet(agents);
+    const groups = buildGroups(allExtensions);
+    return enabled
+      ? groups.filter((g) => groupHasEnabledAgent(g, enabled))
+      : groups;
+  }, [allExtensions, agents]);
+
+  const groupKeyMap = useMemo(
+    () => groupKeyById(visibleGroups),
+    [visibleGroups],
+  );
 
   // Map extension ID → scope (used by the scope filter on scopedResults).
   const scopeMap = useMemo(() => {
@@ -159,26 +166,33 @@ export default function AuditPage() {
     return map;
   }, [allExtensions]);
 
-  // Apply the global scope filter to raw audit results before any other
-  // derivation (counts, sorting, grouping). In All-scopes mode every result
-  // passes; otherwise we keep only results whose extension lives in the
-  // selected scope.
-  const scopedResults = useMemo(() => {
-    if (scope.type === "all") return results;
-    return results.filter((r) => {
-      const extScope = scopeMap.get(r.extension_id);
-      if (!extScope) return false;
-      if (scope.type === "global") return extScope.type === "global";
-      return extScope.type === "project" && extScope.path === scope.path;
-    });
-  }, [results, scope, scopeMap]);
+  // Narrow the raw audit results once, before any other derivation (counts,
+  // sorting, grouping), to the ones this page reports on: the extension still
+  // exists and is visible, and it lives in the selected scope. Doing it here
+  // is what keeps the header's two numbers describing the same set — a result
+  // whose extension is gone has no row to attach to, and used to be counted
+  // anyway under its raw ID.
+  const scopedResults = useMemo(
+    () =>
+      results.filter((r) => {
+        if (!groupKeyMap.has(r.extension_id)) return false;
+        if (scope.type === "all") return true;
+        const extScope = scopeMap.get(r.extension_id);
+        if (!extScope) return false;
+        if (scope.type === "global") return extScope.type === "global";
+        return extScope.type === "project" && extScope.path === scope.path;
+      }),
+    [results, scope, scopeMap, groupKeyMap],
+  );
 
-  // Count extensions that actually have audit results
+  // Extensions that actually have audit results, counted the same way the
+  // rows below are grouped.
   const totalExtensions = useMemo(() => {
     const auditedIds = new Set(scopedResults.map((r) => r.extension_id));
-    return buildGroups(allExtensions.filter((e) => auditedIds.has(e.id)))
-      .length;
-  }, [allExtensions, scopedResults]);
+    return visibleGroups.filter((g) =>
+      g.instances.some((i) => auditedIds.has(i.id)),
+    ).length;
+  }, [visibleGroups, scopedResults]);
 
   const sortedResults = useMemo(
     () =>

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -17,15 +17,15 @@ import { useNavigate } from "react-router-dom";
 import { AgentCard } from "@/components/shared/agent-card";
 import { api } from "@/lib/invoke";
 import type { AgentDetail, DashboardStats } from "@/lib/types";
-import {
-  agentDisplayName,
-  extensionGroupKey,
-  formatRelativeTime,
-  sortAgents,
-} from "@/lib/types";
+import { agentDisplayName, formatRelativeTime, sortAgents } from "@/lib/types";
 import { useAgentStore } from "@/stores/agent-store";
 import { useAuditStore } from "@/stores/audit-store";
-import { buildGroups, useExtensionStore } from "@/stores/extension-store";
+import {
+  buildGroups,
+  enabledAgentSet,
+  groupHasEnabledAgent,
+  useExtensionStore,
+} from "@/stores/extension-store";
 import { toast } from "@/stores/toast-store";
 
 // ---------------------------------------------------------------------------
@@ -228,26 +228,17 @@ export default function OverviewPage() {
   // Show skeleton until both extensions (fetched in App.tsx) and local data are ready.
   const initialLoaded = localReady && extHasFetched;
 
-  // Filter extensions to only those belonging to enabled agents
-  const enabledAgentNames = useMemo(
-    () => new Set(agents.filter((a) => a.enabled).map((a) => a.name)),
-    [agents],
-  );
-  const visibleExtensions = useMemo(
-    () =>
-      extensions.filter(
-        (e) =>
-          e.agents.length === 0 ||
-          e.agents.some((a) => enabledAgentNames.has(a)),
-      ),
-    [extensions, enabledAgentNames],
-  );
-
-  // Group extensions so identical skills across agents count as one
-  const visibleGroups = useMemo(
-    () => buildGroups(visibleExtensions),
-    [visibleExtensions],
-  );
+  // Group extensions so identical skills across agents count as one, then drop
+  // the groups that live only on agents the user switched off. Grouping first
+  // and filtering after is what the Extensions list and the Audit page do —
+  // same helper, same order — so the three headline counts agree.
+  const visibleGroups = useMemo(() => {
+    const enabled = enabledAgentSet(agents);
+    const groups = buildGroups(extensions);
+    return enabled
+      ? groups.filter((g) => groupHasEnabledAgent(g, enabled))
+      : groups;
+  }, [extensions, agents]);
 
   // Dashboard stats — derived client-side from grouped extension data
   const stats = useMemo<DashboardStats | null>(() => {
@@ -377,28 +368,32 @@ export default function OverviewPage() {
     // not the time each individual entry was added.
     const accurateKinds = new Set(["skill", "plugin", "cli"]);
     const seenExtNames = new Set<string>();
-    for (const ext of visibleExtensions) {
-      if (!accurateKinds.has(ext.kind)) continue;
-      if (seenExtNames.has(ext.name)) continue;
-      seenExtNames.add(ext.name);
+    for (const g of visibleGroups) {
+      const ext = g.instances[0];
+      if (!accurateKinds.has(g.kind)) continue;
+      if (seenExtNames.has(g.name)) continue;
+      seenExtNames.add(g.name);
       items.push({
         type: "extension",
-        kind: ext.kind,
-        label: ext.name,
+        kind: g.kind,
+        label: g.name,
         sublabel: t("activity.extensionInstalled", {
-          kind: ext.kind.toUpperCase(),
-          time: formatRelativeTime(ext.installed_at),
+          kind: g.kind.toUpperCase(),
+          time: formatRelativeTime(g.installed_at),
         }),
-        timestamp: new Date(ext.installed_at).getTime(),
+        timestamp: new Date(g.installed_at).getTime(),
         // Pass scope through the URL (see config-items comment above for why
         // setScope + navigate in the same handler races and loses the nav).
+        // The group's own key is what the Extensions list matches on — an
+        // `extensionGroupKey(ext)` recomputed from one instance misses the
+        // sibling merge buildGroups applies, and lands on nothing.
         onSelect: () => {
           const scopeParam =
             ext.scope.type === "global"
               ? ""
               : `&scope=${encodeURIComponent(ext.scope.path)}`;
           navigate(
-            `/extensions?groupKey=${encodeURIComponent(extensionGroupKey(ext))}${scopeParam}`,
+            `/extensions?groupKey=${encodeURIComponent(g.groupKey)}${scopeParam}`,
           );
         },
       });
@@ -406,7 +401,7 @@ export default function OverviewPage() {
 
     items.sort((a, b) => b.timestamp - a.timestamp);
     return items.slice(0, 20);
-  }, [visibleExtensions, navigate, t]);
+  }, [visibleGroups, navigate, t]);
 
   const hasActivity =
     agentActivityItems.length > 0 || extensionActivityItems.length > 0;

--- a/src/stores/__tests__/extension-helpers.test.ts
+++ b/src/stores/__tests__/extension-helpers.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest";
 import type { Extension, GroupedExtension } from "@/lib/types";
+import { extensionGroupKey } from "@/lib/types";
 import type { ScopeValue } from "@/stores/scope-store";
 import {
   agentsInScope,
   BUILTIN_PACK_PREFIX,
   buildGroups,
+  enabledAgentSet,
   expandGroupKeys,
   getCachedFiltered,
   getCachedGroups,
+  groupHasEnabledAgent,
+  groupKeyById,
   instancesInScope,
   pickSourceInstance,
   resolveInstallTargetScope,
@@ -713,5 +717,145 @@ describe("hook grouping merges across scopes (like MCP)", () => {
     expect(groups[0].agents).toEqual(
       expect.arrayContaining(["claude", "kiro"]),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// One count rule across Overview, Extensions and Audit
+// ---------------------------------------------------------------------------
+
+describe("enabledAgentSet", () => {
+  it("returns null for an unfetched agent list so nothing gets hidden", () => {
+    expect(enabledAgentSet([])).toBeNull();
+  });
+
+  it("keeps only the switched-on agents", () => {
+    const set = enabledAgentSet([
+      { name: "claude", enabled: true },
+      { name: "windsurf", enabled: false },
+    ]);
+    expect([...(set ?? [])]).toEqual(["claude"]);
+  });
+});
+
+describe("groupHasEnabledAgent", () => {
+  const groupOn = (agents: string[]): GroupedExtension =>
+    buildGroups([{ ...baseExt, id: agents.join("-"), agents }])[0];
+
+  it("keeps a group that survives on one enabled agent", () => {
+    expect(
+      groupHasEnabledAgent(
+        groupOn(["claude", "windsurf"]),
+        new Set(["claude"]),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops a group that exists only on switched-off agents", () => {
+    expect(
+      groupHasEnabledAgent(groupOn(["windsurf"]), new Set(["claude"])),
+    ).toBe(false);
+  });
+
+  it("keeps agentless rows", () => {
+    expect(groupHasEnabledAgent(groupOn([]), new Set(["claude"]))).toBe(true);
+  });
+});
+
+describe("getCachedFiltered drops switched-off agents' rows", () => {
+  const claudeOnly = { ...baseExt, id: "c", name: "kept", agents: ["claude"] };
+  const windsurfOnly = {
+    ...baseExt,
+    id: "w",
+    name: "dropped",
+    agents: ["windsurf"],
+  };
+  const groups = buildGroups([claudeOnly, windsurfOnly]);
+  const allScope: ScopeValue = { type: "all" };
+
+  it("hides a row whose only agent is switched off", () => {
+    const result = getCachedFiltered(
+      groups,
+      null,
+      null,
+      null,
+      null,
+      "",
+      allScope,
+      {},
+      false,
+      new Set(["claude"]),
+    );
+    expect(result.map((g) => g.name)).toEqual(["kept"]);
+  });
+
+  it("hides nothing when the agent list hasn't loaded (null)", () => {
+    const result = getCachedFiltered(
+      groups,
+      null,
+      null,
+      null,
+      null,
+      "",
+      allScope,
+      {},
+      false,
+      null,
+    );
+    expect(result).toHaveLength(2);
+  });
+
+  it("is not a user filter: no Clear-filters affordance can bring the row back", () => {
+    // Same call with every user filter cleared still hides it — the rule is
+    // about what exists, not about what the user narrowed to.
+    const cleared = getCachedFiltered(
+      groups,
+      null,
+      null,
+      null,
+      null,
+      "",
+      allScope,
+      {},
+      false,
+      new Set(["claude"]),
+    );
+    expect(cleared.some((g) => g.name === "dropped")).toBe(false);
+  });
+});
+
+describe("groupKeyById", () => {
+  it("maps every instance to its group's key, sibling merge included", () => {
+    // The audit page starts from bare extension IDs. Recomputing
+    // extensionGroupKey() per instance would split this pair in two — the
+    // sourceless copy and its pack-carrying twin — and report one extension
+    // as two rows.
+    const shared: Extension = {
+      ...baseExt,
+      source: { origin: "agent", url: null, version: null, commit_hash: null },
+      install_meta: null,
+    };
+    const withPack = { ...shared, id: "a", agents: ["claude"], pack: "o/r" };
+    const sourceless = { ...shared, id: "b", agents: ["codex"], pack: null };
+
+    const groups = buildGroups([withPack, sourceless]);
+    const byId = groupKeyById(groups);
+
+    expect(groups).toHaveLength(1);
+    expect(byId.get("a")).toBe(groups[0].groupKey);
+    expect(byId.get("b")).toBe(groups[0].groupKey);
+    expect(extensionGroupKey(sourceless)).not.toBe(extensionGroupKey(withPack));
+  });
+});
+
+describe("agentsInScope with enabledAgents", () => {
+  it("drops badges for switched-off agents", () => {
+    const group = buildGroups([
+      { ...baseExt, id: "a", agents: ["claude", "codex"] },
+    ])[0];
+    expect(agentsInScope(group, { type: "all" }, new Set(["claude"]))).toEqual([
+      "claude",
+    ]);
+    expect(agentsInScope(group, { type: "all" })).toEqual(["claude", "codex"]);
   });
 });

--- a/src/stores/extension-helpers.ts
+++ b/src/stores/extension-helpers.ts
@@ -78,17 +78,64 @@ export function instancesInScope(
 
 /** Agent names that have an instance of `group` in `scope`. All mode
  *  returns the full cross-scope union. Group identity (`group.agents`)
- *  stays scope-free — this is a DISPLAY/FILTER projection. */
+ *  stays scope-free — this is a DISPLAY/FILTER projection.
+ *
+ *  Pass `enabledAgents` to drop the ones the user switched off. A row that
+ *  exists *only* on switched-off agents is gone from the list entirely, so
+ *  leaving their badges on the rows that survive would be a half-truth: the
+ *  same agent both absent and present depending on which row you look at.
+ *  The file-level surfaces — PATHS, the delete dialog — deliberately do NOT
+ *  take this projection; they must keep showing every copy on disk, so
+ *  deleting a row can never quietly remove a file the user was never shown. */
 export function agentsInScope(
   group: GroupedExtension,
   scope: ScopeValue,
+  enabledAgents: ReadonlySet<string> | null = null,
 ): string[] {
-  if (scope.type === "all") return group.agents;
-  return sortAgentNames([
-    ...new Set(
-      instancesInScope(group.instances, scope).flatMap((i) => i.agents),
-    ),
-  ]);
+  const keep = (names: string[]) =>
+    enabledAgents ? names.filter((a) => enabledAgents.has(a)) : names;
+  if (scope.type === "all") return keep(group.agents);
+  return keep(
+    sortAgentNames([
+      ...new Set(
+        instancesInScope(group.instances, scope).flatMap((i) => i.agents),
+      ),
+    ]),
+  );
+}
+
+/** The agents a count should include, or null for "don't filter".
+ *
+ *  Null is what an unfetched agent list looks like: the backend always reports
+ *  every adapter, so an empty array means the request hasn't landed, and
+ *  reading that as "nothing is enabled" would blank every list on first paint.
+ *  Callers pass the result straight to `groupHasEnabledAgent`. */
+export function enabledAgentSet(
+  agents: readonly { name: string; enabled: boolean }[],
+): ReadonlySet<string> | null {
+  if (agents.length === 0) return null;
+  return new Set(agents.filter((a) => a.enabled).map((a) => a.name));
+}
+
+/** Does this group exist on at least one agent the user still has switched on?
+ *
+ *  Disabling an agent means "I don't use this" — its rows have no business
+ *  padding the Extensions list or the audit report either. The rule is
+ *  group-level on purpose: a skill installed on both Claude and a disabled
+ *  Windsurf stays, with every instance intact, so deleting it still cleans up
+ *  the Windsurf copy on disk. Only a group that lives *nowhere* enabled drops
+ *  out. Agentless rows (rare, scanner-synthesised) always pass.
+ *
+ *  Every surface that reports an extension count routes through here — see
+ *  `getCachedFiltered`, the Overview stats and the Audit page — so the three
+ *  numbers can't drift apart again. */
+export function groupHasEnabledAgent(
+  group: GroupedExtension,
+  enabledAgents: ReadonlySet<string>,
+): boolean {
+  return (
+    group.agents.length === 0 || group.agents.some((a) => enabledAgents.has(a))
+  );
 }
 
 /** Scope an Install-to-Agent action targets for a given active scope:
@@ -186,6 +233,21 @@ export function buildGroups(extensions: Extension[]): GroupedExtension[] {
   return groups;
 }
 
+/** `instance id -> the groupKey buildGroups actually assigned it`.
+ *
+ *  For anything that starts from a bare extension ID — audit results, deep
+ *  links — this is the only correct way to reach a row. Recomputing
+ *  `extensionGroupKey(ext)` from the instance skips the sibling merge above,
+ *  so a sourceless copy and its URL-carrying twin resolve to two different
+ *  keys and show up as two rows for one extension. */
+export function groupKeyById(groups: GroupedExtension[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const g of groups) {
+    for (const inst of g.instances) map.set(inst.id, g.groupKey);
+  }
+  return map;
+}
+
 /** Find all child extensions of a CLI group (by cli_parent_id or matching pack).
  *  When one instance of a group matches, all sibling instances are included
  *  so that toggle/delete affects every agent the extension is installed on. */
@@ -266,6 +328,11 @@ export function getCachedFiltered(
    *  buries that — dsh contributes ~130 rows against ~20 from every other
    *  agent combined. Off by default: the baseline stays visible unless asked. */
   hideVendorBaseline = false,
+  /** Agents the user has switched on. Rows that exist only on switched-off
+   *  agents are dropped before any user filter runs — they are not part of
+   *  the list at all, so no "Clear filters" affordance can bring them back.
+   *  Defaults to null (no agent is disabled) for callers that don't care. */
+  enabledAgents: ReadonlySet<string> | null = null,
 ): GroupedExtension[] {
   // Memoize: skip recomputation if inputs haven't changed
   const scopeKeyForCache =
@@ -275,11 +342,15 @@ export function getCachedFiltered(
         ? "global"
         : `project:${scope.path}`;
   const shippedPacks = new Set(Object.values(vendorBaselineByAgent).flat());
-  const key = `${groups.length}|${kindFilter}|${agentFilter}|${packFilter}|${tagFilter}|${searchQuery}|${scopeKeyForCache}|${[...shippedPacks].join(",")}|${hideVendorBaseline}`;
+  const enabledKey = enabledAgents ? [...enabledAgents].sort().join(",") : "*";
+  const key = `${groups.length}|${kindFilter}|${agentFilter}|${packFilter}|${tagFilter}|${searchQuery}|${scopeKeyForCache}|${[...shippedPacks].join(",")}|${hideVendorBaseline}|${enabledKey}`;
   if (key === _cachedFilterKey && groups === _cachedFilterGroupsRef) {
     return _cachedFiltered;
   }
   let result = groups;
+  if (enabledAgents) {
+    result = result.filter((g) => groupHasEnabledAgent(g, enabledAgents));
+  }
   if (kindFilter) {
     result = result.filter((g) => g.kind === kindFilter);
   }
@@ -288,7 +359,7 @@ export function getCachedFiltered(
     // column renders) so the filter can never surface a card whose visible
     // badges don't contain the filtered agent.
     result = result.filter((g) =>
-      agentsInScope(g, scope).includes(agentFilter),
+      agentsInScope(g, scope, enabledAgents).includes(agentFilter),
     );
   }
   // Applied before packFilter so "hide built-ins" and an explicit built-in

--- a/src/stores/extension-store.ts
+++ b/src/stores/extension-store.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/lib/types";
 import { useAgentStore } from "./agent-store";
 import {
+  enabledAgentSet,
   expandGroupKeys,
   findCliChildren,
   getCachedFiltered,
@@ -20,7 +21,12 @@ import {
 import { useScopeStore } from "./scope-store";
 import { toast } from "./toast-store";
 
-export { buildGroups } from "./extension-helpers";
+export {
+  buildGroups,
+  enabledAgentSet,
+  groupHasEnabledAgent,
+  groupKeyById,
+} from "./extension-helpers";
 
 /**
  * Run a pending delete's backend calls, reporting the first failure instead of
@@ -647,9 +653,18 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
       scope,
       vendorBaselineByAgent(),
       get().hideVendorBaseline,
+      enabledAgents(),
     );
   },
 }));
+
+/** Agents the user still has switched on. Read from the agent store on demand
+ *  for the same reason as `vendorBaselineByAgent` below: the Extensions list,
+ *  the Overview stats and the Audit report all need it, and threading it
+ *  through props is how the three drifted apart in the first place. */
+function enabledAgents(): ReadonlySet<string> | null {
+  return enabledAgentSet(useAgentStore.getState().agents);
+}
 
 /** `agent name -> packs that ship with it`, as the backend reports it. Read
  *  from the agent store rather than threaded through props so the source


### PR DESCRIPTION
## Problem

Overview, Extensions and Audit each answered "how many extensions do you have?" differently. On one real install, at the same moment:

| Surface | Number |
|---|---|
| Overview | 191 extensions |
| Extensions (Global scope) | 206 results |
| Audit | scanned 206 / **216 results** |

Two independent causes.

**1. Audit disagreed with itself.** The "scanned" count went through `buildGroups()`; the row list recomputed `extensionGroupKey()` per instance. Those are not the same thing — `buildGroups()` has a pre-pass that folds a sourceless copy into its same-scope, URL-carrying sibling. Skipping it splits those rows in two, so one extension rendered as two audit rows (10 of them on the install above): two `arxiv-search`, three `frontend-design`, and so on.

**2. Overview and Extensions disagreed about what exists.** Overview dropped rows belonging only to switched-off agents; the Extensions list never looked at agent enablement. The Extensions agent dropdown has *always* listed enabled agents only — so those rows could not even be filtered to, yet still padded the total.

## Change

One rule, defined once, used by all three surfaces:

- `enabledAgentSet()` — the agents a count should include, or `null` for "list not fetched yet, don't hide anything".
- `groupHasEnabledAgent()` — does this row live on at least one of them.
- `groupKeyById()` — the canonical `instance id → groupKey` map, for anything that starts from a bare extension ID.

The enablement rule is **group-level** on purpose: a skill installed on both Claude and a disabled Windsurf stays, with every instance intact, so deleting it still cleans up the Windsurf copy on disk. Only a row that lives *nowhere* enabled drops out.

The agent-badge column and the detail panel's AGENTS chips take the same projection, so a disabled agent isn't simultaneously absent (its exclusive rows are gone) and present (its badge on surviving rows). PATHS and the delete dialog deliberately do **not** — they answer "what is on disk", so deleting a row can never quietly remove a file the user was never shown.

Fixed in passing, both the same root cause:
- Overview's "recently installed" deep link recomputed the group key the same wrong way and landed on nothing.
- Audit results whose extension no longer exists were counted under their raw ID in All-scopes mode.

## Effect

Replayed against the same install (753 extension rows):

| Surface | Before | After |
|---|---|---|
| Overview (always All scopes) | 191 | 214 |
| Extensions · All scopes | 214 | **214** |
| Extensions · Global | 206 | 206 |
| Audit · Global | 206 / **216** | 206 / **206** |
| Audit · All scopes | 214 / 224 | **214 / 214** |

- Audit's two header numbers are now one set counted twice, not two.
- Overview and Extensions agree in All scopes — and not by luck: before this change they only matched because no disabled agent happened to hold an exclusive extension.
- In a scoped view the two differ by scope alone, which is the intended design (Overview is deliberately scope-independent).
- Overview moving 191 → 214 is the pre-existing desktop build treating an agent missing from its adapter list as disabled; on this branch it counts normally.

## Testing

`tsc --noEmit` clean, biome clean on touched files, 306 frontend tests pass (10 new, covering the enablement rule, the null "not loaded" case, the badge projection, and the `groupKeyById` regression that split one extension into two rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)