### PR TITLE
release: v1.9.0

### DIFF
--- a/.github/release-notes/v1.9.0.md
+++ b/.github/release-notes/v1.9.0.md
@@ -1,0 +1,18 @@
+## ✨ Highlights
+
+- **New agent: DeepSeek Harness** — HarnessKit now manages [DeepSeek Harness](https://www.deepseek.com/harness/en/) as its 12th agent: skills, MCP servers, and plugins, each with enable/disable, plus its rules and settings files. Writes land inside a marked managed block, so the rest of your `cordis.patch.yml` — comments, anchors, `!!js` expressions — stays byte-for-byte intact. (It's still pre-1.0, so its config format may yet move.)
+- **Windsurf is now Devin Desktop** — following Cognition's rename. HarnessKit models Cascade, the agent formerly known as Windsurf: per-user config stays at `~/.codeium/windsurf/`, project config is now read from `.devin/` (with `.windsurf/` still honored), and `.devinignore` joins `.windsurfignore`. Global rules are also read from `memories/global_rules.md` now, where they actually live.
+
+<!-- lang:zh
+## ✨ 更新亮点
+
+- **新增 Agent：DeepSeek Harness** — HarnessKit 现已支持 [DeepSeek Harness](https://www.deepseek.com/harness/en/)，第 12 个受管 Agent：Skills、MCP servers 和 Plugins 均可启用/停用，其 rules 与 settings 配置文件也一并纳管。所有写入都落在带标记的托管块内，你自己的 `cordis.patch.yml` 内容——注释、锚点、`!!js` 表达式——保持逐字节不变。（它目前仍处于 1.0 之前的版本，配置格式仍可能变动。）
+- **Windsurf 更名为 Devin Desktop** — 跟随 Cognition 的品牌变更。HarnessKit 管理的是 Cascade，也就是原来那个叫 Windsurf 的 Agent：用户级配置仍在 `~/.codeium/windsurf/`，项目级配置改为从 `.devin/` 读取（`.windsurf/` 仍然兼容），并新增了 `.devinignore`。全局 rules 现在也会从其实际所在的 `memories/global_rules.md` 读取。
+-->
+
+<!-- lang:zh-TW
+## ✨ 更新亮點
+
+- **新增代理：DeepSeek Harness** — HarnessKit 現已支援 [DeepSeek Harness](https://www.deepseek.com/harness/en/)，第 12 個受管代理：skill、MCP server 與外掛皆可啟用／停用，其 rules 與設定檔也一併納管。所有寫入都落在標記過的託管區塊內，你自己的 `cordis.patch.yml` 內容——註解、錨點、`!!js` 運算式——維持逐位元組不變。（它目前仍是 1.0 之前的版本，設定格式仍可能變動。）
+- **Windsurf 更名為 Devin Desktop** — 跟隨 Cognition 的品牌變更。HarnessKit 管理的是 Cascade，也就是原本叫 Windsurf 的那個代理：使用者層級的設定仍在 `~/.codeium/windsurf/`，專案層級的設定改從 `.devin/` 讀取（`.windsurf/` 仍然相容），並新增了 `.devinignore`。全域 rules 現在也會從其實際所在的 `memories/global_rules.md` 讀取。
+-->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk-cli"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "hk-core"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "hk-desktop"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "hk-web"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hk-core", "crates/hk-cli", "crates/hk-desktop", "crates/hk-we
 resolver = "2"
 
 [workspace.package]
-version = "1.8.2"
+version = "1.9.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/hk-desktop/tauri.conf.json
+++ b/crates/hk-desktop/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "HarnessKit",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "identifier": "com.harnesskit.app",
   "build": {
     "frontendDist": "../../dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "harnesskit-frontend",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harnesskit-frontend",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harnesskit-frontend",
   "private": true,
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Cross-platform extension management for AI coding agents",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Version bump + hand-written release highlights for v1.9.0.

Minor rather than patch: this release adds a 12th agent (DeepSeek Harness) and renames an existing one (Windsurf → Devin Desktop).

## Contents

| File | Change |
|---|---|
| `.github/release-notes/v1.9.0.md` | new — highlights in English, Simplified and Traditional Chinese |
| `Cargo.toml`, `Cargo.lock` | workspace + the four `hk-*` crates → 1.9.0 |
| `package.json`, `package-lock.json` | 1.9.0 |
| `crates/hk-desktop/tauri.conf.json` | 1.9.0 |

All five version files come from `scripts/bump-version.sh 1.9.0`; no dependency changes rode along.

## Since v1.8.2

- #116 — DeepSeek Harness agent support (skills, MCP scan + native toggle, audit)
- #118 — DeepSeek Harness plugin scanning, enable/disable, and a real MCP writer
- #114 — Windsurf renamed to Devin Desktop, with Cascade-scoped paths
- #119 — one rule for what counts as an installed extension
- #115 — selected row indicator polish

The last three land in the auto-generated *What's Changed* rather than the highlights.

## Traditional Chinese notes

First release whose notes carry a `lang:zh-TW` block. No code change was needed — both the client parser and the `latest.json` variant script already accept hyphenated language codes, and zh-TW readers were silently falling back to Simplified. The wording follows the terminology already established in the zh-TW locale (代理 / 專案 / 設定 / 外掛) rather than a character-level conversion of the Simplified text.

After merge: tag `v1.9.0` on main, which triggers `release.yml` and produces a **draft** release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)