### PR TITLE
fix(a11y): stop claude's mascot bouncing under reduced motion

### DIFF
--- a/src/components/shared/agent-mascot/mascot.css
+++ b/src/components/shared/agent-mascot/mascot.css
@@ -1930,6 +1930,11 @@
 
 /* === Reduced Motion === */
 @media (prefers-reduced-motion: reduce) {
+  /* The bare `.is-animated` selectors below are not redundant with the `*`
+     ones: `*` only matches descendants, so a mascot that animates its own
+     wrapper needs to name itself. claude-jump, omp-float and dsh-breach are
+     the three hover loops that live on the wrapper. */
+  .mascot-claude.is-animated,
   .mascot-claude.is-animated *,
   .mascot-cursor.is-animated *,
   .mascot-codex.is-animated *,


### PR DESCRIPTION
## What

One line in `mascot.css`: name `.mascot-claude.is-animated` in the
`prefers-reduced-motion` exemption list (plus a comment explaining why the bare
selectors there are not redundant).

## Why

The block exempted `.mascot-claude.is-animated *`. `*` matches **descendants
only**, and `claude-jump` is on the wrapper itself:

```css
.mascot-claude.is-animated {
  animation: claude-jump 1.2s ... infinite;   /* ← the wrapper */
}
.mascot-claude.is-animated .arm-right { ... } /* ← covered by `*` */
```

So with "reduce motion" on, hovering Claude's card froze the arms, legs and
eyes while the whole figure kept bouncing — an infinite loop, which is exactly
the category the media query exists to stop. It reads as a stuck animation
rather than a calm one.

## Why this is safe

- `claude-jump`'s `0%`/`100%` is `translateY(0) scale(1)` — the identity
  transform — so stopping it lands on the resting pose. No layout shift.
- The wrapper has no base rule: all fifteen `.mascot-claude*` rules target
  descendants or the two state classes, so the block's `transition: none`
  has nothing to clobber.
- Not a new behaviour — omp, dsh and grok already name their wrappers for the
  same reason. This closes the inconsistency.
- The card's own hover affordance (border, background, shadow, lift) lives on
  the `<button>`, outside this media block, so hovering still gives feedback.

## Is anything else affected?

No. I parsed the stylesheet and pulled every rule whose selector is exactly
`.mascot-<agent>.is-animated` or `.is-clicked` and that sets `animation` —
i.e. every wrapper-level animation across all thirteen mascots:

| agent  | state   | wrapper animation | exempt before |
|--------|---------|-------------------|---------------|
| claude | hover   | `claude-jump`     | **no**        |
| claude | click   | `claude-peek`     | yes           |
| dsh    | hover   | `dsh-breach`      | yes           |
| dsh    | click   | (composite)       | yes           |
| grok   | click   | `grok-toss`       | yes           |
| omp    | hover   | `omp-float`       | yes           |

Six in total, and this was the only gap. Every other mascot animates
descendants only, which the existing `*` selectors already cover. Re-running
the audit after the change reports no unexempted wrapper animations.

## Checks

`npm run lint` clean (183 files) · `npm test` 34 files / 307 tests · `npm run build` clean.
