### PR TITLE
fix(mcp): lossless secret snapshots on disable/enable, with visible warnings for legacy redacted ones

### DIFF
--- a/crates/hk-core/src/adapter/hermes.rs
+++ b/crates/hk-core/src/adapter/hermes.rs
@@ -271,7 +271,7 @@ impl AgentAdapter for HermesAdapter {
     fn supports_native_mcp_toggle(&self) -> bool {
         // Hermes MCP servers carry a native `enabled: bool` (default true);
         // disabling = set `enabled: false` in place (config retained), exactly
-        // like the `hermes mcp` CLI. No remove, no secret redaction.
+        // like the `hermes mcp` CLI. No remove, no DB snapshot.
         // Docs: https://hermes-agent.nousresearch.com/docs/reference/mcp-config-reference
         true
     }

--- a/crates/hk-core/src/adapter/mod.rs
+++ b/crates/hk-core/src/adapter/mod.rs
@@ -126,8 +126,9 @@ pub struct McpServerEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     /// HTTP headers sent to remote servers (typically `Authorization`).
-    /// Secret-bearing: must be redacted alongside `env` wherever entries
-    /// are snapshotted to the DB (see `manager::redact_mcp_env`).
+    /// Secret-bearing: like `env`, treat it as sensitive wherever entries are
+    /// snapshotted to the DB or rendered for display (see
+    /// `manager::MCP_SECRET_BLOCK_KEYS`).
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub headers: std::collections::HashMap<String, String>,
     #[serde(skip, default = "default_enabled")]
@@ -517,7 +518,7 @@ pub trait AgentAdapter: Send + Sync {
 
     /// Whether this agent's MCP config format carries a native per-server
     /// `enabled: bool` that HarnessKit should toggle IN PLACE, instead of the
-    /// default disable (remove the entry + snapshot it in the DB + redact env).
+    /// default disable (remove the entry from the config + snapshot it in the DB).
     ///
     /// Agents returning `true` are dispatched to a dedicated in-place writer in
     /// `manager::toggle_mcp`; their disabled state lives in the agent's own

--- a/crates/hk-core/src/deployer.rs
+++ b/crates/hk-core/src/deployer.rs
@@ -646,7 +646,7 @@ pub fn set_hermes_plugin_enabled(
 /// leaving the rest of the entry (command/args/env/tools/…) untouched. This is
 /// the in-place "disable" Hermes itself uses: the config stays put and only
 /// `enabled` toggles — unlike HarnessKit's generic MCP disable, it never removes
-/// the entry, snapshots it, or redacts secrets.
+/// the entry from the config or snapshots it in the DB.
 ///
 /// Hermes supports a per-server `enabled: bool` (default `true`). A server with
 /// `enabled: false` is skipped entirely — no connection, discovery, or tool

--- a/crates/hk-core/src/manager.rs
+++ b/crates/hk-core/src/manager.rs
@@ -12,6 +12,11 @@ use std::process::Command;
 /// secret-handling code (redaction, restore warnings) stays format-agnostic.
 const MCP_SECRET_BLOCK_KEYS: [&str; 4] = ["env", "environment", "headers", "http_headers"];
 
+/// Literal written in place of secret values when an MCP entry is
+/// snapshotted on disable. Shared so redaction, restore-warning collection,
+/// and content rendering never drift apart.
+pub const REDACTED_PLACEHOLDER: &str = "<redacted>";
+
 #[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct InstallResult {
     pub name: String,
@@ -21,6 +26,16 @@ pub struct InstallResult {
     /// and the update was silently skipped.
     #[serde(default)]
     pub skipped: bool,
+}
+
+/// Result of a toggle operation. Mirrors the InstallResult pattern:
+/// the operation succeeded, but the caller may need to surface a warning.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct ToggleOutcome {
+    /// Env/header keys still holding the literal `<redacted>` placeholder
+    /// after re-enable. Non-empty means the server was restored but will
+    /// fail to start until the user sets real values in the agent config.
+    pub redacted_secret_keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -40,7 +55,7 @@ impl Manager {
         Self { store }
     }
 
-    pub fn toggle(&self, id: &str, enabled: bool) -> Result<(), HkError> {
+    pub fn toggle(&self, id: &str, enabled: bool) -> Result<ToggleOutcome, HkError> {
         toggle_extension(&self.store, id, enabled)
     }
 
@@ -66,7 +81,7 @@ impl Manager {
 /// Toggle an extension's enabled state. Handles all 5 kinds:
 /// Skill (file rename), MCP (config read/write), Hook (config read/write),
 /// Plugin (Claude config-driven or non-Claude manifest rename), CLI (cascade to children).
-pub fn toggle_extension(store: &Store, id: &str, enabled: bool) -> Result<(), HkError> {
+pub fn toggle_extension(store: &Store, id: &str, enabled: bool) -> Result<ToggleOutcome, HkError> {
     let adapters = adapter::all_adapters();
     toggle_extension_with_adapters(store, &adapters, id, enabled)
 }
@@ -77,17 +92,19 @@ pub fn toggle_extension_with_adapters(
     adapters: &[Box<dyn adapter::AgentAdapter>],
     id: &str,
     enabled: bool,
-) -> Result<(), HkError> {
+) -> Result<ToggleOutcome, HkError> {
     let ext = store
         .get_extension(id)?
         .ok_or_else(|| HkError::NotFound(format!("Extension not found: {}", id)))?;
 
     // Already in the target state — nothing to do.
     if ext.enabled == enabled {
-        return Ok(());
+        return Ok(ToggleOutcome::default());
     }
 
     let projects = store.list_project_tuples();
+
+    let mut outcome = ToggleOutcome::default();
 
     match ext.kind {
         ExtensionKind::Skill => {
@@ -108,7 +125,7 @@ pub fn toggle_extension_with_adapters(
             }
         }
         ExtensionKind::Mcp => {
-            toggle_mcp(&ext, enabled, store, adapters)?;
+            outcome = toggle_mcp(&ext, enabled, store, adapters)?;
             store.set_enabled(id, enabled)?;
         }
         ExtensionKind::Hook => {
@@ -125,7 +142,7 @@ pub fn toggle_extension_with_adapters(
             store.set_enabled(id, enabled)?;
         }
     }
-    Ok(())
+    Ok(outcome)
 }
 
 fn toggle_skill(
@@ -171,7 +188,8 @@ fn toggle_mcp(
     enabled: bool,
     store: &Store,
     adapters: &[Box<dyn adapter::AgentAdapter>],
-) -> Result<(), HkError> {
+) -> Result<ToggleOutcome, HkError> {
+    let mut redacted_secret_keys: Vec<String> = Vec::new();
     for a in adapters {
         if !ext.agents.contains(&a.name().to_string()) {
             continue;
@@ -258,7 +276,7 @@ fn toggle_mcp(
                     .get("env")
                     .and_then(|env| env.get("PATH"))
                     .and_then(|p| p.as_str())
-                    == Some("<redacted>");
+                    == Some(REDACTED_PLACEHOLDER);
             if needs_path_repair {
                 let cmd = entry
                     .get("command")
@@ -281,7 +299,9 @@ fn toggle_mcp(
                 .filter_map(|block| entry.get(block).and_then(|v| v.as_object()))
                 .flat_map(|obj| {
                     obj.iter()
-                        .filter(|(k, v)| k.as_str() != "PATH" && v.as_str() == Some("<redacted>"))
+                        .filter(|(k, v)| {
+                            k.as_str() != "PATH" && v.as_str() == Some(REDACTED_PLACEHOLDER)
+                        })
                         .map(|(k, _)| k.clone())
                 })
                 .collect();
@@ -292,6 +312,11 @@ fn toggle_mcp(
                     ext.name,
                     redacted_keys.join(", ")
                 );
+            }
+            for k in &redacted_keys {
+                if !redacted_secret_keys.contains(k) {
+                    redacted_secret_keys.push(k.clone());
+                }
             }
             deployer::restore_mcp_server(&config_path, &ext.name, &entry, format)?;
             store.set_disabled_config(&ext.id, None)?;
@@ -307,7 +332,9 @@ fn toggle_mcp(
             deployer::remove_mcp_server(&config_path, &ext.name, format)?;
         }
     }
-    Ok(())
+    Ok(ToggleOutcome {
+        redacted_secret_keys,
+    })
 }
 
 /// Redact secret-bearing values in an MCP server config entry. Replaces all
@@ -333,7 +360,7 @@ fn redact_mcp_env(entry: &serde_json::Value) -> serde_json::Value {
                 if key == "PATH" {
                     continue;
                 }
-                *value = serde_json::Value::String("<redacted>".into());
+                *value = serde_json::Value::String(REDACTED_PLACEHOLDER.into());
             }
         }
     }
@@ -2452,7 +2479,8 @@ mod tests {
 
         // ENABLE — url restored intact, header value stays redacted (the
         // user is warned to re-set it; the secret itself is gone by design).
-        toggle_extension_with_adapters(&store, &adapters, &ext.id, true).unwrap();
+        let out = toggle_extension_with_adapters(&store, &adapters, &ext.id, true).unwrap();
+        assert_eq!(out.redacted_secret_keys, vec!["Authorization".to_string()]);
         let doc: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(home.join(".claude.json")).unwrap())
                 .unwrap();

--- a/crates/hk-core/src/manager.rs
+++ b/crates/hk-core/src/manager.rs
@@ -9,12 +9,21 @@ use std::process::Command;
 /// string map. Most agents use `"env"`; OpenCode's schema names the same
 /// block `"environment"`. Remote entries carry auth in `"headers"` (JSON/
 /// YAML agents) or `"http_headers"` (Codex TOML). Centralized so
-/// secret-handling code (redaction, restore warnings) stays format-agnostic.
+/// secret-handling code (restore warnings) stays format-agnostic.
 const MCP_SECRET_BLOCK_KEYS: [&str; 4] = ["env", "environment", "headers", "http_headers"];
 
-/// Literal written in place of secret values when an MCP entry is
-/// snapshotted on disable. Shared so redaction, restore-warning collection,
-/// and content rendering never drift apart.
+/// Legacy placeholder. Versions up to v1.10.0 overwrote secret values with this
+/// literal before snapshotting a disabled MCP entry, which made re-enable lossy:
+/// the server came back but could not authenticate. Disable now snapshots the
+/// entry verbatim, so nothing new ever carries this string — it is kept only to
+/// recognize snapshots written by those older versions, so re-enabling one still
+/// warns the user (`ToggleOutcome::redacted_secret_keys`) and renders as
+/// `<redacted>` rather than `****` in the detail panel.
+///
+/// This constant and the warning path it feeds may be removed only when
+/// pre-v1.10.0 snapshots can no longer exist — in practice, when a schema
+/// migration rewrites or drops `disabled_config`. A version bump alone is not
+/// enough: a disabled server can sit untouched in the store indefinitely.
 pub const REDACTED_PLACEHOLDER: &str = "<redacted>";
 
 #[derive(Debug, Clone, Default, serde::Serialize)]
@@ -33,8 +42,10 @@ pub struct InstallResult {
 #[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ToggleOutcome {
     /// Env/header keys still holding the literal `<redacted>` placeholder
-    /// after re-enable. Non-empty means the server was restored but will
-    /// fail to start until the user sets real values in the agent config.
+    /// after re-enable. Non-empty means the snapshot was written by a version
+    /// that redacted secrets on disable, so the server was restored but will
+    /// fail to authenticate until the user sets real values in the agent
+    /// config. Always empty for snapshots taken by this version.
     pub redacted_secret_keys: Vec<String>,
 }
 
@@ -263,7 +274,7 @@ fn toggle_mcp(
                 HkError::NotFound(format!("No saved config for MCP server '{}'", ext.name))
             })?;
             let mut entry: serde_json::Value = serde_json::from_str(&saved)?;
-            // Self-heal: an earlier version of redact_mcp_env redacted PATH along
+            // Self-heal a legacy snapshot: an early version redacted PATH along
             // with secrets. For agents where HarnessKit injects PATH (see
             // AgentAdapter::needs_path_injection), recompute and overwrite PATH so
             // the restored config is actually usable.
@@ -290,8 +301,10 @@ fn toggle_mcp(
                     env_obj.insert("PATH".into(), serde_json::Value::String(path_val));
                 }
             }
-            // Warn about redacted env/header values — server will be restored
-            // but the user needs to manually set the real values in the config.
+            // Legacy path: a snapshot taken before disable became lossless still
+            // holds `<redacted>` where its secrets were. Restore it as-is but
+            // report the affected keys so the user knows to re-enter them.
+            // Snapshots taken by this version never match, so this stays empty.
             // PATH is excluded: it is auto-injected, not a secret, and is
             // self-healed above for antigravity.
             let redacted_keys: Vec<String> = MCP_SECRET_BLOCK_KEYS
@@ -325,46 +338,19 @@ fn toggle_mcp(
                 .ok_or_else(|| {
                     HkError::NotFound(format!("MCP server '{}' not found in config", ext.name))
                 })?;
-            // Redact env values before persisting to the DB so secrets are not
-            // stored in plain text in the SQLite database.
-            let redacted = redact_mcp_env(&entry);
-            store.set_disabled_config(&ext.id, Some(&redacted.to_string()))?;
+            // Snapshot the entry verbatim, secrets included, so re-enable gives
+            // back a server that actually runs. The snapshot lives only in the
+            // store's `disabled_config` column — it is not part of the Extension
+            // model and never crosses an API boundary — and the DB is written
+            // with `PRAGMA secure_delete` and restricted to the owner (0o600 on
+            // Unix; on Windows it inherits the default ACLs of its directory).
+            store.set_disabled_config(&ext.id, Some(&entry.to_string()))?;
             deployer::remove_mcp_server(&config_path, &ext.name, format)?;
         }
     }
     Ok(ToggleOutcome {
         redacted_secret_keys,
     })
-}
-
-/// Redact secret-bearing values in an MCP server config entry. Replaces all
-/// values inside env and header blocks with "<redacted>" while preserving
-/// keys. This prevents secrets (API keys, bearer tokens, etc.) from being
-/// stored in the harnesskit SQLite database when an MCP server is disabled.
-///
-/// The block names in `MCP_SECRET_BLOCK_KEYS` cover every format's spelling
-/// (`env`/`environment` for stdio, `headers`/`http_headers` for remote); at
-/// most one env and one header block is present per entry, so iterating all
-/// keeps this helper format-agnostic without needing to thread `McpFormat`
-/// through every caller.
-///
-/// `PATH` is excluded — HarnessKit auto-injects it for agents whose
-/// `needs_path_injection()` returns true (see install.rs). It is an operational
-/// variable, not a secret, and must round-trip on disable→enable so the server
-/// can find its binary again.
-fn redact_mcp_env(entry: &serde_json::Value) -> serde_json::Value {
-    let mut redacted = entry.clone();
-    for block_key in MCP_SECRET_BLOCK_KEYS {
-        if let Some(obj) = redacted.get_mut(block_key).and_then(|v| v.as_object_mut()) {
-            for (key, value) in obj.iter_mut() {
-                if key == "PATH" {
-                    continue;
-                }
-                *value = serde_json::Value::String(REDACTED_PLACEHOLDER.into());
-            }
-        }
-    }
-    redacted
 }
 
 fn toggle_hook(
@@ -2052,110 +2038,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_redact_mcp_env() {
-        let entry = serde_json::json!({
-            "command": "npx",
-            "args": ["-y", "@example/server"],
-            "env": {
-                "API_KEY": "sk-secret-123",
-                "GITHUB_TOKEN": "ghp_abcdef"
-            }
-        });
-        let redacted = super::redact_mcp_env(&entry);
-        assert_eq!(redacted["command"], "npx");
-        assert_eq!(redacted["args"][0], "-y");
-        assert_eq!(redacted["env"]["API_KEY"], "<redacted>");
-        assert_eq!(redacted["env"]["GITHUB_TOKEN"], "<redacted>");
-    }
-
-    #[test]
-    fn test_redact_mcp_env_no_env() {
-        let entry = serde_json::json!({
-            "command": "npx",
-            "args": ["-y", "@example/server"]
-        });
-        let redacted = super::redact_mcp_env(&entry);
-        assert_eq!(redacted, entry); // No change when no env
-    }
-
-    #[test]
-    fn test_redact_mcp_env_empty_env() {
-        let entry = serde_json::json!({
-            "command": "npx",
-            "env": {}
-        });
-        let redacted = super::redact_mcp_env(&entry);
-        assert_eq!(redacted["env"], serde_json::json!({}));
-    }
-
-    #[test]
-    fn test_redact_mcp_env_preserves_path() {
-        // PATH is auto-injected (e.g. for antigravity) and is not a secret —
-        // it must round-trip on disable→enable while other env values are redacted.
-        let entry = serde_json::json!({
-            "command": "/opt/homebrew/bin/npx",
-            "args": ["-y", "@modelcontextprotocol/server-memory"],
-            "env": {
-                "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
-                "API_KEY": "sk-secret-123"
-            }
-        });
-        let redacted = super::redact_mcp_env(&entry);
-        assert_eq!(
-            redacted["env"]["PATH"], "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
-            "PATH must be preserved verbatim, not redacted"
-        );
-        assert_eq!(redacted["env"]["API_KEY"], "<redacted>");
-    }
-
-    #[test]
-    fn test_redact_mcp_env_handles_opencode_environment_key() {
-        // OpenCode's MCP schema names the env block "environment" (not "env").
-        // Without this support, secrets in OpenCode entries would be stored in
-        // plaintext in the SQLite DB on disable, and the restore-time warning
-        // about manually re-setting redacted values would never fire.
-        let entry = serde_json::json!({
-            "type": "local",
-            "command": ["npx", "-y", "@modelcontextprotocol/server-github"],
-            "environment": {
-                "PATH": "/opt/homebrew/bin:/usr/local/bin",
-                "GITHUB_TOKEN": "ghp_realsecret"
-            }
-        });
-        let redacted = super::redact_mcp_env(&entry);
-        assert_eq!(
-            redacted["environment"]["PATH"], "/opt/homebrew/bin:/usr/local/bin",
-            "PATH must round-trip through redaction even under OpenCode's 'environment' key"
-        );
-        assert_eq!(redacted["environment"]["GITHUB_TOKEN"], "<redacted>");
-        // Schema-defining fields (type, command) untouched.
-        assert_eq!(redacted["type"], "local");
-        assert_eq!(redacted["command"][0], "npx");
-    }
-
-    #[test]
-    fn test_redact_mcp_env_covers_remote_header_blocks() {
-        // Remote MCP entries carry auth in `headers` (JSON/YAML agents) or
-        // `http_headers` (Codex TOML). Without redaction, disabling a remote
-        // server would store the bearer token in plaintext in SQLite.
-        let json_entry = serde_json::json!({
-            "type": "http",
-            "url": "https://mcp.linear.app/mcp",
-            "headers": {"Authorization": "Bearer realsecret"}
-        });
-        let redacted = super::redact_mcp_env(&json_entry);
-        assert_eq!(redacted["headers"]["Authorization"], "<redacted>");
-        assert_eq!(redacted["url"], "https://mcp.linear.app/mcp");
-
-        let toml_entry = serde_json::json!({
-            "url": "https://mcp.figma.com/mcp",
-            "http_headers": {"X-Api-Key": "realsecret"}
-        });
-        let redacted = super::redact_mcp_env(&toml_entry);
-        assert_eq!(redacted["http_headers"]["X-Api-Key"], "<redacted>");
-    }
-
     #[cfg(unix)]
     #[test]
     fn test_copy_dir_contents_skips_symlinks_with_recheck() {
@@ -2424,19 +2306,11 @@ mod tests {
         assert!(plugin_enabled, "config.toml should show enabled=true");
     }
 
-    /// Hermes MCP disable uses the native in-config `enabled` field: the server
-    /// entry stays in config.yaml with `enabled: false`, secrets are NOT
-    /// redacted, advanced keys (tools) are preserved, and no DB snapshot is
-    /// taken. Re-enable must round-trip without hitting the generic
-    /// get_disabled_config NotFound path. Mirrors `hermes mcp` enable/disable.
-    ///
-    /// Lives here (not tests/toggle_integration.rs) because the redirectable
-    /// `HermesAdapter::with_home` constructor is `#[cfg(test)]`-gated and so is
-    /// only reachable from the crate's own unit tests, not integration tests.
+    /// Remote (HTTP) MCP disable→enable must be lossless: the snapshot keeps the
+    /// real bearer token so the restored entry is immediately usable, and no
+    /// warning fires because nothing was dropped.
     #[test]
-    fn test_remote_mcp_disable_redacts_headers_and_enable_keeps_url() {
-        // Remote (HTTP) MCP disable→enable: the DB snapshot must never hold
-        // the bearer token in plaintext, and the url must survive the trip.
+    fn test_remote_mcp_disable_enable_roundtrip_is_lossless() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
         std::fs::write(
@@ -2460,36 +2334,126 @@ mod tests {
             .find(|e| e.name == "linear")
             .expect("linear mcp scanned");
 
-        // DISABLE — entry removed from config, snapshot redacted in DB.
+        // DISABLE — entry removed from config, full entry snapshotted in the DB.
         toggle_extension_with_adapters(&store, &adapters, &ext.id, false).unwrap();
         let config = std::fs::read_to_string(home.join(".claude.json")).unwrap();
         assert!(!config.contains("linear"), "entry removed on disable");
-        let snapshot = store
-            .get_disabled_config(&ext.id)
-            .unwrap()
-            .expect("snapshot taken");
-        assert!(
-            !snapshot.contains("realsecret"),
-            "bearer token must not reach the DB in plaintext: {snapshot}"
+        let snapshot: serde_json::Value = serde_json::from_str(
+            &store
+                .get_disabled_config(&ext.id)
+                .unwrap()
+                .expect("snapshot taken"),
+        )
+        .unwrap();
+        assert_eq!(
+            snapshot["headers"]["Authorization"], "Bearer realsecret",
+            "snapshot must keep the real header value: {snapshot}"
         );
-        assert!(
-            snapshot.contains("<redacted>") && snapshot.contains("https://mcp.linear.app/mcp"),
-            "snapshot keeps structure + url: {snapshot}"
-        );
+        assert_eq!(snapshot["url"], "https://mcp.linear.app/mcp");
 
-        // ENABLE — url restored intact, header value stays redacted (the
-        // user is warned to re-set it; the secret itself is gone by design).
+        // ENABLE — the whole entry comes back, secret included, with no warning.
         let out = toggle_extension_with_adapters(&store, &adapters, &ext.id, true).unwrap();
-        assert_eq!(out.redacted_secret_keys, vec!["Authorization".to_string()]);
+        assert!(
+            out.redacted_secret_keys.is_empty(),
+            "nothing was dropped, so nothing to warn about: {:?}",
+            out.redacted_secret_keys
+        );
         let doc: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(home.join(".claude.json")).unwrap())
                 .unwrap();
         let entry = &doc["mcpServers"]["linear"];
         assert_eq!(entry["url"], "https://mcp.linear.app/mcp");
         assert_eq!(entry["type"], "http");
-        assert_eq!(entry["headers"]["Authorization"], "<redacted>");
+        assert_eq!(entry["headers"]["Authorization"], "Bearer realsecret");
     }
 
+    /// A snapshot written by an older HarnessKit still holds `<redacted>` in
+    /// place of the secret. Re-enabling one must restore what it has and report
+    /// the affected keys so the UI can tell the user to re-set them by hand.
+    #[test]
+    fn test_legacy_redacted_snapshot_still_warns_on_enable() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        std::fs::write(
+            home.join(".claude.json"),
+            r#"{"mcpServers":{"github":{"command":"npx","args":["-y","@modelcontextprotocol/server-github"],
+                "env":{"GITHUB_TOKEN":"ghp_realsecret"}}}}"#,
+        )
+        .unwrap();
+
+        let store = crate::store::Store::open(&dir.path().join("test.db")).unwrap();
+        let adapters: Vec<Box<dyn adapter::AgentAdapter>> = vec![Box::new(
+            adapter::claude::ClaudeAdapter::with_home(home.to_path_buf()),
+        )];
+
+        let scanned = scanner::scan_mcp_servers(&*adapters[0]);
+        store.sync_extensions(&scanned).unwrap();
+        let ext = store
+            .list_extensions(Some(ExtensionKind::Mcp), None)
+            .unwrap()
+            .into_iter()
+            .find(|e| e.name == "github")
+            .expect("github mcp scanned");
+
+        toggle_extension_with_adapters(&store, &adapters, &ext.id, false).unwrap();
+        // Overwrite the fresh snapshot with a legacy (redacted) one. It carries
+        // all four secret-block spellings at once — no real agent writes an
+        // entry like this, but it pins MCP_SECRET_BLOCK_KEYS so the collection
+        // stays format-agnostic (`environment` is OpenCode's name for `env`,
+        // `http_headers` is Codex TOML's name for `headers`). PATH appears
+        // redacted under both env spellings: it is auto-injected rather than
+        // secret, so it must never be reported. REGION holds a real value, so a
+        // half-legacy snapshot must not over-report keys that survived.
+        store
+            .set_disabled_config(
+                &ext.id,
+                Some(
+                    r#"{"command":"npx","args":["-y","@modelcontextprotocol/server-github"],
+                        "env":{"GITHUB_TOKEN":"<redacted>","PATH":"<redacted>","REGION":"us-east-1"},
+                        "environment":{"OPENCODE_KEY":"<redacted>","PATH":"<redacted>"},
+                        "headers":{"Authorization":"<redacted>"},
+                        "http_headers":{"X-Api-Key":"<redacted>"}}"#,
+                ),
+            )
+            .unwrap();
+
+        let out = toggle_extension_with_adapters(&store, &adapters, &ext.id, true).unwrap();
+        let mut reported = out.redacted_secret_keys.clone();
+        reported.sort();
+        assert_eq!(
+            reported,
+            vec![
+                "Authorization".to_string(),
+                "GITHUB_TOKEN".to_string(),
+                "OPENCODE_KEY".to_string(),
+                "X-Api-Key".to_string(),
+            ],
+            "every secret-block spelling is scanned; PATH and surviving real \
+             values are never reported"
+        );
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(home.join(".claude.json")).unwrap())
+                .unwrap();
+        let env = &doc["mcpServers"]["github"]["env"];
+        assert_eq!(
+            env["GITHUB_TOKEN"], "<redacted>",
+            "legacy placeholder is restored verbatim — the secret is gone for good"
+        );
+        assert_eq!(
+            env["REGION"], "us-east-1",
+            "non-redacted values in a legacy snapshot still round-trip"
+        );
+    }
+
+    /// Hermes MCP disable uses the native in-config `enabled` field: the server
+    /// entry stays in config.yaml with `enabled: false`, advanced keys (tools)
+    /// are preserved, and no DB snapshot is taken. Re-enable must round-trip
+    /// without hitting the generic get_disabled_config NotFound path. Mirrors
+    /// `hermes mcp` enable/disable.
+    ///
+    /// Lives here (not tests/toggle_integration.rs) because the redirectable
+    /// `HermesAdapter::with_home` constructor is `#[cfg(test)]`-gated and so is
+    /// only reachable from the crate's own unit tests, not integration tests.
     #[test]
     fn test_hermes_mcp_native_disable_enable_in_place() {
         let dir = TempDir::new().unwrap();
@@ -2531,7 +2495,7 @@ mod tests {
         assert_eq!(
             gh["env"]["TOKEN"].as_str(),
             Some("secret123"),
-            "secret NOT redacted"
+            "env stays in the config file untouched"
         );
         assert!(
             gh["tools"]["include"].as_sequence().is_some(),

--- a/crates/hk-core/src/service.rs
+++ b/crates/hk-core/src/service.rs
@@ -1252,8 +1252,16 @@ pub fn get_extension_content(
                             ];
                             if !server.headers.is_empty() {
                                 lines.push("Headers:".into());
-                                for k in server.headers.keys() {
-                                    lines.push(format!("  {} = ****", k));
+                                for (k, v) in &server.headers {
+                                    if v == manager::REDACTED_PLACEHOLDER {
+                                        lines.push(format!(
+                                            "  {} = {}",
+                                            k,
+                                            manager::REDACTED_PLACEHOLDER
+                                        ));
+                                    } else {
+                                        lines.push(format!("  {} = ****", k));
+                                    }
                                 }
                             }
                             lines
@@ -1266,8 +1274,16 @@ pub fn get_extension_content(
                         };
                         if !server.env.is_empty() {
                             lines.push("Environment:".into());
-                            for k in server.env.keys() {
-                                lines.push(format!("  {} = ****", k));
+                            for (k, v) in &server.env {
+                                if v == manager::REDACTED_PLACEHOLDER {
+                                    lines.push(format!(
+                                        "  {} = {}",
+                                        k,
+                                        manager::REDACTED_PLACEHOLDER
+                                    ));
+                                } else {
+                                    lines.push(format!("  {} = ****", k));
+                                }
                             }
                         }
                         return Ok(ExtensionContent {

--- a/crates/hk-core/src/service.rs
+++ b/crates/hk-core/src/service.rs
@@ -1252,6 +1252,10 @@ pub fn get_extension_content(
                             ];
                             if !server.headers.is_empty() {
                                 lines.push("Headers:".into());
+                                // Real values are masked as `****`; a literal
+                                // `<redacted>` shows through so the user can see
+                                // which secrets a legacy snapshot lost and must
+                                // be re-entered by hand.
                                 for (k, v) in &server.headers {
                                     if v == manager::REDACTED_PLACEHOLDER {
                                         lines.push(format!(

--- a/crates/hk-core/src/store.rs
+++ b/crates/hk-core/src/store.rs
@@ -125,7 +125,16 @@ pub struct Store {
 impl Store {
     pub fn open(path: &Path) -> Result<Self, HkError> {
         let conn = Connection::open(path)?;
-        conn.execute_batch("PRAGMA foreign_keys = ON")?;
+        // secure_delete zeroes freed pages instead of leaving their bytes in the
+        // freelist. `disabled_config` holds a disabled MCP entry verbatim,
+        // secrets included, so its bytes must not outlive the row.
+        //
+        // Both pragmas are per-connection, not stored in the file: every
+        // connection has to set them itself. This is the only place the
+        // HarnessKit DB is opened (the other `Connection::open` calls in the
+        // crate read *other* agents' databases), so setting them here covers
+        // every delete. A second connection added later must repeat them.
+        conn.execute_batch("PRAGMA foreign_keys = ON; PRAGMA secure_delete = ON")?;
         let store = Self { conn, db_path: path.to_path_buf() };
         store.migrate()?;
 
@@ -166,6 +175,11 @@ impl Store {
     /// The backup is written to `{db_path}.backup-v{current_version}`.
     /// Errors are logged but do not abort the migration — a failed backup
     /// should not prevent the app from starting.
+    ///
+    /// The copy inherits the secret-bearing `disabled_config` column, so it is
+    /// as sensitive as the DB itself. No explicit chmod is needed: `fs::copy`
+    /// carries over the source's permission bits, and any DB old enough to need
+    /// a migration has been through `Store::open`, which sets 0o600 on Unix.
     fn backup_before_migrate(&self, current_version: i64) {
         let backup_path = self.db_path.with_extension(
             format!("db.backup-v{}", current_version),
@@ -923,6 +937,11 @@ impl Store {
     }
 
     pub fn delete_extension(&self, id: &str) -> Result<(), HkError> {
+        // `PRAGMA secure_delete` (set in `open`) already zeroes the row's pages,
+        // including the `disabled_config` snapshot, so no separate scrub pass is
+        // needed — and a scrub in its own autocommit statement would be worse
+        // than useless: a crash between the two would leave a disabled row whose
+        // snapshot is gone, failing re-enable with "No saved config".
         self.conn.execute("DELETE FROM extensions WHERE id = ?1", params![id])?;
         Ok(())
     }

--- a/crates/hk-desktop/src/commands/extensions.rs
+++ b/crates/hk-desktop/src/commands/extensions.rs
@@ -20,7 +20,7 @@ pub async fn toggle_extension(
     state: State<'_, AppState>,
     id: String,
     enabled: bool,
-) -> Result<(), HkError> {
+) -> Result<manager::ToggleOutcome, HkError> {
     let store = state.store.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let store = store.lock();

--- a/crates/hk-web/src/handlers/extensions.rs
+++ b/crates/hk-web/src/handlers/extensions.rs
@@ -36,16 +36,10 @@ pub struct ToggleParams {
 pub async fn toggle_extension(
     State(state): State<WebState>,
     Json(params): Json<ToggleParams>,
-) -> Result<()> {
+) -> Result<manager::ToggleOutcome> {
     blocking(move || {
         let store = state.store.lock();
-        manager::toggle_extension_with_adapters(
-            &store,
-            &state.adapters,
-            &params.id,
-            params.enabled,
-        )?;
-        Ok(())
+        manager::toggle_extension_with_adapters(&store, &state.adapters, &params.id, params.enabled)
     }).await
 }
 

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -937,8 +937,9 @@ export function ExtensionDetail() {
 
         {/* 8a. MCP configuration summary — the backend masks real secret
          * values as **** but renders snapshot placeholders as <redacted>,
-         * so a server broken by a disable→enable round-trip is visibly
-         * different from a healthy one. */}
+         * so a server broken by a disable→enable round-trip under an older
+         * version (legacy snapshots only — the round-trip is lossless now) is
+         * visibly different from a healthy one. */}
         {group.kind === "mcp" && activeInstanceId && (
           <div className="mt-4">
             <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">

--- a/src/components/extensions/extension-detail.tsx
+++ b/src/components/extensions/extension-detail.tsx
@@ -935,6 +935,21 @@ export function ExtensionDetail() {
           scope={scope}
         />
 
+        {/* 8a. MCP configuration summary — the backend masks real secret
+         * values as **** but renders snapshot placeholders as <redacted>,
+         * so a server broken by a disable→enable round-trip is visibly
+         * different from a healthy one. */}
+        {group.kind === "mcp" && activeInstanceId && (
+          <div className="mt-4">
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              {t("detail.configuration")}
+            </h4>
+            <pre className="max-h-[200px] overflow-y-auto whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-muted-foreground">
+              {instanceData.get(activeInstanceId)?.content ?? ""}
+            </pre>
+          </div>
+        )}
+
         {/* 9. Content / Documentation — skip for hooks and CLIs */}
         {group.kind !== "hook" &&
           group.kind !== "cli" &&

--- a/src/lib/i18n/locales/en/extensions.json
+++ b/src/lib/i18n/locales/en/extensions.json
@@ -25,7 +25,8 @@
     "updatedCount_other": "{{count}} extensions updated",
     "failedUpdate": "Failed to update {{name}}: {{msg}}",
     "noLongerAvailable_one": "{{names}} is no longer available in the remote repository",
-    "noLongerAvailable_other": "{{names}} are no longer available in their remote repositories"
+    "noLongerAvailable_other": "{{names}} are no longer available in their remote repositories",
+    "mcpSecretsRedacted": "MCP \"{{name}}\": {{keys}} are placeholders — set real values"
   },
   "table": {
     "selectAll": "Select all extensions",
@@ -98,6 +99,7 @@
     "installToFailed": "Failed to install to {{agent}}",
     "permissions": "Permissions",
     "documentation": "Documentation",
+    "configuration": "Configuration",
     "openInFinder": "Open in Finder",
     "deleteButton": "Delete...",
     "deleteShippedTip": "{{agent}} ships this plugin — it can be disabled but not deleted",

--- a/src/lib/i18n/locales/zh-TW/extensions.json
+++ b/src/lib/i18n/locales/zh-TW/extensions.json
@@ -25,7 +25,8 @@
     "updatedCount_other": "已更新 {{count}} 個擴充",
     "failedUpdate": "更新 {{name}} 失敗：{{msg}}",
     "noLongerAvailable_one": "{{names}} 在遠端儲存庫已不再提供",
-    "noLongerAvailable_other": "{{names}} 在遠端儲存庫已不再提供"
+    "noLongerAvailable_other": "{{names}} 在遠端儲存庫已不再提供",
+    "mcpSecretsRedacted": "MCP「{{name}}」：{{keys}} 為佔位符，請填入真實值"
   },
   "table": {
     "selectAll": "選擇全部擴充",
@@ -98,6 +99,7 @@
     "installToFailed": "安裝到 {{agent}} 失敗",
     "permissions": "權限",
     "documentation": "文件",
+    "configuration": "設定",
     "openInFinder": "在 Finder 中開啟",
     "deleteButton": "刪除...",
     "deleteShippedTip": "{{agent}} 內建此外掛——可以停用,但無法刪除",

--- a/src/lib/i18n/locales/zh/extensions.json
+++ b/src/lib/i18n/locales/zh/extensions.json
@@ -25,7 +25,8 @@
     "updatedCount_other": "已更新 {{count}} 个扩展",
     "failedUpdate": "更新 {{name}} 失败：{{msg}}",
     "noLongerAvailable_one": "{{names}} 在远程仓库中已不再可用",
-    "noLongerAvailable_other": "{{names}} 在远程仓库中已不再可用"
+    "noLongerAvailable_other": "{{names}} 在远程仓库中已不再可用",
+    "mcpSecretsRedacted": "MCP“{{name}}”：{{keys}} 为占位符，请填入真实值"
   },
   "table": {
     "selectAll": "选择全部扩展",
@@ -98,6 +99,7 @@
     "installToFailed": "安装到 {{agent}} 失败",
     "permissions": "权限",
     "documentation": "文档",
+    "configuration": "配置",
     "openInFinder": "在访达中打开",
     "deleteButton": "删除...",
     "deleteShippedTip": "{{agent}} 自带此插件——可以停用,但无法删除",

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -28,6 +28,7 @@ import type {
   Project,
   ScanResult,
   SkillAuditInfo,
+  ToggleOutcome,
   UpdateStatus,
 } from "./types";
 
@@ -60,7 +61,7 @@ export const api = {
     return transport("get_dashboard_stats");
   },
 
-  toggleExtension(id: string, enabled: boolean): Promise<void> {
+  toggleExtension(id: string, enabled: boolean): Promise<ToggleOutcome> {
     validateNonEmpty(id, "Extension ID");
     return transport("toggle_extension", { id, enabled });
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -473,6 +473,10 @@ export interface InstallResult {
   skipped?: boolean;
 }
 
+export interface ToggleOutcome {
+  redacted_secret_keys: string[];
+}
+
 export interface DiscoveredSkill {
   skill_id: string;
   name: string;

--- a/src/stores/__tests__/extension-store.test.ts
+++ b/src/stores/__tests__/extension-store.test.ts
@@ -27,6 +27,66 @@ const dshPlugin: Extension = {
   scope: { type: "global" },
 };
 
+const linearMcp: Extension = {
+  id: "m1",
+  kind: "mcp",
+  name: "linear",
+  description: "Remote MCP server",
+  source: { origin: "agent", url: null, version: null, commit_hash: null },
+  agents: ["claude"],
+  tags: [],
+  pack: null,
+  permissions: [],
+  enabled: false,
+  trust_score: null,
+  installed_at: "2026-08-01T00:00:00Z",
+  updated_at: "2026-08-01T00:00:00Z",
+  source_path: null,
+  cli_parent_id: null,
+  cli_meta: null,
+  install_meta: null,
+  scope: { type: "global" },
+};
+
+describe("extension-store toggle", () => {
+  beforeEach(() => {
+    useExtensionStore.setState({ extensions: [], pendingDelete: null });
+    vi.resetAllMocks();
+  });
+
+  // Re-enabling an MCP server whose secrets were redacted on disable
+  // succeeds, but the server cannot start until the user restores the real
+  // values. The backend only wrote that to stderr, so desktop and web users
+  // never saw it.
+  it("toggle surfaces a warning toast when re-enable reports redacted secrets", async () => {
+    useExtensionStore.setState({ extensions: [linearMcp] });
+    const groupKey = useExtensionStore.getState().grouped()[0].groupKey;
+    vi.mocked(api.toggleExtension).mockResolvedValue({
+      redacted_secret_keys: ["API_KEY"],
+    });
+    const warnSpy = vi.spyOn(toast, "warning").mockImplementation(() => {});
+
+    await useExtensionStore.getState().toggle(groupKey, true);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("API_KEY");
+    expect(warnSpy.mock.calls[0][0]).toContain("linear");
+  });
+
+  it("stays quiet when no secrets came back redacted", async () => {
+    useExtensionStore.setState({ extensions: [linearMcp] });
+    const groupKey = useExtensionStore.getState().grouped()[0].groupKey;
+    vi.mocked(api.toggleExtension).mockResolvedValue({
+      redacted_secret_keys: [],
+    });
+    const warnSpy = vi.spyOn(toast, "warning").mockImplementation(() => {});
+
+    await useExtensionStore.getState().toggle(groupKey, true);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("extension-store confirmDelete", () => {
   beforeEach(() => {
     useExtensionStore.setState({ extensions: [], pendingDelete: null });

--- a/src/stores/__tests__/extension-store.test.ts
+++ b/src/stores/__tests__/extension-store.test.ts
@@ -54,8 +54,9 @@ describe("extension-store toggle", () => {
     vi.resetAllMocks();
   });
 
-  // Re-enabling an MCP server whose secrets were redacted on disable
-  // succeeds, but the server cannot start until the user restores the real
+  // Legacy snapshots only: disable is lossless now, but a server disabled by
+  // an older version has `<redacted>` where its secrets were. Re-enabling one
+  // succeeds, yet the server cannot start until the user restores the real
   // values. The backend only wrote that to stderr, so desktop and web users
   // never saw it.
   it("toggle surfaces a warning toast when re-enable reports redacted secrets", async () => {

--- a/src/stores/extension-store.ts
+++ b/src/stores/extension-store.ts
@@ -8,6 +8,7 @@ import type {
   ExtensionKind,
   GroupedExtension,
   NewRepoSkill,
+  ToggleOutcome,
   UpdateStatus,
 } from "@/lib/types";
 import { useAgentStore } from "./agent-store";
@@ -46,6 +47,35 @@ async function runPendingDeletes(ids: Iterable<string>): Promise<unknown> {
     return null;
   } catch (e) {
     return e;
+  }
+}
+
+/** Surface per-server warnings for MCP entries restored with `<redacted>`
+ *  placeholder secrets. Keys are unioned per server name because a
+ *  cross-agent group toggles one instance per agent. */
+function warnRedactedSecrets(
+  results: PromiseSettledResult<ToggleOutcome>[],
+  nameAt: (index: number) => string,
+) {
+  const keysByName = new Map<string, Set<string>>();
+  results.forEach((result, index) => {
+    if (
+      result.status === "fulfilled" &&
+      result.value.redacted_secret_keys.length > 0
+    ) {
+      const name = nameAt(index);
+      const set = keysByName.get(name) ?? new Set<string>();
+      for (const k of result.value.redacted_secret_keys) set.add(k);
+      keysByName.set(name, set);
+    }
+  });
+  for (const [name, keys] of keysByName) {
+    toast.warning(
+      i18n.t("extensions:page.mcpSecretsRedacted", {
+        name,
+        keys: [...keys].join(", "),
+      }),
+    );
   }
 }
 
@@ -339,6 +369,8 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
       allToToggle.map((e) => api.toggleExtension(e.id, enabled)),
     );
 
+    warnRedactedSecrets(results, (i) => allToToggle[i].name);
+
     const failedIds = new Set<string>();
     results.forEach((result, index) => {
       if (result.status === "rejected") {
@@ -363,6 +395,10 @@ export const useExtensionStore = create<ExtensionState>((set, get) => ({
     const results = await Promise.allSettled(
       ids.map((id) => api.toggleExtension(id, enabled)),
     );
+
+    const extById = new Map(get().extensions.map((e) => [e.id, e]));
+    warnRedactedSecrets(results, (i) => extById.get(ids[i])?.name ?? ids[i]);
+
     const failedIds = new Set<string>();
     results.forEach((result, index) => {
       if (result.status === "rejected") {

--- a/src/stores/toast-store.ts
+++ b/src/stores/toast-store.ts
@@ -19,9 +19,12 @@ export const useToastStore = create<ToastState>((set) => ({
   add(message, type = "success") {
     const id = String(++nextId);
     set((s) => ({ toasts: [...s.toasts, { id, message, type }] }));
-    setTimeout(() => {
-      set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
-    }, 2500);
+    setTimeout(
+      () => {
+        set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+      },
+      type === "warning" ? 6000 : 2500,
+    );
   },
   dismiss(id) {
     set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));


### PR DESCRIPTION
## Problem

Disabling an MCP server snapshots its entry with env/header secrets replaced by a `<redacted>` placeholder; re-enabling restored the placeholder, so the server could no longer start. The only warning was an `eprintln!` on the backend's stderr — invisible to desktop and web users — and the detail panel rendered placeholders and real secrets identically, hiding the breakage.

## Fix (two commits)

**1. Make the breakage visible** — toggle operations return a `ToggleOutcome` (mirroring the existing `InstallResult.skipped → toast.warning` pattern) carrying still-redacted keys; the frontend surfaces them as a warning toast on both single- and batch-toggle paths (warning toasts now stay 6s). The detail panel gains a CONFIGURATION section for MCP servers that renders literal placeholders as `<redacted>`, distinct from masked real values (`****`). A shared `REDACTED_PLACEHOLDER` constant keeps redaction detection, warning collection, and rendering from drifting.

**2. Stop breaking things in the first place** — disable now snapshots the entry **verbatim** (secrets included) into `disabled_config`, so re-enable restores a working server. The column never leaves hk-core: it is not part of the `Extension` model and no API serializes it. `PRAGMA secure_delete` zeroes freed pages on row deletion. `redact_mcp_env` and its tests are removed (net −10 lines).

Snapshots written by ≤ v1.10.0 still carry placeholders and cannot be recovered; the warning path from commit 1 now serves exactly that legacy case, pinned by a dedicated test (all four secret-block spellings, PATH exclusion under both spellings, no over-reporting on half-legacy snapshots). Its removal criterion is documented on the constant: only when pre-v1.10.0 snapshots can no longer exist (i.e. when a migration rewrites or drops `disabled_config`).

Note: agents with native per-server toggles (hermes/kiro/omp/dsh/grok) never redacted — they flip an in-place flag and were never affected.

## Verified on device (web mode)

- disable → enable on a server with a real env secret: config file byte-identical afterwards, no toast — the round-trip is lossless.
- enabling a legacy `<redacted>` snapshot: warning toast fires with the affected keys; detail panel shows `<redacted>` for the lost value and `****` for healthy ones.

## Follow-ups (not in this PR)

- `toggle_by_pack` still discards per-toggle outcomes, so pack-level batch enables surface no warning in the GUI — same hole, different entry point; needs `Vec<ToggleOutcome>` aggregation semantics.
- The store file's permission tightening (0o600) is Unix-only; Windows relies on default user-profile ACLs (documented in-code). Explicit Windows ACL hardening could follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)