### PR TITLE
feat(kiro): unblock global hook install (shipped upstream in IDE 1.0.182 / CLI 2.13.0)

### DIFF
--- a/crates/hk-core/src/adapter/kiro.rs
+++ b/crates/hk-core/src/adapter/kiro.rs
@@ -106,16 +106,6 @@ impl AgentAdapter for KiroAdapter {
         true
     }
 
-    /// Kiro's docs describe `~/.kiro/hooks/` (user-level), but no released
-    /// version loads it — verified on-device with 1.0.89 (macOS): the IDE
-    /// only counts `.kiro/hooks/` workspace hooks. Upstream:
-    /// kirodotdev/Kiro#5440 (open feature request, Feb 2026) and
-    /// kirodotdev/Kiro#9857 (open bug, "not loaded in 1.0.52"). Flip this
-    /// back to `true` once upstream ships user-level loading.
-    fn supports_global_hook_install(&self) -> bool {
-        false
-    }
-
     fn hook_config_paths_for(&self, scope: &ConfigScope) -> Vec<PathBuf> {
         match scope {
             ConfigScope::Global => Self::json_files(&self.base_dir().join("hooks")),

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -940,23 +940,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_supports_global_hook_install_false_only_for_kiro() {
-        // Kiro's docs claim `~/.kiro/hooks/` (user-level) but no released
-        // version loads it (kirodotdev/Kiro#5440, #9857; verified on 1.0.89).
-        // Everyone else keeps the default: global hook deploy allowed.
-        let adapters = all_adapters();
-        for a in &adapters {
-            let expected = a.name() != "kiro";
-            assert_eq!(
-                a.supports_global_hook_install(),
-                expected,
-                "{} supports_global_hook_install should be {expected}",
-                a.name()
-            );
-        }
-    }
-
     /// The full per-agent capability matrix, every value verified against
     /// official docs 2026-07 (see docs/superpowers/specs/
     /// 2026-07-11-cross-agent-project-install-plan.md for citations).
@@ -977,8 +960,8 @@ mod tests {
             ("copilot", true, true, false, true, true),  // project hooks deferred
             ("antigravity", true, false, false, false, true), // no MCP/project, no hooks
             ("opencode", true, true, false, false, true), // hooks are JS plugins
-            ("kiro", true, true, true, true, false),     // kirodotdev/Kiro#5440
-            ("omp", true, true, false, false, true),     // hooks are JS/TS modules
+            ("kiro", true, true, true, true, true), // global hooks shipped in Kiro IDE 1.0.182 / CLI 2.13.0
+            ("omp", true, true, false, false, true), // hooks are JS/TS modules
             ("hermes", false, false, false, true, true), // global-only (hermes-agent#4667)
             ("dsh", true, false, false, false, true), // MCP is cordis-layer only; no own hook format
             ("grok", true, true, true, true, true),

--- a/crates/hk-core/src/models.rs
+++ b/crates/hk-core/src/models.rs
@@ -363,8 +363,9 @@ pub struct AgentCapabilities {
     /// Whether the agent has a declarative hook system at all
     /// (`hook_format() != HookFormat::None`).
     pub hooks_supported: bool,
-    /// Whether user-level (global) hook install works upstream
-    /// (false only for Kiro today, kirodotdev/Kiro#5440).
+    /// False when the agent cannot load user-level (global) hooks.
+    /// No shipped adapter sets this to false today; the capability matrix
+    /// test pins per-agent values.
     pub global_hook_install: bool,
     /// Which remote MCP transports the agent's config can express
     /// (derived from `AgentAdapter::remote_mcp_schema`). Gates installing

--- a/crates/hk-core/src/service.rs
+++ b/crates/hk-core/src/service.rs
@@ -1552,9 +1552,9 @@ pub fn install_to_agent(
             entry.event = translated_event;
 
             // Global installs bail out for agents that don't load user-level
-            // hooks (e.g. Kiro, kirodotdev/Kiro#5440) instead of writing a
-            // config that would silently never fire. Project-scope installs
-            // are exactly the supported alternative for those agents.
+            // hooks instead of writing a config that would silently never
+            // fire. Project-scope installs are the supported alternative for
+            // those agents.
             if matches!(target_scope, ConfigScope::Global)
                 && !target_adapter.supports_global_hook_install()
             {
@@ -3391,7 +3391,7 @@ mod tests {
     }
 
     #[test]
-    fn test_install_to_agent_kiro_hook_project_ok_global_rejected() {
+    fn test_install_to_agent_kiro_hook_project_and_global_ok() {
         use crate::adapter;
 
         let dir = TempDir::new().unwrap();
@@ -3425,8 +3425,8 @@ mod tests {
             Box::new(adapter::kiro::KiroAdapter::with_home(home.to_path_buf())),
         ];
 
-        // Global install to Kiro stays rejected (kirodotdev/Kiro#5440).
-        let err = install_to_agent(
+        // Global install lands in ~/.kiro/hooks/ (Kiro IDE 1.0.182 / CLI 2.13.0).
+        install_to_agent(
             &store,
             &adapters,
             &source_id,
@@ -3434,13 +3434,16 @@ mod tests {
             None,
             &ConfigScope::Global,
         )
-        .unwrap_err();
+        .unwrap();
+        let global_hook_file = home.join(".kiro").join("hooks").join("harnesskit.json");
+        let global_written = std::fs::read_to_string(&global_hook_file).unwrap();
         assert!(
-            matches!(&err, HkError::Validation(msg) if msg.contains("per-project")),
-            "kiro global hook install must stay blocked, got: {err:?}"
+            global_written.contains("\"v1\""),
+            "Kiro global hook file needs version v1"
         );
+        assert!(global_written.contains("echo hi"));
 
-        // Project install is exactly the supported alternative.
+        // Project install keeps working alongside it.
         install_to_agent(&store, &adapters, &source_id, "kiro", None, &scope).unwrap();
         let hook_file = project_dir
             .join(".kiro")
@@ -3452,6 +3455,95 @@ mod tests {
             "Kiro hook file needs version v1"
         );
         assert!(written.contains("echo hi"));
+    }
+
+    /// No shipped adapter reports `supports_global_hook_install() == false`,
+    /// so the guard in `install_to_agent` would otherwise be untested. This
+    /// stub keeps it covered for whichever agent needs it next.
+    struct NoGlobalHooksAdapter {
+        home: std::path::PathBuf,
+    }
+
+    impl crate::adapter::AgentAdapter for NoGlobalHooksAdapter {
+        fn name(&self) -> &str {
+            "noglobalhooks"
+        }
+        fn base_dir(&self) -> std::path::PathBuf {
+            self.home.join(".noglobalhooks")
+        }
+        fn detect(&self) -> bool {
+            true
+        }
+        fn skill_dirs(&self) -> Vec<std::path::PathBuf> {
+            vec![]
+        }
+        fn mcp_config_path(&self) -> std::path::PathBuf {
+            self.base_dir().join("mcp.json")
+        }
+        fn hook_config_path(&self) -> std::path::PathBuf {
+            self.base_dir().join("hooks.json")
+        }
+        fn plugin_dirs(&self) -> Vec<std::path::PathBuf> {
+            vec![]
+        }
+        fn read_mcp_servers(&self) -> Vec<crate::adapter::McpServerEntry> {
+            vec![]
+        }
+        fn read_hooks(&self) -> Vec<crate::adapter::HookEntry> {
+            vec![]
+        }
+        fn supports_global_hook_install(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn test_install_to_agent_global_hook_rejected_when_unsupported() {
+        use crate::adapter;
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let store = Mutex::new(Store::open(&home.join("test.db")).unwrap());
+
+        // Source: a Claude global hook in ~/.claude/settings.json.
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        std::fs::write(
+            home.join(".claude").join("settings.json"),
+            r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hi"}]}]}}"#,
+        )
+        .unwrap();
+        let hook_name = "PreToolUse:Bash:echo hi";
+        let source_id =
+            scanner::stable_id_with_scope_for(hook_name, "hook", "claude", &ConfigScope::Global);
+        let mut ext = make_skill(ConfigScope::Global, None);
+        ext.id = source_id.clone();
+        ext.kind = ExtensionKind::Hook;
+        ext.name = hook_name.into();
+        ext.source_path = None;
+        store.lock().insert_extension(&ext).unwrap();
+
+        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![
+            Box::new(adapter::claude::ClaudeAdapter::with_home(
+                home.to_path_buf(),
+            )),
+            Box::new(NoGlobalHooksAdapter {
+                home: home.to_path_buf(),
+            }),
+        ];
+
+        let err = install_to_agent(
+            &store,
+            &adapters,
+            &source_id,
+            "noglobalhooks",
+            None,
+            &ConfigScope::Global,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(&err, HkError::Validation(msg) if msg.contains("per-project")),
+            "global hook install must be blocked for agents without user-level hooks, got: {err:?}"
+        );
     }
 
     #[test]

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -654,10 +654,11 @@ export function ExtensionDetail() {
                     const hookUnsupported =
                       group.kind === "hook" &&
                       !agent.capabilities.hooks_supported;
-                    // Kiro loads workspace hooks but no released version
-                    // loads user-level ~/.kiro/hooks/ (kirodotdev/Kiro#5440),
-                    // so global-targeted hook installs stay blocked while
-                    // project-scope installs go through.
+                    // Blocks global-targeted hook installs for agents that
+                    // load workspace hooks only; project-scope installs still
+                    // go through. Currently every adapter reports true, so
+                    // this branch is dormant — kept because the capability
+                    // flag is the designed off-switch for future agents.
                     const globalHookBlocked =
                       group.kind === "hook" &&
                       effectiveTarget?.type === "global" &&

--- a/src/lib/i18n/locales/en/extensions.json
+++ b/src/lib/i18n/locales/en/extensions.json
@@ -90,7 +90,7 @@
     "agents": "Agents",
     "installToAgent": "Install to Agent",
     "hooksNotSupported": "Hooks not supported",
-    "kiroGlobalHooksPending": "Kiro does not load user-level (global) hooks yet (upstream kirodotdev/Kiro#5440) - install this hook per-project instead",
+    "kiroGlobalHooksPending": "This agent doesn't load user-level (global) hooks — install this hook per-project instead",
     "projectScopeUnsupported": "{{agent}} doesn't support project-level {{kind}} installs yet",
     "remoteTransportUnsupported": "{{agent}} doesn't support {{transport}} remote MCP servers",
     "cliChildrenSkipped": "Skipped {{count}} bundled item(s) this agent can't install at project scope",

--- a/src/lib/i18n/locales/zh-TW/extensions.json
+++ b/src/lib/i18n/locales/zh-TW/extensions.json
@@ -90,7 +90,7 @@
     "agents": "代理",
     "installToAgent": "安裝到代理",
     "hooksNotSupported": "不支援 hook",
-    "kiroGlobalHooksPending": "Kiro 尚未載入使用者層（全域）hook（上游 kirodotdev/Kiro#5440），請改用專案層安裝",
+    "kiroGlobalHooksPending": "該代理不載入使用者層級（全域）hook——請將此 hook 安裝到專案層",
     "projectScopeUnsupported": "{{agent}} 尚不支援專案層 {{kind}} 安裝",
     "remoteTransportUnsupported": "{{agent}} 不支援 {{transport}} 遠端 MCP server",
     "cliChildrenSkipped": "已跳過 {{count}} 個該代理無法在專案層安裝的隨附項目",

--- a/src/lib/i18n/locales/zh/extensions.json
+++ b/src/lib/i18n/locales/zh/extensions.json
@@ -90,7 +90,7 @@
     "agents": "智能体",
     "installToAgent": "安装到智能体",
     "hooksNotSupported": "不支持 hook",
-    "kiroGlobalHooksPending": "Kiro 尚未加载用户级（全局）hook（上游 kirodotdev/Kiro#5440），请改用项目级安装",
+    "kiroGlobalHooksPending": "该智能体不加载用户级（全局）hook——请将此 hook 安装到项目级",
     "projectScopeUnsupported": "{{agent}} 尚不支持项目级 {{kind}} 安装",
     "remoteTransportUnsupported": "{{agent}} 不支持 {{transport}} 远程 MCP 服务器",
     "cliChildrenSkipped": "已跳过 {{count}} 个该智能体无法在项目级安装的捆绑项",


### PR DESCRIPTION
## What

Kiro now loads `~/.kiro/hooks/` in every workspace (kirodotdev/Kiro#5440, closed completed 2026-07-22; shipped in IDE 1.0.182 and CLI 2.13.0). This removes the `supports_global_hook_install()` override so Kiro inherits the trait default like every other adapter. Scanner and deploy paths were already scope-agnostic — only the install guard was blocking.

- The capability guard in `install_to_agent` **stays**: it is the designed off-switch for future agents, now pinned by a dedicated stub-adapter test (`NoGlobalHooksAdapter`) since no shipped adapter returns `false` anymore.
- The redundant `test_supports_global_hook_install_false_only_for_kiro` is deleted; the capability matrix test already pins the per-agent value.
- Locale copy for the (now dormant) UI branch is reworded to be agent-neutral; the `kiroGlobalHooksPending` key name is frozen to avoid three-locale churn (follow-up: rename when a real agent needs the branch again).

## Verified on device (Kiro IDE 1.0.437)

Installed a global Stop→command hook through this branch; Kiro loaded it with no schema warning (`v2 hooks loaded 1 standalone hooks`) and executed it after a prompt in a workspace that has **no** `.kiro` directory at all (visible "Run Command Hook" card + the command's side effect observed).

One operational note worth knowing: hook **execution** is gated on workspace trust, and the trust decision is captured at session start — trusting a folder after opening it requires a window reload before hooks run.

## User-facing requirements (release-notes material)

- Kiro IDE ≥ 1.0.182; CLI support is in the 3.0 early-access mode (`kiro-cli --v3`).
- Kiro merges hooks across scopes (no override): the same hook installed at both global and project level fires twice.
- Kiro's own IDE UI currently has no entry point for creating user-level hooks (kirodotdev/Kiro#10915) — HarnessKit writes the file directly, so it is unaffected.

## Discovered during testing (separate follow-up, not in this PR)

Removing the last hook from a Kiro hooks file leaves `{"hooks": [], "version": "v1"}` behind, which Kiro warns about on every load ("hooks[] must have at least one entry"). Reproduced twice; the deployer should delete the file when the last entry is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)