### PR TITLE
refactor(web): drop redundant scan_all+sync from install_to_agent

### DIFF
--- a/crates/hk-web/src/handlers/install.rs
+++ b/crates/hk-web/src/handlers/install.rs
@@ -260,7 +260,7 @@ pub async fn install_to_agent(
         // Capture (name, kind) up front so the return value is bit-perfect
         // parity with the pre-extraction code: the original bound `ext`
         // BEFORE the deploy and reused it for the stable_id, so we do the
-        // same. A re-fetch after sync would change error behavior in the
+        // same. A re-fetch after the deploy would change error behavior in the
         // (vanishingly rare) case where the source extension disappears
         // mid-deploy.
         let (ext_name, ext_kind) = {
@@ -282,15 +282,6 @@ pub async fn install_to_agent(
             params.hermes_category.as_deref(),
             &params.target_scope,
         )?;
-
-        // Web-only: re-scan + sync after a successful deploy so the new
-        // extension shows up in the next list_extensions response without
-        // the user having to manually refresh. Desktop relies on a separate
-        // scan_and_sync round-trip from the frontend.
-        let store = state.store.lock();
-        let projects = store.list_project_tuples();
-        let scanned = scanner::scan_all(&state.adapters, &projects);
-        store.sync_extensions(&scanned)?;
 
         // Scope-correct ID for the deployed row. Known pre-existing caveat:
         // for hooks the service deploys under a *translated* event name


### PR DESCRIPTION
## What

Removes the "Web-only" re-scan + sync block at the end of the web `install_to_agent` handler (net −9 lines), plus a one-word fix to an adjacent comment whose "after sync" anchor referred to the deleted block.

## Why it is safe

- The frontend store action follows **every** `installToAgent` call with `rescanAndFetch()` on **both** transports; its backend `scan_and_sync` is a strict superset of the deleted block.
- Desktop has shipped without this block since the command existed — the same frontend code has been running the "post-deletion" behavior in production all along.
- The recomputed stable id returned by the handler has no consumers (the store action's type is `Promise<void>`; all UI call sites discard it).
- The two existing `install_to_agent` API tests exercise failure paths that never reach the deleted code; `cargo test --workspace` is green.

## Verified

- API sequence smoke: `install_to_agent` → (no rescan: target row absent, as expected) → `scan_and_sync` → target row present with the exact id the handler returned.
- Browser smoke: cross-agent install from the Extensions detail panel; the target agent appears in the list without a manual refresh.

## Side benefit

Cross-agent installs of CLI child extensions no longer run a full `scan_all` per child **while holding the store mutex**.

## Not in this PR

Desktop/web return-value divergence (`deployed_name` vs stable id — both discarded by the frontend) is a separate cleanup; unifying on `deployed_name` would also retire the handler's known hook-id caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)