### PR TITLE
release: v1.10.1

### DIFF
--- a/.github/release-notes/v1.10.1.md
+++ b/.github/release-notes/v1.10.1.md
@@ -1,0 +1,18 @@
+## ✨ Highlights
+
+- **MCP secrets survive disable/enable** — disabling an MCP server no longer strips its env/header secrets, so re-enabling restores a working server.
+- **Kiro global hooks** — hooks can now be installed to Kiro's global scope (`~/.kiro/hooks/`); requires Kiro IDE 1.0.182 or newer.
+
+<!-- lang:zh
+## ✨ 更新亮点
+
+- **MCP secret 在停用/启用后不再丢失** — 停用 MCP server 不再抹掉 env/header 里的 secret，重新启用即恢复可用。
+- **Kiro 全局 hooks** — hook 现可安装到 Kiro 的全局作用域（`~/.kiro/hooks/`）；需要 Kiro IDE 1.0.182 及以上。
+-->
+
+<!-- lang:zh-TW
+## ✨ 更新亮點
+
+- **MCP secret 在停用／啟用後不再遺失** — 停用 MCP server 不再抹掉 env/header 裡的 secret，重新啟用即恢復可用。
+- **Kiro 全域 hooks** — hook 現可安裝到 Kiro 的全域範圍（`~/.kiro/hooks/`）；需要 Kiro IDE 1.0.182 及以上。
+-->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk-cli"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "hk-core"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "hk-desktop"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "hk-web"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/hk-core", "crates/hk-cli", "crates/hk-desktop", "crates/hk-we
 resolver = "2"
 
 [workspace.package]
-version = "1.10.0"
+version = "1.10.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/hk-desktop/tauri.conf.json
+++ b/crates/hk-desktop/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "HarnessKit",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "identifier": "com.harnesskit.app",
   "build": {
     "frontendDist": "../../dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "harnesskit-frontend",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harnesskit-frontend",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harnesskit-frontend",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Cross-platform extension management for AI coding agents",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Version bump to 1.10.1 (workspace / frontend / Tauri + both lockfiles) and the hand-written release highlights with zh / zh-TW comment-block translations (validated through scripts/notes-desktop-variant.mjs).

Patch release contents: #130, #131, #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)