### PR TITLE
fix(extensions): single-file extensions render in Documentation; add full-file preview

### DIFF
--- a/crates/hk-desktop/src/commands/extensions.rs
+++ b/crates/hk-desktop/src/commands/extensions.rs
@@ -56,8 +56,24 @@ pub fn list_skill_files(
     path: String,
 ) -> Result<Vec<FileEntry>, HkError> {
     let root = std::path::Path::new(&path);
+    if !root.exists() {
+        return Err(HkError::Validation("Path does not exist".into()));
+    }
     if !root.is_dir() {
-        return Err(HkError::Validation("Path is not a directory".into()));
+        // Single-file extensions (e.g. Oh My Pi `.ts` plugins) live directly
+        // in the agent's extension directory. Surface them as a one-entry
+        // tree so the Documentation panel previews their content instead of
+        // reporting "No files found".
+        let name = root
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.clone());
+        return Ok(vec![FileEntry {
+            name,
+            path,
+            is_dir: false,
+            children: None,
+        }]);
     }
     list_dir_entries(root, 0)
 }

--- a/crates/hk-web/src/handlers/extensions.rs
+++ b/crates/hk-web/src/handlers/extensions.rs
@@ -166,7 +166,7 @@ pub async fn list_skill_files(
 ) -> Result<Vec<FileEntry>> {
     blocking(move || {
         let path = std::path::Path::new(&params.path);
-        if !path.exists() || !path.is_dir() {
+        if !path.exists() {
             return Err(hk_core::HkError::NotFound("Directory not found".into()));
         }
         // Validate path is within an allowed agent directory
@@ -184,6 +184,22 @@ pub async fn list_skill_files(
                     "Path is not within a known agent directory".into(),
                 ));
             }
+        }
+        if !path.is_dir() {
+            // Single-file extensions (e.g. Oh My Pi `.ts` plugins) live
+            // directly in the agent's extension directory. Surface them as a
+            // one-entry tree so the Documentation panel previews their
+            // content instead of reporting "No files found".
+            let name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| params.path.clone());
+            return Ok(vec![FileEntry {
+                name,
+                path: params.path.clone(),
+                is_dir: false,
+                children: None,
+            }]);
         }
         Ok(list_dir_entries(path, 0))
     }).await

--- a/crates/hk-web/tests/api_test.rs
+++ b/crates/hk-web/tests/api_test.rs
@@ -303,6 +303,37 @@ async fn list_skill_files_returns_single_entry_for_file() {
     assert_eq!(entries[0]["children"], serde_json::Value::Null);
 }
 
+/// The single-file branch must stay BEHIND the path allowlist: an existing
+/// file outside every adapter root and registered project is rejected, never
+/// listed. Locks the check ordering against future reordering.
+#[tokio::test]
+async fn list_skill_files_rejects_file_outside_allowed_roots() {
+    let (state, tmp) = test_state();
+    // No project registered for this fixture dir, and temp dirs are outside
+    // the home directory, so the path is not allowed.
+    let file_path = tmp.path().join("stray-plugin.ts");
+    std::fs::write(&file_path, "// plugin\n").unwrap();
+
+    let app = hk_web::router::build_router(state);
+    let response = app
+        .oneshot(
+            Request::post("/api/list_skill_files")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "path": file_path.to_string_lossy() }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response.status().is_client_error(),
+        "file outside allowed roots must be rejected, got {}",
+        response.status()
+    );
+}
+
 /// Directories keep the existing tree behavior.
 #[tokio::test]
 async fn list_skill_files_lists_directory_entries() {

--- a/crates/hk-web/tests/api_test.rs
+++ b/crates/hk-web/tests/api_test.rs
@@ -251,3 +251,114 @@ async fn install_to_agent_accepts_both_scope_shapes() {
         );
     }
 }
+
+/// Single-file extensions (e.g. Oh My Pi `.ts` plugins) live directly in the
+/// agent's extension directory, so `list_skill_files` must return a one-entry
+/// tree instead of 404 "Directory not found" — the Documentation panel walks
+/// the tree and previews each file it finds.
+#[tokio::test]
+async fn list_skill_files_returns_single_entry_for_file() {
+    let (state, tmp) = test_state();
+    // Adapters' real skill dirs are not writable in tests; register the
+    // fixture root as an allowed project so the path check passes.
+    {
+        let store = state.store.lock();
+        store
+            .insert_project(&hk_core::models::Project {
+                id: "proj-test".into(),
+                name: "test".into(),
+                path: tmp.path().to_string_lossy().to_string(),
+                created_at: chrono::Utc::now(),
+                exists: true,
+            })
+            .unwrap();
+    }
+    let ext_dir = tmp.path().join("extensions");
+    std::fs::create_dir_all(&ext_dir).unwrap();
+    let file_path = ext_dir.join("my-plugin.ts");
+    std::fs::write(&file_path, "// plugin\n").unwrap();
+
+    let app = hk_web::router::build_router(state);
+    let response = app
+        .oneshot(
+            Request::post("/api/list_skill_files")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "path": file_path.to_string_lossy() }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let entries = value.as_array().expect("array of FileEntry");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["name"], "my-plugin.ts");
+    assert_eq!(entries[0]["is_dir"], false);
+    assert_eq!(entries[0]["children"], serde_json::Value::Null);
+}
+
+/// Directories keep the existing tree behavior.
+#[tokio::test]
+async fn list_skill_files_lists_directory_entries() {
+    let (state, tmp) = test_state();
+    {
+        let store = state.store.lock();
+        store
+            .insert_project(&hk_core::models::Project {
+                id: "proj-test".into(),
+                name: "test".into(),
+                path: tmp.path().to_string_lossy().to_string(),
+                created_at: chrono::Utc::now(),
+                exists: true,
+            })
+            .unwrap();
+    }
+    let skill_dir = tmp.path().join("my-skill");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(skill_dir.join("SKILL.md"), "# skill\n").unwrap();
+
+    let app = hk_web::router::build_router(state);
+    let response = app
+        .oneshot(
+            Request::post("/api/list_skill_files")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "path": skill_dir.to_string_lossy() }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let entries = value.as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["name"], "SKILL.md");
+}
+
+/// Missing paths still 404.
+#[tokio::test]
+async fn list_skill_files_missing_path_is_not_found() {
+    let (state, _tmp) = test_state();
+    let app = hk_web::router::build_router(state);
+    let response = app
+        .oneshot(
+            Request::post("/api/list_skill_files")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"path":"/does/not/exist-xyz"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/src/components/extensions/__tests__/file-tree-node.test.tsx
+++ b/src/components/extensions/__tests__/file-tree-node.test.tsx
@@ -109,4 +109,37 @@ describe("FilePreview", () => {
     });
     expect(screen.getByText(/content of new/)).toBeInTheDocument();
   });
+
+  it("re-enables the full-load button after navigating to another truncated file", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.readConfigFilePreview).mockImplementation(
+      (path: string, maxLines?: number) => {
+        if (path === "/a/old.ts" && maxLines !== undefined) {
+          // Full fetch for the old file never resolves.
+          return new Promise<string>(() => {});
+        }
+        return Promise.resolve("truncated body\n\n... (12 more lines)");
+      },
+    );
+
+    const utils = renderTree(fileEntry("/a/old.ts"));
+    await waitFor(() => {
+      expect(screen.getByText(/truncated body/)).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /showFull/ }));
+
+    utils.rerender(
+      <FileTreeNode
+        entry={fileEntry("/a/new.ts")}
+        depth={0}
+        expandedPath="/a/new.ts"
+        onToggle={vi.fn()}
+        dirExpanded={false}
+        onToggleDir={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /showFull/ })).toBeEnabled();
+    });
+  });
 });

--- a/src/components/extensions/__tests__/file-tree-node.test.tsx
+++ b/src/components/extensions/__tests__/file-tree-node.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/invoke";
+import type { FileEntry } from "@/lib/types";
+import { FileTreeNode } from "../file-tree-node";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock("@/lib/invoke", () => ({
+  api: {
+    readConfigFilePreview: vi.fn(),
+    openInSystem: vi.fn(),
+  },
+}));
+
+const fileEntry = (path: string): FileEntry => ({
+  name: path.split("/").pop() ?? path,
+  path,
+  is_dir: false,
+  children: null,
+});
+function renderTree(entry: FileEntry) {
+  return render(
+    <FileTreeNode
+      entry={entry}
+      depth={0}
+      expandedPath={entry.path}
+      onToggle={vi.fn()}
+      dirExpanded={false}
+      onToggleDir={vi.fn()}
+    />,
+  );
+}
+
+describe("FilePreview", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("renders the initial truncated preview and offers a full load", async () => {
+    vi.mocked(api.readConfigFilePreview).mockResolvedValue(
+      "truncated body\n\n... (12 more lines)",
+    );
+    renderTree(fileEntry("/a/plugin.ts"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/truncated body/)).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: /showFull/ }),
+    ).toBeInTheDocument();
+    expect(api.readConfigFilePreview).toHaveBeenCalledWith("/a/plugin.ts");
+  });
+
+  // A slow "Show full file" fetch for the old file must never overwrite the
+  // preview after the tree has navigated to a different file: FilePreview is
+  // reused in place when the accordion moves to another entry, so the stale
+  // promise can resolve after the path prop changed.
+  it("ignores a stale full fetch after the path changed", async () => {
+    const user = userEvent.setup();
+    let resolveStaleFull: (value: string) => void = () => {};
+    vi.mocked(api.readConfigFilePreview).mockImplementation(
+      (path: string, maxLines?: number) => {
+        if (path === "/a/old.ts" && maxLines !== undefined) {
+          return new Promise<string>((resolve) => {
+            resolveStaleFull = resolve;
+          });
+        }
+        if (path === "/a/old.ts") {
+          return Promise.resolve("truncated body\n\n... (12 more lines)");
+        }
+        return Promise.resolve("content of new file");
+      },
+    );
+
+    const utils = renderTree(fileEntry("/a/old.ts"));
+    await waitFor(() => {
+      expect(screen.getByText(/truncated body/)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /showFull/ }));
+    expect(api.readConfigFilePreview).toHaveBeenCalledWith(
+      "/a/old.ts",
+      1_000_000,
+    );
+
+    // Navigate to a different file: the same node instance now previews the
+    // new path, whose load resolves while the old full fetch is still pending.
+    utils.rerender(
+      <FileTreeNode
+        entry={fileEntry("/a/new.ts")}
+        depth={0}
+        expandedPath="/a/new.ts"
+        onToggle={vi.fn()}
+        dirExpanded={false}
+        onToggleDir={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/content of new/)).toBeInTheDocument();
+    });
+
+    resolveStaleFull("STALE full content of old");
+    await waitFor(() => {
+      expect(screen.queryByText(/STALE/)).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/content of new/)).toBeInTheDocument();
+  });
+});

--- a/src/components/extensions/file-tree-node.tsx
+++ b/src/components/extensions/file-tree-node.tsx
@@ -207,14 +207,19 @@ function FilePreview({ path }: { path: string }) {
   // files that were truncated. Detected from the trailer the backend appends.
   const truncated =
     preview !== null && /\n\.\.\. \(\d+ more lines\)$/.test(preview);
+  // Track the current path so a slow full-content fetch for an old file can
+  // never clobber the preview the user has since navigated to.
+  const pathRef = useRef(path);
+  pathRef.current = path;
   const loadFull = async () => {
     setLoadingFull(true);
     try {
-      setPreview(await api.readConfigFilePreview(path, 1_000_000));
+      const full = await api.readConfigFilePreview(path, 1_000_000);
+      if (pathRef.current === path) setPreview(full);
     } catch {
       // Keep the truncated preview rather than flipping to "unavailable".
     } finally {
-      setLoadingFull(false);
+      if (pathRef.current === path) setLoadingFull(false);
     }
   };
 

--- a/src/components/extensions/file-tree-node.tsx
+++ b/src/components/extensions/file-tree-node.tsx
@@ -1,4 +1,5 @@
 import {
+  ChevronDown,
   ChevronRight,
   Copy,
   ExternalLink,
@@ -185,6 +186,7 @@ function FilePreview({ path }: { path: string }) {
   const handleNestedWheel = useScrollPassthrough();
   const [preview, setPreview] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
+  const [loadingFull, setLoadingFull] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -200,6 +202,21 @@ function FilePreview({ path }: { path: string }) {
       cancelled = true;
     };
   }, [path]);
+
+  // The backend preview caps at 30 lines; offer one-click full content for
+  // files that were truncated. Detected from the trailer the backend appends.
+  const truncated =
+    preview !== null && /\n\.\.\. \(\d+ more lines\)$/.test(preview);
+  const loadFull = async () => {
+    setLoadingFull(true);
+    try {
+      setPreview(await api.readConfigFilePreview(path, 1_000_000));
+    } catch {
+      // Keep the truncated preview rather than flipping to "unavailable".
+    } finally {
+      setLoadingFull(false);
+    }
+  };
 
   const actionButton =
     "inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent";
@@ -229,6 +246,15 @@ function FilePreview({ path }: { path: string }) {
             className={actionButton}
           >
             <ExternalLink size={11} /> {t("fileTree.open")}
+          </button>
+        )}
+        {truncated && (
+          <button
+            onClick={loadFull}
+            disabled={loadingFull}
+            className={actionButton}
+          >
+            <ChevronDown size={11} /> {t("fileTree.showFull")}
           </button>
         )}
         <button

--- a/src/components/extensions/file-tree-node.tsx
+++ b/src/components/extensions/file-tree-node.tsx
@@ -190,6 +190,8 @@ function FilePreview({ path }: { path: string }) {
 
   useEffect(() => {
     let cancelled = false;
+    // loadFull's stale-path guard never resets this after a path change.
+    setLoadingFull(false);
     api
       .readConfigFilePreview(path)
       .then((content) => {

--- a/src/lib/i18n/locales/en/extensions.json
+++ b/src/lib/i18n/locales/en/extensions.json
@@ -203,7 +203,8 @@
   "fileTree": {
     "moreFiles": "{{count}} more — Open in Finder",
     "open": "Open",
-    "openInFinder": "Open in Finder"
+    "openInFinder": "Open in Finder",
+    "showFull": "Show full file"
   },
   "newSkills": {
     "aria": "New skills available",

--- a/src/lib/i18n/locales/zh-TW/extensions.json
+++ b/src/lib/i18n/locales/zh-TW/extensions.json
@@ -203,7 +203,8 @@
   "fileTree": {
     "moreFiles": "還有 {{count}} 個，在 Finder 中開啟",
     "open": "開啟",
-    "openInFinder": "在 Finder 中開啟"
+    "openInFinder": "在 Finder 中開啟",
+    "showFull": "顯示完整檔案"
   },
   "newSkills": {
     "aria": "有新 skill 可用",

--- a/src/lib/i18n/locales/zh/extensions.json
+++ b/src/lib/i18n/locales/zh/extensions.json
@@ -203,7 +203,8 @@
   "fileTree": {
     "moreFiles": "还有 {{count}} 个 — 在访达中打开",
     "open": "打开",
-    "openInFinder": "在访达中打开"
+    "openInFinder": "在访达中打开",
+    "showFull": "显示完整文件"
   },
   "newSkills": {
     "aria": "有新 skill 可用",


### PR DESCRIPTION
## Problem

1. **Single-file extensions show "No files found"** — Oh My Pi plugins are single `.ts` files directly under `~/.omp/agent/extensions/`, not directories. `list_skill_files` rejected non-directory paths, so the Documentation panel showed "No files found" even though `read_config_file_preview` reads the file fine.
2. **Previews silently truncate** — every file preview caps at 30 lines with no way to see the rest in web mode.

## Fix

- `list_skill_files` (web + desktop): a file path now returns a one-entry tree (`is_dir: false`) instead of 404, after the same path-allowlist check. The Documentation panel previews the file normally.
- Frontend `FilePreview`: when the backend appends its truncation trailer, a "Show full file" button re-fetches with a raised `max_lines` and swaps in the complete content. Default 30-line previews are unchanged for config dashboards. The full fetch is guarded against a stale resolution overwriting a newer file's preview.

## Tests

- 3 new integration tests in `crates/hk-web/tests/api_test.rs`: single file → one-entry tree; directory regression; missing path → 404. Plus an ordering test pinning that the single-file branch stays behind the path allowlist.
- New vitest for `FilePreview`: truncated preview renders the button; a stale full-content fetch after the path changed is dropped.
- `cargo test --workspace` green, `npm test` 311 green, `cargo check --workspace` + `vite build` green.
- Verified live against a real 13-agent install: OMP `.ts` plugin renders and previews in the web UI.
