### PR TITLE
release: v1.10.0

### DIFF
--- a/.github/release-notes/v1.10.0.md
+++ b/.github/release-notes/v1.10.0.md
@@ -1,0 +1,18 @@
+## ✨ Highlights
+
+- **New agent: Grok Build** — HarnessKit now manages [Grok Build](https://github.com/xai-org/grok-build) as its 13th agent: skills, MCP servers over stdio, HTTP and SSE, hooks, and plugins, each with enable/disable, plus its config and rules files. Toggles go through Grok's own native switches, so whatever you turn off here is off for Grok itself. Skills are found recursively, including the shared `~/.agents/skills` tree Grok reads by default.
+- **Deleted skills no longer linger** — a skill you disabled and then deleted outside the app used to stay in the list forever. It now clears on the next scan.
+
+<!-- lang:zh
+## ✨ 更新亮点
+
+- **新增 Agent：Grok Build** — HarnessKit 现已支持 [Grok Build](https://github.com/xai-org/grok-build)，第 13 个受管 Agent：Skills、MCP servers（stdio、HTTP 与 SSE）、Hooks 和 Plugins，均可启用/停用，其配置与规则文件也一并纳管。启停走的是 Grok 自己的原生开关，所以你在这里关掉的东西，对 Grok 而言也是关的。Skills 支持递归查找，包括 Grok 默认会读取的共享目录 `~/.agents/skills`。
+- **删掉的 Skill 不再残留** — 停用后又在应用外删掉的 Skill，过去会永远留在列表里，现在会在下一次扫描时清除。
+-->
+
+<!-- lang:zh-TW
+## ✨ 更新亮點
+
+- **新增代理：Grok Build** — HarnessKit 現已支援 [Grok Build](https://github.com/xai-org/grok-build)，第 13 個受管代理：skill、MCP server（stdio、HTTP 與 SSE）、hook 與外掛，皆可啟用／停用，其設定與規則檔案也一併納管。啟停走的是 Grok 自己的原生開關，所以你在這裡關掉的東西，對 Grok 而言也是關的。skill 支援遞迴尋找，包括 Grok 預設會讀取的共用目錄 `~/.agents/skills`。
+- **刪掉的 skill 不再殘留** — 停用後又在應用程式外刪掉的 skill，過去會永遠留在清單裡，現在會在下一次掃描時清除。
+-->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk-cli"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "hk-core"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "hk-desktop"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "hk-web"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hk-core", "crates/hk-cli", "crates/hk-desktop", "crates/hk-we
 resolver = "2"
 
 [workspace.package]
-version = "1.9.0"
+version = "1.10.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/hk-desktop/tauri.conf.json
+++ b/crates/hk-desktop/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "HarnessKit",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "identifier": "com.harnesskit.app",
   "build": {
     "frontendDist": "../../dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "harnesskit-frontend",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harnesskit-frontend",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harnesskit-frontend",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Cross-platform extension management for AI coding agents",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bump the workspace, frontend, and Tauri versions to 1.10.0 and add the
hand-written release highlights.

Minor rather than patch: this release adds a 13th agent (Grok Build, #125).

## Highlights in this release

- **New agent: Grok Build** — skills, MCP servers over stdio/HTTP/SSE, hooks,
  plugins, and its config and rules files, with enable/disable going through
  Grok's own native switches.
- **Deleted skills no longer linger** (#128) — a skill you disabled and then
  deleted outside the app used to stay in the list forever.

Notes carry Simplified and Traditional Chinese as `lang:` comment blocks;
`scripts/notes-desktop-variant.mjs` parses the file into the fenced form
`latest.json` expects.

## Changed

Version only — no dependency updates. `Cargo.lock` moves 4 lines and
`package-lock.json` 2, all of them this repo's own crates and package.

| File | Change |
|---|---|
| `Cargo.toml` | 1.9.0 → 1.10.0 |
| `package.json` | 1.9.0 → 1.10.0 |
| `crates/hk-desktop/tauri.conf.json` | 1.9.0 → 1.10.0 |
| `Cargo.lock`, `package-lock.json` | version lines only |
| `.github/release-notes/v1.10.0.md` | new |
